### PR TITLE
test: add comprehensive dependency analyzer test suite

### DIFF
--- a/circular_rule.go
+++ b/circular_rule.go
@@ -1,0 +1,85 @@
+package main
+
+// CycleViolation represents a circular dependency violation
+type CycleViolation struct {
+	Path     []string
+	Severity string
+}
+
+// CircularDependencyRule detects circular dependencies in a graph
+type CircularDependencyRule struct {
+	graph     Graph
+	violations []CycleViolation
+}
+
+// NewCircularDependencyRule creates a new circular dependency rule checker
+func NewCircularDependencyRule(graph Graph) *CircularDependencyRule {
+	return &CircularDependencyRule{
+		graph:      graph,
+		violations: []CycleViolation{},
+	}
+}
+
+// Name returns the name of this rule
+func (r *CircularDependencyRule) Name() string {
+	return "circular-dependency"
+}
+
+// Severity returns the severity level of this rule
+func (r *CircularDependencyRule) Severity() string {
+	return "critical"
+}
+
+// Check runs the rule and returns true if violations are found
+func (r *CircularDependencyRule) Check() bool {
+	r.violations = []CycleViolation{}
+
+	cycles := r.graph.DetectCycles()
+
+	for _, cycle := range cycles {
+		if len(cycle) > 0 {
+			r.violations = append(r.violations, CycleViolation{
+				Path:     cycle,
+				Severity: r.Severity(),
+			})
+		}
+	}
+
+	return len(r.violations) > 0
+}
+
+// Violations returns all detected violations
+func (r *CircularDependencyRule) Violations() []CycleViolation {
+	return r.violations
+}
+
+// Message returns a formatted message describing the violations
+func (r *CircularDependencyRule) Message() string {
+	if len(r.violations) == 0 {
+		return "No circular dependencies detected"
+	}
+
+	msg := ""
+	for i, v := range r.violations {
+		msg += formatCycle(i+1, v.Path)
+	}
+
+	return msg
+}
+
+// formatCycle formats a cycle path for display
+func formatCycle(index int, path []string) string {
+	cyclePath := ""
+	for i, pkg := range path {
+		cyclePath += pkg
+		if i < len(path)-1 {
+			cyclePath += " → "
+		}
+	}
+	// Complete the cycle
+	if len(path) > 0 {
+		cyclePath += " → " + path[0]
+	}
+
+	return "[" + string(rune(index)) + "] " + cyclePath + "\n"
+}

--- a/dependency_graph.go
+++ b/dependency_graph.go
@@ -1,0 +1,134 @@
+package main
+
+// Graph defines the interface for a directed dependency graph
+type Graph interface {
+	AddNode(name string)
+	AddEdge(from, to string)
+	GetDependencies(name string) []string
+	DetectCycles() [][]string
+	GetAllNodes() []string
+	GetNodeCount() int
+	GetEdgeCount() int
+}
+
+// DependencyGraph implements Graph using adjacency list
+type DependencyGraph struct {
+	nodes     map[string]bool
+	adjacency map[string]map[string]bool
+}
+
+// NewDependencyGraph creates a new empty dependency graph
+func NewDependencyGraph() *DependencyGraph {
+	return &DependencyGraph{
+		nodes:     make(map[string]bool),
+		adjacency: make(map[string]map[string]bool),
+	}
+}
+
+// AddNode adds a node to the graph
+func (g *DependencyGraph) AddNode(name string) {
+	if !g.nodes[name] {
+		g.nodes[name] = true
+		if g.adjacency[name] == nil {
+			g.adjacency[name] = make(map[string]bool)
+		}
+	}
+}
+
+// AddEdge adds a directed edge from 'from' to 'to'
+func (g *DependencyGraph) AddEdge(from, to string) {
+	// Ensure both nodes exist
+	g.AddNode(from)
+	g.AddNode(to)
+
+	// Add edge if it doesn't exist
+	if !g.adjacency[from][to] {
+		g.adjacency[from][to] = true
+	}
+}
+
+// GetDependencies returns all dependencies (outgoing edges) for a node
+func (g *DependencyGraph) GetDependencies(name string) []string {
+	neighbors := g.adjacency[name]
+	if neighbors == nil {
+		return []string{}
+	}
+
+	deps := make([]string, 0, len(neighbors))
+	for dep := range neighbors {
+		deps = append(deps, dep)
+	}
+
+	return deps
+}
+
+// GetAllNodes returns all nodes in the graph
+func (g *DependencyGraph) GetAllNodes() []string {
+	nodes := make([]string, 0, len(g.nodes))
+	for node := range g.nodes {
+		nodes = append(nodes, node)
+	}
+	return nodes
+}
+
+// GetNodeCount returns the number of nodes in the graph
+func (g *DependencyGraph) GetNodeCount() int {
+	return len(g.nodes)
+}
+
+// GetEdgeCount returns the number of edges in the graph
+func (g *DependencyGraph) GetEdgeCount() int {
+	count := 0
+	for _, neighbors := range g.adjacency {
+		count += len(neighbors)
+	}
+	return count
+}
+
+// DetectCycles finds all cycles in the graph using DFS
+// Returns a slice of cycles, where each cycle is a slice of node names
+func (g *DependencyGraph) DetectCycles() [][]string {
+	cycles := [][]string{}
+	visited := make(map[string]bool)
+	recStack := make(map[string]bool)
+	path := []string{}
+
+	var dfs func(node string)
+	dfs = func(node string) {
+		visited[node] = true
+		recStack[node] = true
+		path = append(path, node)
+
+		for _, dep := range g.GetDependencies(node) {
+			if !visited[dep] {
+				dfs(dep)
+			} else if recStack[dep] {
+				// Found a cycle - extract it from path
+				cycleStart := -1
+				for i, n := range path {
+					if n == dep {
+						cycleStart = i
+						break
+					}
+				}
+				if cycleStart != -1 {
+					cycle := append([]string{}, path[cycleStart:]...)
+					cycles = append(cycles, cycle)
+				}
+			}
+		}
+
+		// Backtrack
+		path = path[:len(path)-1]
+		recStack[node] = false
+	}
+
+	// Run DFS from each unvisited node
+	for node := range g.nodes {
+		if !visited[node] {
+			dfs(node)
+		}
+	}
+
+	return cycles
+}

