### PR TITLE
feat: implement Go import extraction engine for v0.2

### DIFF
--- a/import_extractor.go
+++ b/import_extractor.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ImportMetadata holds package-level import information
+type ImportMetadata struct {
+	Package string
+	Imports []string
+}
+
+// ImportExtractor extracts import metadata from Go source files
+type ImportExtractor struct {
+	modulePath   string
+	stdlibPrefixs map[string]bool
+}
+
+// NewImportExtractor creates a new ImportExtractor
+func NewImportExtractor(modulePath string) *ImportExtractor {
+	return &ImportExtractor{
+		modulePath: modulePath,
+		stdlibPrefixs: buildStdlibPrefixs(),
+	}
+}
+
+// ExtractFromDir extracts import metadata from all .go files in a directory
+func (e *ImportExtractor) ExtractFromDir(rootPath string) (map[string]*ImportMetadata, error) {
+	result := make(map[string]*ImportMetadata)
+
+	err := filepath.Walk(rootPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		// Skip directories
+		if info.IsDir() {
+			// Skip hidden directories
+			if strings.HasPrefix(info.Name(), ".") {
+				return filepath.SkipDir
+			}
+			// Skip vendor, node_modules, and docs
+			if info.Name() == "vendor" || info.Name() == "node_modules" || info.Name() == "docs" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Only process .go files
+		if !strings.HasSuffix(info.Name(), ".go") {
+			return nil
+		}
+
+		// Parse the Go file
+		metadata, err := e.ExtractFromFile(path)
+		if err != nil {
+			// Gracefully handle invalid files - skip them
+			return nil
+		}
+
+		if metadata != nil {
+			result[path] = metadata
+		}
+
+		return nil
+	})
+
+	return result, err
+}
+
+// ExtractFromFile extracts import metadata from a single Go file
+func (e *ImportExtractor) ExtractFromFile(filePath string) (*ImportMetadata, error) {
+	fset := token.NewFileSet()
+
+	// Parse the file with parser.ParseFile which handles errors gracefully
+	file, err := parser.ParseFile(fset, filePath, nil, parser.ImportsOnly)
+	if err != nil {
+		// Gracefully handle malformed files
+		return nil, nil
+	}
+
+	// Get the package name
+	packageName := file.Name.Name
+
+	// Extract imports
+	imports := e.extractImports(file)
+
+	return &ImportMetadata{
+		Package: packageName,
+		Imports: imports,
+	}, nil
+}
+
+// extractImports extracts and normalizes import paths from an AST file
+func (e *ImportExtractor) extractImports(file *ast.File) []string {
+	importMap := make(map[string]bool)
+
+	for _, imp := range file.Imports {
+		importPath := strings.Trim(imp.Path.Value, `"`)
+
+		// Skip standard library imports
+		if e.isStdlibImport(importPath) {
+			continue
+		}
+
+		// Normalize the import path (remove aliases, etc.)
+		normalized := e.normalizeImport(importPath)
+
+		if normalized != "" && !importMap[normalized] {
+			importMap[normalized] = true
+		}
+	}
+
+	// Convert map to slice
+	imports := make([]string, 0, len(importMap))
+	for imp := range importMap {
+		imports = append(imports, imp)
+	}
+
+	return imports
+}
+
+// isStdlibImport checks if an import path is from the standard library
+func (e *ImportExtractor) isStdlibImport(importPath string) bool {
+	// Standard library imports don't contain a dot in the first path component
+	// and are not the current module
+	parts := strings.Split(importPath, "/")
+	if len(parts) == 0 {
+		return true
+	}
+
+	firstPart := parts[0]
+
+	// Standard library packages typically don't have dots or hyphens in their names
+	// and are not relative paths
+	if !strings.Contains(firstPart, ".") && !strings.Contains(firstPart, "-") {
+		// Check against known stdlib prefixes
+		return e.stdlibPrefixs[firstPart]
+	}
+
+	return false
+}
+
+// normalizeImport normalizes an import path relative to the module
+func (e *ImportExtractor) normalizeImport(importPath string) string {
+	// Remove module prefix if it's an internal import
+	if strings.HasPrefix(importPath, e.modulePath+"/") {
+		relative := strings.TrimPrefix(importPath, e.modulePath+"/")
+		return "./" + relative
+	} else if importPath == e.modulePath {
+		return "./"
+	}
+
+	// Return external imports as-is
+	return importPath
+}
+
+// buildStdlibPrefixs builds a set of common stdlib package prefixes
+func buildStdlibPrefixs() map[string]bool {
+	return map[string]bool{
+		// A
+		"archive": true,
+		"bufio": true,
+		"bytes": true,
+		// C
+		"compress": true,
+		"container": true,
+		"context": true,
+		"crypto": true,
+		// D
+		"database": true,
+		"debug": true,
+		// E
+		"encoding": true,
+		"errors": true,
+		// F
+		"flag": true,
+		"fmt": true,
+		// G
+		"go": true,
+		// H
+		"hash": true,
+		"html": true,
+		// I
+		"image": true,
+		"index": true,
+		"internal": true,
+		"io": true,
+		// L
+		"log": true,
+		// M
+		"math": true,
+		"mime": true,
+		// N
+		"net": true,
+		// O
+		"os": true,
+		// P
+		"path": true,
+		"plugin": true,
+		"pprof": true,
+		// R
+		"reflect": true,
+		"regexp": true,
+		"runtime": true,
+		// S
+		"sort": true,
+		"strconv": true,
+		"strings": true,
+		"sync": true,
+		"syscall": true,
+		// T
+		"testing": true,
+		"text": true,
+		"time": true,
+		// U
+		"unicode": true,
+		// V
+		"unsafe": true,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const version = "0.1.0-dev"
+const version = "0.2.0-dev"
 
 func main() {
 	// Command flags
@@ -16,6 +16,11 @@ func main() {
 	analyzePath := analyzeCmd.String("path", ".", "Path to analyze")
 	analyzeFormat := analyzeCmd.String("format", "text", "Output format (text, json)")
 	analyzeVerbose := analyzeCmd.Bool("verbose", false, "Enable verbose output")
+
+	// Extract imports command
+	extractCmd := flag.NewFlagSet("extract", flag.ExitOnError)
+	extractPath := extractCmd.String("path", ".", "Path to extract imports from")
+	extractModule := extractCmd.String("module", "RepoDoctor", "Module path for normalization")
 
 	versionCmd := flag.NewFlagSet("version", flag.ExitOnError)
 
@@ -29,6 +34,9 @@ func main() {
 	case "analyze":
 		analyzeCmd.Parse(os.Args[2:])
 		runAnalyze(*analyzePath, *analyzeFormat, *analyzeVerbose)
+	case "extract":
+		extractCmd.Parse(os.Args[2:])
+		runExtract(*extractPath, *extractModule, *analyzeVerbose)
 	case "version":
 		versionCmd.Parse(os.Args[2:])
 		fmt.Printf("RepoDoctor v%s\n", version)
@@ -49,6 +57,7 @@ Usage:
 
 Commands:
   analyze    Analyze repository architecture and health
+  extract    Extract Go package imports from source files
   version    Show version information
   help       Show this help message
 
@@ -58,9 +67,16 @@ Arguments:
     -format    Output format: text, json (default: text)
     -verbose   Enable verbose output
 
+  extract [options]
+    -path      Directory path to extract imports from (default: current directory)
+    -module    Module path for import normalization (default: RepoDoctor)
+    -verbose   Enable verbose output
+
 Examples:
   repodoctor analyze .
   repodoctor analyze -path ./myproject -format json
+  repodoctor extract .
+  repodoctor extract -path ./src -module github.com/myorg/myrepo
   repodoctor version`)
 }
 
@@ -161,4 +177,69 @@ func scanDirectory(path string, verbose bool) (totalFiles, goFiles, totalLines i
 	})
 
 	return
+}
+
+func runExtract(path, module string, verbose bool) {
+	// Resolve to absolute path
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error resolving path: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Check if path exists
+	info, err := os.Stat(absPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: path does not exist: %s\n", absPath)
+		os.Exit(1)
+	}
+
+	if !info.IsDir() {
+		fmt.Fprintf(os.Stderr, "Error: path is not a directory: %s\n", absPath)
+		os.Exit(1)
+	}
+
+	fmt.Printf("RepoDoctor v%s\n", version)
+	fmt.Printf("Extracting imports from: %s\n", absPath)
+	fmt.Printf("Module path: %s\n\n", module)
+
+	// Create extractor and extract imports
+	extractor := NewImportExtractor(module)
+	imports, err := extractor.ExtractFromDir(absPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error extracting imports: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Display results
+	fmt.Println("📊 Import Extraction Results")
+	fmt.Println(strings.Repeat("─", 60))
+
+	totalImports := 0
+	for filePath, metadata := range imports {
+		relPath, _ := filepath.Rel(absPath, filePath)
+		if relPath == "" {
+			relPath = filePath
+		}
+
+		fmt.Printf("\n📄 %s (package: %s)\n", relPath, metadata.Package)
+		if len(metadata.Imports) > 0 {
+			for _, imp := range metadata.Imports {
+				fmt.Printf("   • %s\n", imp)
+				totalImports++
+			}
+		} else {
+			fmt.Printf("   (no external imports)\n")
+		}
+
+		if verbose {
+			fmt.Printf("   └─ Absolute: %s\n", filePath)
+		}
+	}
+
+	fmt.Println(strings.Repeat("─", 60))
+	fmt.Printf("📦 Total files analyzed: %d\n", len(imports))
+	fmt.Printf("📥 Total unique imports: %d\n", totalImports)
+	fmt.Println("✨ Import extraction completed successfully")
+	fmt.Println()
 }


### PR DESCRIPTION
- Add ImportMetadata struct to hold package-level import data
- Create ImportExtractor with stdlib detection and path normalization
- Add 'extract' CLI command to extract imports from Go files
- Normalize internal module paths to relative paths
- Filter standard library imports automatically
- Handle malformed files gracefully without panicking