### PR TITLE
refactor(cli): split oversized responsibilities to satisfy CI rules

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -9,6 +9,12 @@ import (
 	"text/template"
 )
 
+type ruleTemplateData struct {
+	RuleName string
+	TypeName string
+	RuleID   string
+}
+
 // RuleTemplateGenerator generates rule templates
 type RuleTemplateGenerator struct {
 	rulesDir string
@@ -62,8 +68,40 @@ func (g *RuleTemplateGenerator) Generate(ruleName string) error {
 // generateTemplate creates the rule template content
 func (g *RuleTemplateGenerator) generateTemplate(ruleName string) string {
 	typeName := ruleTypeName(ruleName)
+	data := g.buildRuleTemplateData(ruleName, typeName)
 
-	tmpl := `package rules
+	content, err := g.renderRuleTemplate(data)
+	if err != nil {
+		return g.generateSimpleTemplate(ruleName, typeName)
+	}
+
+	return content
+}
+
+func (g *RuleTemplateGenerator) buildRuleTemplateData(ruleName, typeName string) ruleTemplateData {
+	return ruleTemplateData{
+		RuleName: ruleName,
+		TypeName: typeName,
+		RuleID:   strings.ReplaceAll(ruleName, "-", "_"),
+	}
+}
+
+func (g *RuleTemplateGenerator) renderRuleTemplate(data ruleTemplateData) (string, error) {
+	t, err := template.New("rule").Parse(g.ruleTemplateText())
+	if err != nil {
+		return "", err
+	}
+
+	var builder strings.Builder
+	if err := t.Execute(&builder, data); err != nil {
+		return "", err
+	}
+
+	return builder.String(), nil
+}
+
+func (g *RuleTemplateGenerator) ruleTemplateText() string {
+	return `package rules
 
 import "fmt"
 
@@ -140,26 +178,6 @@ type Violation struct {
 	Line     int
 }
 `
-
-	t := template.Must(template.New("rule").Parse(tmpl))
-
-	data := struct {
-		RuleName string
-		TypeName string
-		RuleID   string
-	}{
-		RuleName: ruleName,
-		TypeName: typeName,
-		RuleID:   strings.ReplaceAll(ruleName, "-", "_"),
-	}
-
-	var builder strings.Builder
-	if err := t.Execute(&builder, data); err != nil {
-		// Fallback to simple template if template fails
-		return g.generateSimpleTemplate(ruleName, typeName)
-	}
-
-	return builder.String()
 }
 
 const simpleRuleTemplate = `package rules

--- a/interactive.go
+++ b/interactive.go
@@ -13,14 +13,31 @@ import (
 
 // InteractiveMode provides an interactive CLI experience
 type InteractiveMode struct {
+	io               *interactiveIO
+	configController *InteractiveConfigController
+}
+
+type interactiveIO struct {
 	reader *bufio.Reader
+}
+
+// InteractiveConfigController handles rule configuration workflows.
+type InteractiveConfigController struct {
+	io *interactiveIO
 }
 
 // NewInteractiveMode creates a new interactive mode instance
 func NewInteractiveMode() *InteractiveMode {
+	io := &interactiveIO{reader: bufio.NewReader(os.Stdin)}
+
 	return &InteractiveMode{
-		reader: bufio.NewReader(os.Stdin),
+		io:               io,
+		configController: NewInteractiveConfigController(io),
 	}
+}
+
+func NewInteractiveConfigController(io *interactiveIO) *InteractiveConfigController {
+	return &InteractiveConfigController{io: io}
 }
 
 // Run starts the interactive mode session
@@ -32,7 +49,7 @@ func (i *InteractiveMode) Run() {
 	for {
 		i.showMainMenu()
 
-		choice := i.readChoice()
+		choice := i.io.readChoice()
 
 		switch choice {
 		case 1:
@@ -40,7 +57,7 @@ func (i *InteractiveMode) Run() {
 		case 2:
 			i.viewHistory()
 		case 3:
-			i.configureRules()
+			i.configController.configureRules()
 		case 4:
 			fmt.Println("\nExiting RepoDoctor Interactive Mode...")
 			return
@@ -60,22 +77,6 @@ func (i *InteractiveMode) showMainMenu() {
 	fmt.Print("\n> ")
 }
 
-// readChoice reads and validates user choice
-func (i *InteractiveMode) readChoice() int {
-	input, err := i.reader.ReadString('\n')
-	if err != nil {
-		return -1
-	}
-
-	input = strings.TrimSpace(input)
-	choice, err := strconv.Atoi(input)
-	if err != nil {
-		return -1
-	}
-
-	return choice
-}
-
 // analyzeMenu handles the analyze submenu
 func (i *InteractiveMode) analyzeMenu() {
 	fmt.Println("\nSelect analysis scope:")
@@ -84,20 +85,14 @@ func (i *InteractiveMode) analyzeMenu() {
 	fmt.Println("  3. Back to main menu")
 	fmt.Print("\n> ")
 
-	choice := i.readChoice()
+	choice := i.io.readChoice()
 
 	switch choice {
 	case 1:
 		fmt.Println("\nAnalyzing current repository...")
 		runAnalyze(".", "text", false, true, true)
 	case 2:
-		fmt.Print("\nEnter path to analyze: ")
-		path, err := i.reader.ReadString('\n')
-		if err != nil {
-			fmt.Println("Error reading path")
-			return
-		}
-		path = strings.TrimSpace(path)
+		path := i.io.readString("\nEnter path to analyze: ")
 		if path == "" {
 			fmt.Println("Path cannot be empty")
 			return
@@ -118,7 +113,7 @@ func (i *InteractiveMode) viewHistory() {
 }
 
 // configureRules handles rule configuration
-func (i *InteractiveMode) configureRules() {
+func (c *InteractiveConfigController) configureRules() {
 	absPath, err := filepath.Abs(".")
 	if err != nil {
 		fmt.Printf("\nError resolving repository path: %v\n\n", err)
@@ -133,18 +128,18 @@ func (i *InteractiveMode) configureRules() {
 	}
 
 	for {
-		i.showConfigMenu(config)
-		choice := i.readChoice()
+		c.showConfigMenu(config)
+		choice := c.io.readChoice()
 
 		switch choice {
 		case 1:
-			i.toggleSizeRule(config)
+			c.toggleSizeRule(config)
 		case 2:
-			i.toggleGodObjectRule(config)
+			c.toggleGodObjectRule(config)
 		case 3:
-			i.setMaxFileLines(config)
+			c.setMaxFileLines(config)
 		case 4:
-			i.setMaxFunctionLines(config)
+			c.setMaxFunctionLines(config)
 		case 5:
 			if err := saveConfig(absPath, config); err != nil {
 				fmt.Printf("\nError saving configuration: %v\n\n", err)
@@ -159,7 +154,7 @@ func (i *InteractiveMode) configureRules() {
 	}
 }
 
-func (i *InteractiveMode) showConfigMenu(config *Config) {
+func (c *InteractiveConfigController) showConfigMenu(config *Config) {
 	fmt.Println("\nRule Configuration")
 	fmt.Println(strings.Repeat("─", 50))
 	fmt.Printf("Current settings:\n")
@@ -177,7 +172,7 @@ func (i *InteractiveMode) showConfigMenu(config *Config) {
 	fmt.Print("\n> ")
 }
 
-func (i *InteractiveMode) toggleSizeRule(config *Config) {
+func (c *InteractiveConfigController) toggleSizeRule(config *Config) {
 	current := *config.Rules.EnableSizeRule
 	next := !current
 	config.Rules.EnableSizeRule = &next
@@ -187,7 +182,7 @@ func (i *InteractiveMode) toggleSizeRule(config *Config) {
 	fmt.Printf("\nSize Rule is now %s.\n\n", boolLabel(next))
 }
 
-func (i *InteractiveMode) toggleGodObjectRule(config *Config) {
+func (c *InteractiveConfigController) toggleGodObjectRule(config *Config) {
 	current := *config.Rules.EnableGodObjectRule
 	next := !current
 	config.Rules.EnableGodObjectRule = &next
@@ -197,8 +192,8 @@ func (i *InteractiveMode) toggleGodObjectRule(config *Config) {
 	fmt.Printf("\nGod Object Rule is now %s.\n\n", boolLabel(next))
 }
 
-func (i *InteractiveMode) setMaxFileLines(config *Config) {
-	value, ok := i.readPositiveInt("Enter max file lines")
+func (c *InteractiveConfigController) setMaxFileLines(config *Config) {
+	value, ok := c.io.readPositiveInt("Enter max file lines")
 	if !ok {
 		fmt.Print("\nInvalid value. Please enter a positive number.\n\n")
 		return
@@ -207,8 +202,8 @@ func (i *InteractiveMode) setMaxFileLines(config *Config) {
 	fmt.Printf("\nMax file lines set to %d.\n\n", value)
 }
 
-func (i *InteractiveMode) setMaxFunctionLines(config *Config) {
-	value, ok := i.readPositiveInt("Enter max function lines")
+func (c *InteractiveConfigController) setMaxFunctionLines(config *Config) {
+	value, ok := c.io.readPositiveInt("Enter max function lines")
 	if !ok {
 		fmt.Print("\nInvalid value. Please enter a positive number.\n\n")
 		return
@@ -217,8 +212,24 @@ func (i *InteractiveMode) setMaxFunctionLines(config *Config) {
 	fmt.Printf("\nMax function lines set to %d.\n\n", value)
 }
 
-func (i *InteractiveMode) readPositiveInt(prompt string) (int, bool) {
-	input := i.readString(prompt + ": ")
+// readChoice reads and validates user choice
+func (io *interactiveIO) readChoice() int {
+	input, err := io.reader.ReadString('\n')
+	if err != nil {
+		return -1
+	}
+
+	input = strings.TrimSpace(input)
+	choice, err := strconv.Atoi(input)
+	if err != nil {
+		return -1
+	}
+
+	return choice
+}
+
+func (io *interactiveIO) readPositiveInt(prompt string) (int, bool) {
+	input := io.readString(prompt + ": ")
 	value, err := strconv.Atoi(strings.TrimSpace(input))
 	if err != nil || value <= 0 {
 		return 0, false
@@ -247,9 +258,9 @@ func boolLabel(value bool) string {
 }
 
 // readString reads a string input from user
-func (i *InteractiveMode) readString(prompt string) string {
+func (io *interactiveIO) readString(prompt string) string {
 	fmt.Print(prompt)
-	input, err := i.reader.ReadString('\n')
+	input, err := io.reader.ReadString('\n')
 	if err != nil {
 		return ""
 	}
@@ -257,8 +268,8 @@ func (i *InteractiveMode) readString(prompt string) string {
 }
 
 // confirm asks for yes/no confirmation
-func (i *InteractiveMode) confirm(prompt string) bool {
-	response := i.readString(prompt + " (y/n): ")
+func (io *interactiveIO) confirm(prompt string) bool {
+	response := io.readString(prompt + " (y/n): ")
 	return strings.ToLower(response) == "y" || strings.ToLower(response) == "yes"
 }
 

--- a/main.go
+++ b/main.go
@@ -24,74 +24,28 @@ func main() {
 func executeCommand(cmd string, args []string) error {
 	switch cmd {
 	case "analyze":
-		analyzeCmd := flag.NewFlagSet("analyze", flag.ExitOnError)
-		path := analyzeCmd.String("path", ".", "Path to analyze")
-		format := analyzeCmd.String("format", "text", "Output format (text, json)")
-		verbose := analyzeCmd.Bool("verbose", false, "Enable verbose output")
-		jsonOut := analyzeCmd.Bool("json", false, "Output in JSON format")
-		watch := analyzeCmd.Bool("watch", false, "Enable watch mode for continuous analysis")
-		noColor := analyzeCmd.Bool("no-color", false, "Disable colored output")
-		analyzeCmd.Parse(args)
-
-		outputFormat := *format
-		if *jsonOut {
-			outputFormat = "json"
-		}
-		if *watch {
-			runWatch(*path)
-		} else {
-			runAnalyze(*path, outputFormat, *verbose, !*noColor, true)
-		}
+		return handleAnalyzeCommand(args)
 
 	case "extract":
-		extractCmd := flag.NewFlagSet("extract", flag.ExitOnError)
-		path := extractCmd.String("path", ".", "Path to extract imports from")
-		module := extractCmd.String("module", "RepoDoctor", "Module path for normalization")
-		verbose := extractCmd.Bool("verbose", false, "Enable verbose output")
-		jsonOut := extractCmd.Bool("json", false, "Output in JSON format")
-		extractCmd.Parse(args)
-		if err := runExtract(*path, *module, *verbose, *jsonOut); err != nil {
-			return err
-		}
+		return handleExtractCommand(args)
 
 	case "report":
-		reportCmd := flag.NewFlagSet("report", flag.ExitOnError)
-		path := reportCmd.String("path", "repodoctor-report.json", "Path to report file")
-		format := reportCmd.String("format", "text", "Output format (text, json)")
-		jsonOut := reportCmd.Bool("json", false, "Output in JSON format")
-		reportCmd.Parse(args)
-
-		outputFormat := *format
-		if *jsonOut {
-			outputFormat = "json"
-		}
-		if err := runReport(*path, outputFormat); err != nil {
-			return err
-		}
+		return handleReportCommand(args)
 
 	case "history":
-		historyCmd := flag.NewFlagSet("history", flag.ExitOnError)
-		path := historyCmd.String("path", ".", "Path to repository")
-		historyCmd.Parse(args)
-		if err := runHistory(*path); err != nil {
-			return err
-		}
+		return handleHistoryCommand(args)
 
 	case "interactive":
-		runInteractive()
+		return handleInteractiveCommand()
 
 	case "generate":
-		generateCmd := flag.NewFlagSet("generate", flag.ExitOnError)
-		generateCmd.Parse(args)
-		if err := runGenerate(generateCmd.Args()); err != nil {
-			return err
-		}
+		return handleGenerateCommand(args)
 
 	case "version":
-		fmt.Printf("RepoDoctor v%s\n", version)
+		return handleVersionCommand()
 
 	case "help", "-h", "--help":
-		printUsage()
+		return handleHelpCommand()
 
 	default:
 		printUsage()
@@ -103,6 +57,84 @@ func executeCommand(cmd string, args []string) error {
 			nil,
 		)
 	}
+}
+
+func handleAnalyzeCommand(args []string) error {
+	analyzeCmd := flag.NewFlagSet("analyze", flag.ExitOnError)
+	path := analyzeCmd.String("path", ".", "Path to analyze")
+	format := analyzeCmd.String("format", "text", "Output format (text, json)")
+	verbose := analyzeCmd.Bool("verbose", false, "Enable verbose output")
+	jsonOut := analyzeCmd.Bool("json", false, "Output in JSON format")
+	watch := analyzeCmd.Bool("watch", false, "Enable watch mode for continuous analysis")
+	noColor := analyzeCmd.Bool("no-color", false, "Disable colored output")
+	analyzeCmd.Parse(args)
+
+	outputFormat := *format
+	if *jsonOut {
+		outputFormat = "json"
+	}
+	if *watch {
+		runWatch(*path)
+		return nil
+	}
+
+	runAnalyze(*path, outputFormat, *verbose, !*noColor, true)
+	return nil
+}
+
+func handleExtractCommand(args []string) error {
+	extractCmd := flag.NewFlagSet("extract", flag.ExitOnError)
+	path := extractCmd.String("path", ".", "Path to extract imports from")
+	module := extractCmd.String("module", "RepoDoctor", "Module path for normalization")
+	verbose := extractCmd.Bool("verbose", false, "Enable verbose output")
+	jsonOut := extractCmd.Bool("json", false, "Output in JSON format")
+	extractCmd.Parse(args)
+
+	return runExtract(*path, *module, *verbose, *jsonOut)
+}
+
+func handleReportCommand(args []string) error {
+	reportCmd := flag.NewFlagSet("report", flag.ExitOnError)
+	path := reportCmd.String("path", "repodoctor-report.json", "Path to report file")
+	format := reportCmd.String("format", "text", "Output format (text, json)")
+	jsonOut := reportCmd.Bool("json", false, "Output in JSON format")
+	reportCmd.Parse(args)
+
+	outputFormat := *format
+	if *jsonOut {
+		outputFormat = "json"
+	}
+
+	return runReport(*path, outputFormat)
+}
+
+func handleHistoryCommand(args []string) error {
+	historyCmd := flag.NewFlagSet("history", flag.ExitOnError)
+	path := historyCmd.String("path", ".", "Path to repository")
+	historyCmd.Parse(args)
+
+	return runHistory(*path)
+}
+
+func handleInteractiveCommand() error {
+	runInteractive()
+	return nil
+}
+
+func handleGenerateCommand(args []string) error {
+	generateCmd := flag.NewFlagSet("generate", flag.ExitOnError)
+	generateCmd.Parse(args)
+
+	return runGenerate(generateCmd.Args())
+}
+
+func handleVersionCommand() error {
+	fmt.Printf("RepoDoctor v%s\n", version)
+	return nil
+}
+
+func handleHelpCommand() error {
+	printUsage()
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Split executeCommand into command-specific handlers to reduce function size.
- Refactor generator template flow into focused helpers to reduce function size.
- Extract interactive configuration responsibilities out of InteractiveMode to address god object violations.

## Verification
- go test ./...
- go vet ./...

## Notes
- Includes only targeted refactor files (main.go, generator.go, interactive.go).