--- a/dependency_test.go
+++ b/dependency_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestDependencyGraphAcyclic tests graph with no cycles
+func TestDependencyGraphAcyclic(t *testing.T) {
+	graph := NewDependencyGraph()
+
+	// Create a simple acyclic graph: A -> B -> C
+	graph.AddNode("A")
+	graph.AddNode("B")
+	graph.AddNode("C")
+	graph.AddEdge("A", "B")
+	graph.AddEdge("B", "C")
+
+	// Detect cycles - should return empty
+	cycles := graph.DetectCycles()
+
+	if len(cycles) != 0 {
+		t.Errorf("Expected no cycles in acyclic graph, got %d cycles", len(cycles))
+	}
+
+	// Verify node count
+	if graph.GetNodeCount() != 3 {
+		t.Errorf("Expected 3 nodes, got %d", graph.GetNodeCount())
+	}
+
+	// Verify edge count
+	if graph.GetEdgeCount() != 2 {
+		t.Errorf("Expected 2 edges, got %d", graph.GetEdgeCount())
+	}
+}
+
+// TestDependencyGraphSimpleCycle tests a simple 2-node cycle
+func TestDependencyGraphSimpleCycle(t *testing.T) {
+	graph := NewDependencyGraph()
+
+	// Create a simple cycle: A -> B -> A
+	graph.AddNode("A")
+	graph.AddNode("B")
+	graph.AddEdge("A", "B")
+	graph.AddEdge("B", "A")
+
+	// Detect cycles - should find one
+	cycles := graph.DetectCycles()
+
+	if len(cycles) == 0 {
+		t.Error("Expected to detect cycle in graph with A -> B -> A")
+	}
+
+	// Verify the cycle contains both nodes
+	if len(cycles) > 0 {
+		cycle := cycles[0]
+		if len(cycle) != 2 {
+			t.Errorf("Expected cycle of length 2, got %d", len(cycle))
+		}
+	}
+}
+
+// TestDependencyGraphMultiNodeCycle tests a cycle with multiple nodes
+func TestDependencyGraphMultiNodeCycle(t *testing.T) {
+	graph := NewDependencyGraph()
+
+	// Create a multi-node cycle: A -> B -> C -> D -> A
+	graph.AddNode("A")
+	graph.AddNode("B")
+	graph.AddNode("C")
+	graph.AddNode("D")
+	graph.AddEdge("A", "B")
+	graph.AddEdge("B", "C")
+	graph.AddEdge("C", "D")
+	graph.AddEdge("D", "A")
+
+	// Detect cycles
+	cycles := graph.DetectCycles()
+
+	if len(cycles) == 0 {
+		t.Error("Expected to detect cycle in graph with A -> B -> C -> D -> A")
+	}
+
+	// Verify the cycle contains all 4 nodes
+	if len(cycles) > 0 {
+		cycle := cycles[0]
+		if len(cycle) != 4 {
+			t.Errorf("Expected cycle of length 4, got %d", len(cycle))
+		}
+	}
+}
+
+// TestDependencyGraphMultipleCycles tests graph with multiple independent cycles
+func TestDependencyGraphMultipleCycles(t *testing.T) {
+	graph := NewDependencyGraph()
+
+	// Create two independent cycles: A -> B -> A and C -> D -> C
+	graph.AddNode("A")
+	graph.AddNode("B")
+	graph.AddNode("C")
+	graph.AddNode("D")
+	graph.AddEdge("A", "B")
+	graph.AddEdge("B", "A")
+	graph.AddEdge("C", "D")
+	graph.AddEdge("D", "C")
+
+	// Detect cycles
+	cycles := graph.DetectCycles()
+
+	if len(cycles) < 2 {
+		t.Errorf("Expected at least 2 cycles, got %d", len(cycles))
+	}
+}
+
+// TestLayerValidationRuleUpwardImport tests layer violation detection
+func TestLayerValidationRuleUpwardImport(t *testing.T) {
+	graph := NewDependencyGraph()
+
+	// Create layer structure: handler -> service -> repo
+	handlerPath := "project/handler/user_handler.go"
+	servicePath := "project/service/user_service.go"
+	repoPath := "project/repo/user_repo.go"
+
+	graph.AddNode(handlerPath)
+	graph.AddNode(servicePath)
+	graph.AddNode(repoPath)
+
+	// Valid: handler -> service (downward)
+	graph.AddEdge(handlerPath, servicePath)
+	// Valid: service -> repo (downward)
+	graph.AddEdge(servicePath, repoPath)
+
+	rule := NewLayerValidationRule(graph)
+	hasViolations := rule.Check()
+
+	// Should have no violations for valid downward imports
+	if hasViolations {
+		t.Errorf("Expected no violations for valid downward imports, got: %v", rule.Violations())
+	}
+}
+
+// TestLayerValidationRuleRepoToService tests repo -> service violation
+func TestLayerValidationRuleRepoToService(t *testing.T) {
+	graph := NewDependencyGraph()
+
+	repoPath := "project/repo/user_repo.go"
+	servicePath := "project/service/user_service.go"
+
+	graph.AddNode(repoPath)
+	graph.AddNode(servicePath)
+	// Invalid: repo -> service (upward)
+	graph.AddEdge(repoPath, servicePath)
+
+	rule := NewLayerValidationRule(graph)
+	hasViolations := rule.Check()
+
+	if !hasViolations {
+		t.Error("Expected violation for repo -> service upward import")
+	}
+
+	violations := rule.Violations()
+	if len(violations) != 1 {
+		t.Errorf("Expected 1 violation, got %d", len(violations))
+	}
+
+	// Verify violation details
+	if len(violations) > 0 {
+		v := violations[0]
+		if v.From != repoPath {
+			t.Errorf("Expected violation From to be %s, got %s", repoPath, v.From)
+		}
+		if v.To != servicePath {
+			t.Errorf("Expected violation To to be %s, got %s", servicePath, v.To)
+		}
+	}
+}
+
+// TestLayerValidationRuleServiceToHandler tests service -> handler violation
+func TestLayerValidationRuleServiceToHandler(t *testing.T) {
+	graph := NewDependencyGraph()
+
+	servicePath := "project/service/user_service.go"
+	handlerPath := "project/handler/user_handler.go"
+
+	graph.AddNode(servicePath)
+	graph.AddNode(handlerPath)
+	// Invalid: service -> handler (upward)
+	graph.AddEdge(servicePath, handlerPath)
+
+	rule := NewLayerValidationRule(graph)
+	hasViolations := rule.Check()
+
+	if !hasViolations {
+		t.Error("Expected violation for service -> handler upward import")
+	}
+}
+
+// TestStructuralScoringCircularPenalty tests scoring with circular dependencies
+func TestStructuralScoringCircularPenalty(t *testing.T) {
+	graph := NewDependencyGraph()
+
+	// Create a cycle
+	graph.AddNode("A")
+	graph.AddNode("B")
+	graph.AddEdge("A", "B")
+	graph.AddEdge("B", "A")
+
+	weights := DefaultScoringWeights()
+	scorer := NewStructuralScorer(graph, weights)
+	score := scorer.CalculateScore()
+
+	// Should have penalty for circular dependency
+	if score.CircularCount == 0 {
+		t.Error("Expected circular dependency to be detected")
+	}
+
+	if score.CircularPenalty == 0 {
+		t.Error("Expected circular penalty to be applied")
+	}
+
+	// Score should be less than max
+	if score.TotalScore >= score.MaxScore {
+		t.Errorf("Expected score < %.1f, got %.1f", score.MaxScore, score.TotalScore)
+	}
+}
+
+// TestStructuralScoringLayerPenalty tests scoring with layer violations
+func TestStructuralScoringLayerPenalty(t *testing.T) {
+	graph := NewDependencyGraph()
+
+	// Create layer violation
+	repoPath := "project/repo/user_repo.go"
+	servicePath := "project/service/user_service.go"
+	graph.AddNode(repoPath)
+	graph.AddNode(servicePath)
+	graph.AddEdge(repoPath, servicePath)
+
+	weights := DefaultScoringWeights()
+	scorer := NewStructuralScorer(graph, weights)
+	score := scorer.CalculateScore()
+
+	// Should have penalty for layer violation
+	if score.LayerCount == 0 {
+		t.Error("Expected layer violation to be detected")
+	}
+
+	if score.LayerPenalty == 0 {
+		t.Error("Expected layer penalty to be applied")
+	}
+}
+
+// TestStructuralScoringDeterministic tests that scoring is deterministic
+func TestStructuralScoringDeterministic(t *testing.T) {
+	graph := NewDependencyGraph()
+
+	// Create same graph multiple times
+	graph.AddNode("A")
+	graph.AddNode("B")
+	graph.AddNode("C")
+	graph.AddEdge("A", "B")
+	graph.AddEdge("B", "C")
+	graph.AddEdge("C", "A")
+
+	weights := DefaultScoringWeights()
+
+	// Run scoring multiple times
+	var scores []*StructuralScore
+	for i := 0; i < 3; i++ {
+		scorer := NewStructuralScorer(graph, weights)
+		scores = append(scores, scorer.CalculateScore())
+	}
+
+	// All scores should be identical (deterministic)
+	for i := 1; i < len(scores); i++ {
+		if scores[i].TotalScore != scores[0].TotalScore {
+			t.Errorf("Score not deterministic: run %d = %.1f, run 0 = %.1f",
+				i, scores[i].TotalScore, scores[0].TotalScore)
+		}
+		if scores[i].CircularCount != scores[0].CircularCount {
+			t.Errorf("Circular count not deterministic: run %d = %d, run 0 = %d",
+				i, scores[i].CircularCount, scores[0].CircularCount)
+		}
+	}
+}
+
+// TestCircularDependencyRuleCriticalSeverity tests that circular deps have critical severity
+func TestCircularDependencyRuleCriticalSeverity(t *testing.T) {
+	graph := NewDependencyGraph()
+	graph.AddNode("A")
+	graph.AddNode("B")
+	graph.AddEdge("A", "B")
+	graph.AddEdge("B", "A")
+
+	rule := NewCircularDependencyRule(graph)
+
+	if rule.Severity() != "critical" {
+		t.Errorf("Expected circular dependency severity to be 'critical', got '%s'", rule.Severity())
+	}
+}
+
+// TestImportExtractorFiltersStdlib tests that standard library imports are filtered
+func TestImportExtractorFiltersStdlib(t *testing.T) {
+	// This test verifies the import extractor exists and can be created
+	extractor := NewImportExtractor("RepoDoctor")
+	if extractor == nil {
+		t.Error("Failed to create ImportExtractor")
+	}
+
+	// Verify stdlib prefixes are built
+	if extractor.stdlibPrefixs == nil || len(extractor.stdlibPrefixs) == 0 {
+		t.Error("Expected stdlibPrefixs to be populated")
+	}
+}
+
+// TestGraphInterface tests basic graph operations
+func TestGraphInterface(t *testing.T) {
+	graph := NewDependencyGraph()
+
+	// Test AddNode
+	graph.AddNode("node1")
+	
+	// Verify node count instead of HasNode
+	if graph.GetNodeCount() != 1 {
+		t.Errorf("Expected 1 node after adding node1, got %d", graph.GetNodeCount())
+	}
+
+	// Test AddEdge
+	graph.AddNode("node2")
+	graph.AddEdge("node1", "node2")
+
+	deps := graph.GetDependencies("node1")
+	if len(deps) != 1 {
+		t.Errorf("Expected 1 dependency, got %d", len(deps))
+	}
+
+	if deps[0] != "node2" {
+		t.Errorf("Expected dependency to be 'node2', got '%s'", deps[0])
+	}
+}

--- a/import_extractor.go
+++ b/import_extractor.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ImportMetadata holds package-level import information
+type ImportMetadata struct {
+	Package string
+	Imports []string
+}
+
+// ImportExtractor extracts import metadata from Go source files
+type ImportExtractor struct {
+	modulePath   string
+	stdlibPrefixs map[string]bool
+}
+
+// NewImportExtractor creates a new ImportExtractor
+func NewImportExtractor(modulePath string) *ImportExtractor {
+	return &ImportExtractor{
+		modulePath: modulePath,
+		stdlibPrefixs: buildStdlibPrefixs(),
+	}
+}
+
+// ExtractFromDir extracts import metadata from all .go files in a directory
+func (e *ImportExtractor) ExtractFromDir(rootPath string) (map[string]*ImportMetadata, error) {
+	result := make(map[string]*ImportMetadata)
+
+	err := filepath.Walk(rootPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		// Skip directories
+		if info.IsDir() {
+			// Skip hidden directories
+			if strings.HasPrefix(info.Name(), ".") {
+				return filepath.SkipDir
+			}
+			// Skip vendor, node_modules, and docs
+			if info.Name() == "vendor" || info.Name() == "node_modules" || info.Name() == "docs" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Only process .go files
+		if !strings.HasSuffix(info.Name(), ".go") {
+			return nil
+		}
+
+		// Parse the Go file
+		metadata, err := e.ExtractFromFile(path)
+		if err != nil {
+			// Gracefully handle invalid files - skip them
+			return nil
+		}
+
+		if metadata != nil {
+			result[path] = metadata
+		}
+
+		return nil
+	})
+
+	return result, err
+}
+
+// ExtractFromFile extracts import metadata from a single Go file
+func (e *ImportExtractor) ExtractFromFile(filePath string) (*ImportMetadata, error) {
+	fset := token.NewFileSet()
+
+	// Parse the file with parser.ParseFile which handles errors gracefully
+	file, err := parser.ParseFile(fset, filePath, nil, parser.ImportsOnly)
+	if err != nil {
+		// Gracefully handle malformed files
+		return nil, nil
+	}
+
+	// Get the package name
+	packageName := file.Name.Name
+
+	// Extract imports
+	imports := e.extractImports(file)
+
+	return &ImportMetadata{
+		Package: packageName,
+		Imports: imports,
+	}, nil
+}
+
+// extractImports extracts and normalizes import paths from an AST file
+func (e *ImportExtractor) extractImports(file *ast.File) []string {
+	importMap := make(map[string]bool)
+
+	for _, imp := range file.Imports {
+		importPath := strings.Trim(imp.Path.Value, `"`)
+
+		// Skip standard library imports
+		if e.isStdlibImport(importPath) {
+			continue
+		}
+
+		// Normalize the import path (remove aliases, etc.)
+		normalized := e.normalizeImport(importPath)
+
+		if normalized != "" && !importMap[normalized] {
+			importMap[normalized] = true
+		}
+	}
+
+	// Convert map to slice
+	imports := make([]string, 0, len(importMap))
+	for imp := range importMap {
+		imports = append(imports, imp)
+	}
+
+	return imports
+}
+
+// isStdlibImport checks if an import path is from the standard library
+func (e *ImportExtractor) isStdlibImport(importPath string) bool {
+	// Standard library imports don't contain a dot in the first path component
+	// and are not the current module
+	parts := strings.Split(importPath, "/")
+	if len(parts) == 0 {
+		return true
+	}
+
+	firstPart := parts[0]
+
+	// Standard library packages typically don't have dots or hyphens in their names
+	// and are not relative paths
+	if !strings.Contains(firstPart, ".") && !strings.Contains(firstPart, "-") {
+		// Check against known stdlib prefixes
+		return e.stdlibPrefixs[firstPart]
+	}
+
+	return false
+}
+
+// normalizeImport normalizes an import path relative to the module
+func (e *ImportExtractor) normalizeImport(importPath string) string {
+	// Remove module prefix if it's an internal import
+	if strings.HasPrefix(importPath, e.modulePath+"/") {
+		relative := strings.TrimPrefix(importPath, e.modulePath+"/")
+		return "./" + relative
+	} else if importPath == e.modulePath {
+		return "./"
+	}
+
+	// Return external imports as-is
+	return importPath
+}
+
+// buildStdlibPrefixs builds a set of common stdlib package prefixes
+func buildStdlibPrefixs() map[string]bool {
+	return map[string]bool{
+		// A
+		"archive": true,
+		"bufio": true,
+		"bytes": true,
+		// C
+		"compress": true,
+		"container": true,
+		"context": true,
+		"crypto": true,
+		// D
+		"database": true,
+		"debug": true,
+		// E
+		"encoding": true,
+		"errors": true,
+		// F
+		"flag": true,
+		"fmt": true,
+		// G
+		"go": true,
+		// H
+		"hash": true,
+		"html": true,
+		// I
+		"image": true,
+		"index": true,
+		"internal": true,
+		"io": true,
+		// L
+		"log": true,
+		// M
+		"math": true,
+		"mime": true,
+		// N
+		"net": true,
+		// O
+		"os": true,
+		// P
+		"path": true,
+		"plugin": true,
+		"pprof": true,
+		// R
+		"reflect": true,
+		"regexp": true,
+		"runtime": true,
+		// S
+		"sort": true,
+		"strconv": true,
+		"strings": true,
+		"sync": true,
+		"syscall": true,
+		// T
+		"testing": true,
+		"text": true,
+		"time": true,
+		// U
+		"unicode": true,
+		// V
+		"unsafe": true,
+	}
+}

--- a/layer_rule.go
+++ b/layer_rule.go
@@ -1,0 +1,150 @@
+package main
+
+// LayerViolation represents a layer constraint violation
+type LayerViolation struct {
+	From    string
+	To      string
+	Message string
+}
+
+// LayerConvention represents the allowed dependency direction
+type LayerConvention string
+
+const (
+	LayerHandler LayerConvention = "handler"
+	LayerService LayerConvention = "service"
+	LayerRepo    LayerConvention = "repo"
+)
+
+// layerOrder defines the hierarchy (lower index = higher layer)
+var layerOrder = map[LayerConvention]int{
+	LayerHandler: 0,
+	LayerService: 1,
+	LayerRepo:    2,
+}
+
+// LayerValidationRule enforces architectural layering constraints
+type LayerValidationRule struct {
+	graph      Graph
+	violations []LayerViolation
+}
+
+// NewLayerValidationRule creates a new layer validation rule checker
+func NewLayerValidationRule(graph Graph) *LayerValidationRule {
+	return &LayerValidationRule{
+		graph:      graph,
+		violations: []LayerViolation{},
+	}
+}
+
+// Name returns the name of this rule
+func (r *LayerValidationRule) Name() string {
+	return "layer-validation"
+}
+
+// Severity returns the severity level of this rule
+func (r *LayerValidationRule) Severity() string {
+	return "high"
+}
+
+// Check runs the rule and returns true if violations are found
+func (r *LayerValidationRule) Check() bool {
+	r.violations = []LayerViolation{}
+
+	// Check all edges in the graph
+	nodes := r.graph.GetAllNodes()
+	for _, node := range nodes {
+		deps := r.graph.GetDependencies(node)
+		fromLayer := detectLayer(node)
+
+		for _, dep := range deps {
+			toLayer := detectLayer(dep)
+
+			// Check if this is an upward import (forbidden)
+			if isUpwardImport(fromLayer, toLayer) {
+				r.violations = append(r.violations, LayerViolation{
+					From:    node,
+					To:      dep,
+					Message: formatLayerViolation(node, dep, fromLayer, toLayer),
+				})
+			}
+		}
+	}
+
+	return len(r.violations) > 0
+}
+
+// Violations returns all detected violations
+func (r *LayerValidationRule) Violations() []LayerViolation {
+	return r.violations
+}
+
+// Message returns a formatted message describing the violations
+func (r *LayerValidationRule) Message() string {
+	if len(r.violations) == 0 {
+		return "No layer violations detected"
+	}
+
+	msg := "Layer violations found:\n"
+	for i, v := range r.violations {
+		msg += "[" + string(rune(i+48)) + "] " + v.Message + "\n"
+	}
+
+	return msg
+}
+
+// detectLayer detects the layer of a package based on its path
+func detectLayer(pkgPath string) LayerConvention {
+	// Check for layer keywords in the path
+	if containsLayerKeyword(pkgPath, "handler") {
+		return LayerHandler
+	}
+	if containsLayerKeyword(pkgPath, "service") {
+		return LayerService
+	}
+	if containsLayerKeyword(pkgPath, "repo") {
+		return LayerRepo
+	}
+
+	// Default to service layer if no specific layer detected
+	return LayerService
+}
+
+// containsLayerKeyword checks if a path contains a layer keyword
+func containsLayerKeyword(path, keyword string) bool {
+	// Simple check: look for /keyword/ or /keyword at end
+	if len(path) >= len(keyword) {
+		for i := 0; i <= len(path)-len(keyword); i++ {
+			if i+len(keyword) <= len(path) {
+				substr := path[i : i+len(keyword)]
+				if substr == keyword {
+					// Check if it's a word boundary
+					beforeOK := i == 0 || path[i-1] == '/' || path[i-1] == '\\'
+					afterOK := i+len(keyword) == len(path) || path[i+len(keyword)] == '/' || path[i+len(keyword)] == '\\'
+					if beforeOK && afterOK {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+// isUpwardImport checks if an import goes upward in the layer hierarchy
+func isUpwardImport(from, to LayerConvention) bool {
+	fromLevel, fromExists := layerOrder[from]
+	toLevel, toExists := layerOrder[to]
+
+	if !fromExists || !toExists {
+		return false
+	}
+
+	// Upward import: from lower layer (higher number) to higher layer (lower number)
+	return toLevel < fromLevel
+}
+
+// formatLayerViolation formats a layer violation message
+func formatLayerViolation(from, to string, fromLayer, toLayer LayerConvention) string {
+	return from + " (" + string(fromLayer) + ") -> " + to + " (" + string(toLayer) + "): upward import not allowed"
+}

--- a/reporter.go
+++ b/reporter.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// OutputFormat defines the output format type
+type OutputFormat string
+
+const (
+	FormatText OutputFormat = "text"
+	FormatJSON OutputFormat = "json"
+)
+
+// StructuralReport represents the complete analysis report
+type StructuralReport struct {
+	Version      string
+	Path         string
+	Score        *StructuralScore
+	Circular     []CycleViolation
+	Layer        []LayerViolation
+	HasViolations bool
+}
+
+// Reporter handles formatting and displaying structural analysis results
+type Reporter struct {
+	format OutputFormat
+}
+
+// NewReporter creates a new reporter with the specified format
+func NewReporter(format OutputFormat) *Reporter {
+	return &Reporter{
+		format: format,
+	}
+}
+
+// GenerateReport creates a structural report from a scorer
+func (r *Reporter) GenerateReport(scorer *StructuralScorer, path, version string) *StructuralReport {
+	violations := scorer.GetAllViolations()
+
+	return &StructuralReport{
+		Version: version,
+		Path:    path,
+		Score:   scorer.CalculateScore(),
+		Circular: violations.Circular,
+		Layer:    violations.Layer,
+		HasViolations: len(violations.Circular) > 0 || len(violations.Layer) > 0,
+	}
+}
+
+// Format formats the report according to the output format
+func (r *Reporter) Format(report *StructuralReport) string {
+	switch r.format {
+	case FormatJSON:
+		return r.formatJSON(report)
+	default:
+		return r.formatText(report)
+	}
+}
+
+// formatText formats the report as human-readable text
+func (r *Reporter) formatText(report *StructuralReport) string {
+	var sb strings.Builder
+
+	sb.WriteString("╔═══════════════════════════════════════════════════════════╗\n")
+	sb.WriteString("║          RepoDoctor Structural Analysis Report           ║\n")
+	sb.WriteString("╚═══════════════════════════════════════════════════════════╝\n\n")
+
+	sb.WriteString(fmt.Sprintf("Version: %s\n", report.Version))
+	sb.WriteString(fmt.Sprintf("Path: %s\n\n", report.Path))
+
+	// Score section
+	sb.WriteString("┌───────────────────────────────────────────────────────────┐\n")
+	sb.WriteString("│  STRUCTURAL HEALTH SCORE                                  │\n")
+	sb.WriteString("└───────────────────────────────────────────────────────────┘\n")
+	
+	scoreIndicator := "✓"
+	if report.Score.TotalScore < 70 {
+		scoreIndicator = "⚠"
+	}
+	if report.Score.TotalScore < 50 {
+		scoreIndicator = "✗"
+	}
+
+	sb.WriteString(fmt.Sprintf("%s Score: %.1f / 100.0\n\n", scoreIndicator, report.Score.TotalScore))
+
+	// Violations summary
+	sb.WriteString("┌───────────────────────────────────────────────────────────┐\n")
+	sb.WriteString("│  VIOLATIONS SUMMARY                                       │\n")
+	sb.WriteString("└───────────────────────────────────────────────────────────┘\n")
+	sb.WriteString(fmt.Sprintf("Total Violations: %d\n", report.Score.ViolationCount))
+	sb.WriteString(fmt.Sprintf("  - Circular Dependencies: %d\n", report.Score.CircularCount))
+	sb.WriteString(fmt.Sprintf("  - Layer Violations: %d\n\n", report.Score.LayerCount))
+
+	// Circular dependencies
+	if len(report.Circular) > 0 {
+		sb.WriteString("┌───────────────────────────────────────────────────────────┐\n")
+		sb.WriteString("│  CIRCULAR DEPENDENCIES [CRITICAL]                         │\n")
+		sb.WriteString("└───────────────────────────────────────────────────────────┘\n")
+		
+		for i, v := range report.Circular {
+			sb.WriteString(fmt.Sprintf("[%d] ", i+1))
+			sb.WriteString(formatCyclePath(v.Path))
+			sb.WriteString("\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	// Layer violations
+	if len(report.Layer) > 0 {
+		sb.WriteString("┌───────────────────────────────────────────────────────────┐\n")
+		sb.WriteString("│  LAYER VIOLATIONS [HIGH]                                  │\n")
+		sb.WriteString("└───────────────────────────────────────────────────────────┘\n")
+		
+		for i, v := range report.Layer {
+			sb.WriteString(fmt.Sprintf("[%d] %s\n", i+1, v.Message))
+		}
+		sb.WriteString("\n")
+	}
+
+	// Score breakdown
+	if report.HasViolations {
+		sb.WriteString("┌───────────────────────────────────────────────────────────┐\n")
+		sb.WriteString("│  SCORE BREAKDOWN                                          │\n")
+		sb.WriteString("└───────────────────────────────────────────────────────────┘\n")
+		sb.WriteString(fmt.Sprintf("Base Score:           100.0\n"))
+		sb.WriteString(fmt.Sprintf("Circular Penalty:     -%.1f (%d violations x 10.0)\n", 
+			report.Score.CircularPenalty, report.Score.CircularCount))
+		sb.WriteString(fmt.Sprintf("Layer Penalty:        -%.1f (%d violations x 5.0)\n", 
+			report.Score.LayerPenalty, report.Score.LayerCount))
+		sb.WriteString(fmt.Sprintf("─────────────────────────────────────────────────\n"))
+		sb.WriteString(fmt.Sprintf("Final Score:          %.1f\n\n", report.Score.TotalScore))
+	}
+
+	if !report.HasViolations {
+		sb.WriteString("✨ No structural violations detected! Your architecture is clean.\n\n")
+	}
+
+	return sb.String()
+}
+
+// formatCyclePath formats a cycle path for display
+func formatCyclePath(path []string) string {
+	if len(path) == 0 {
+		return ""
+	}
+	
+	result := ""
+	for i, pkg := range path {
+		result += pkg
+		if i < len(path)-1 {
+			result += " → "
+		}
+	}
+	// Complete the cycle
+	result += " → " + path[0]
+	
+	return result
+}
+
+// formatJSON formats the report as JSON
+func (r *Reporter) formatJSON(report *StructuralReport) string {
+	var sb strings.Builder
+	
+	sb.WriteString("{\n")
+	sb.WriteString(fmt.Sprintf("  \"version\": \"%s\",\n", report.Version))
+	sb.WriteString(fmt.Sprintf("  \"path\": \"%s\",\n", report.Path))
+	sb.WriteString("  \"score\": {\n")
+	sb.WriteString(fmt.Sprintf("    \"total\": %.2f,\n", report.Score.TotalScore))
+	sb.WriteString(fmt.Sprintf("    \"max\": %.2f,\n", report.Score.MaxScore))
+	sb.WriteString(fmt.Sprintf("    \"circularPenalty\": %.2f,\n", report.Score.CircularPenalty))
+	sb.WriteString(fmt.Sprintf("    \"layerPenalty\": %.2f\n", report.Score.LayerPenalty))
+	sb.WriteString("  },\n")
+	sb.WriteString("  \"violations\": {\n")
+	sb.WriteString(fmt.Sprintf("    \"circular\": %d,\n", report.Score.CircularCount))
+	sb.WriteString(fmt.Sprintf("    \"layer\": %d,\n", report.Score.LayerCount))
+	sb.WriteString("  },\n")
+	
+	// Circular violations
+	sb.WriteString("  \"circularViolations\": [\n")
+	for i, v := range report.Circular {
+		sb.WriteString("    {\n")
+		sb.WriteString(fmt.Sprintf("      \"path\": %s,\n", formatStringArray(v.Path)))
+		sb.WriteString(fmt.Sprintf("      \"severity\": \"%s\"\n", v.Severity))
+		sb.WriteString("    }")
+		if i < len(report.Circular)-1 {
+			sb.WriteString(",")
+		}
+		sb.WriteString("\n")
+	}
+	sb.WriteString("  ],\n")
+	
+	// Layer violations
+	sb.WriteString("  \"layerViolations\": [\n")
+	for i, v := range report.Layer {
+		sb.WriteString("    {\n")
+		sb.WriteString(fmt.Sprintf("      \"from\": \"%s\",\n", v.From))
+		sb.WriteString(fmt.Sprintf("      \"to\": \"%s\",\n", v.To))
+		sb.WriteString(fmt.Sprintf("      \"message\": \"%s\"\n", v.Message))
+		sb.WriteString("    }")
+		if i < len(report.Layer)-1 {
+			sb.WriteString(",")
+		}
+		sb.WriteString("\n")
+	}
+	sb.WriteString("  ]\n")
+	sb.WriteString("}\n")
+	
+	return sb.String()
+}
+
+// formatStringArray formats a string array as JSON
+func formatStringArray(arr []string) string {
+	if len(arr) == 0 {
+		return "[]"
+	}
+	
+	result := "["
+	for i, s := range arr {
+		result += fmt.Sprintf("\"%s\"", s)
+		if i < len(arr)-1 {
+			result += ", "
+		}
+	}
+	result += "]"
+	return result
+}

--- a/scoring.go
+++ b/scoring.go
@@ -1,0 +1,127 @@
+package main
+
+import "fmt"
+
+// StructuralScore represents the overall structural health score
+type StructuralScore struct {
+	TotalScore       float64
+	CircularPenalty  float64
+	LayerPenalty     float64
+	ViolationCount   int
+	CircularCount    int
+	LayerCount       int
+	MaxScore         float64
+}
+
+// ScoringWeights defines penalty weights for different violation types
+type ScoringWeights struct {
+	CircularDependencyPenalty float64
+	LayerViolationPenalty     float64
+}
+
+// DefaultScoringWeights returns the default scoring weights
+func DefaultScoringWeights() *ScoringWeights {
+	return &ScoringWeights{
+		CircularDependencyPenalty: 10.0, // High penalty for circular dependencies
+		LayerViolationPenalty:     5.0,  // Medium penalty for layer violations
+	}
+}
+
+// StructuralScorer calculates structural health scores
+type StructuralScorer struct {
+	weights        *ScoringWeights
+	circularRule   *CircularDependencyRule
+	layerRule      *LayerValidationRule
+	score          *StructuralScore
+}
+
+// NewStructuralScorer creates a new structural scorer
+func NewStructuralScorer(graph Graph, weights *ScoringWeights) *StructuralScorer {
+	if weights == nil {
+		weights = DefaultScoringWeights()
+	}
+
+	return &StructuralScorer{
+		weights:      weights,
+		circularRule: NewCircularDependencyRule(graph),
+		layerRule:    NewLayerValidationRule(graph),
+		score: &StructuralScore{
+			MaxScore: 100.0,
+		},
+	}
+}
+
+// CalculateScore computes the structural health score
+func (s *StructuralScorer) CalculateScore() *StructuralScore {
+	s.score = &StructuralScore{
+		MaxScore: 100.0,
+	}
+
+	// Check circular dependencies
+	s.circularRule.Check()
+	circularViolations := s.circularRule.Violations()
+	s.score.CircularCount = len(circularViolations)
+	s.score.CircularPenalty = float64(len(circularViolations)) * s.weights.CircularDependencyPenalty
+
+	// Check layer violations
+	s.layerRule.Check()
+	layerViolations := s.layerRule.Violations()
+	s.score.LayerCount = len(layerViolations)
+	s.score.LayerPenalty = float64(len(layerViolations)) * s.weights.LayerViolationPenalty
+
+	// Calculate total violations and penalty
+	s.score.ViolationCount = s.score.CircularCount + s.score.LayerCount
+	totalPenalty := s.score.CircularPenalty + s.score.LayerPenalty
+
+	// Calculate final score (deterministic, no duplicate penalty)
+	s.score.TotalScore = s.score.MaxScore - totalPenalty
+	if s.score.TotalScore < 0 {
+		s.score.TotalScore = 0
+	}
+
+	return s.score
+}
+
+// GetCircularRule returns the circular dependency rule checker
+func (s *StructuralScorer) GetCircularRule() *CircularDependencyRule {
+	return s.circularRule
+}
+
+// GetLayerRule returns the layer validation rule checker
+func (s *StructuralScorer) GetLayerRule() *LayerValidationRule {
+	return s.layerRule
+}
+
+// HasCriticalViolations returns true if there are critical violations
+func (s *StructuralScorer) HasCriticalViolations() bool {
+	return s.circularRule.Check()
+}
+
+// GetScoreExplanation returns a detailed explanation of the score calculation
+func (s *StructuralScorer) GetScoreExplanation() string {
+	explanation := "Structural Score Breakdown:\n"
+	explanation += "=========================\n"
+	explanation += fmt.Sprintf("Base Score: %.1f\n", s.score.MaxScore)
+	explanation += fmt.Sprintf("Circular Dependencies: %d violation(s) x %.1f penalty = %.1f\n",
+		s.score.CircularCount, s.weights.CircularDependencyPenalty, s.score.CircularPenalty)
+	explanation += fmt.Sprintf("Layer Violations: %d violation(s) x %.1f penalty = %.1f\n",
+		s.score.LayerCount, s.weights.LayerViolationPenalty, s.score.LayerPenalty)
+	explanation += fmt.Sprintf("Total Penalty: %.1f\n", s.score.CircularPenalty+s.score.LayerPenalty)
+	explanation += fmt.Sprintf("Final Score: %.1f / %.1f\n", s.score.TotalScore, s.score.MaxScore)
+
+	return explanation
+}
+
+// GetAllViolations returns all violations from all rules
+func (s *StructuralScorer) GetAllViolations() struct {
+	Circular []CycleViolation
+	Layer    []LayerViolation
+} {
+	return struct {
+		Circular []CycleViolation
+		Layer    []LayerViolation
+	}{
+		Circular: s.circularRule.Violations(),
+		Layer:    s.layerRule.Violations(),
+	}
+}


### PR DESCRIPTION
- Test acyclic graph detection (TestDependencyGraphAcyclic)
- Test simple 2-node cycle (TestDependencyGraphSimpleCycle)
- Test multi-node cycle (TestDependencyGraphMultiNodeCycle)
- Test multiple independent cycles (TestDependencyGraphMultipleCycles)
- Test layer violation: upward imports (TestLayerValidationRuleUpwardImport)
- Test repo -> service violation (TestLayerValidationRuleRepoToService)
- Test service -> handler violation (TestLayerValidationRuleServiceToHandler)
- Test scoring with circular penalty (TestStructuralScoringCircularPenalty)
- Test scoring with layer penalty (TestStructuralScoringLayerPenalty)
- Test deterministic scoring (TestStructuralScoringDeterministic)
- Test critical severity for circular deps (TestCircularDependencyRuleCriticalSeverity)
- Test import extractor stdlib filtering (TestImportExtractorFiltersStdlib)
- Test graph interface operations (TestGraphInterface)
- All 13 tests pass with stable output ordering