### PR TITLE
RD-701: Analyze CLI path semantics and traversal safety

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,17 +69,41 @@ func handleAnalyzeCommand(args []string) error {
 	noColor := analyzeCmd.Bool("no-color", false, "Disable colored output")
 	analyzeCmd.Parse(args)
 
+	resolvedPath := resolveAnalyzePathArg(args, *path, analyzeCmd.Args())
+
 	outputFormat := *format
 	if *jsonOut {
 		outputFormat = "json"
 	}
 	if *watch {
-		runWatch(*path)
+		runWatch(resolvedPath)
 		return nil
 	}
 
-	runAnalyze(*path, outputFormat, *verbose, !*noColor, true)
+	runAnalyze(resolvedPath, outputFormat, *verbose, !*noColor, true)
 	return nil
+}
+
+func resolveAnalyzePathArg(rawArgs []string, pathFlag string, positional []string) string {
+	if hasExplicitPathFlag(rawArgs) {
+		return pathFlag
+	}
+
+	if len(positional) > 0 {
+		return positional[0]
+	}
+
+	return pathFlag
+}
+
+func hasExplicitPathFlag(rawArgs []string) bool {
+	for _, arg := range rawArgs {
+		if arg == "-path" || strings.HasPrefix(arg, "-path=") {
+			return true
+		}
+	}
+
+	return false
 }
 
 func handleExtractCommand(args []string) error {
@@ -321,7 +345,56 @@ func validatePath(path string) string {
 		os.Exit(1)
 	}
 
-	return absPath
+	cwd, err := filepath.Abs(".")
+	if err != nil {
+		err := HandleInvalidPathError(".", err)
+		err.Display()
+		fmt.Fprintf(os.Stderr, ColorError(fmt.Sprintf("Error: Could not resolve repository root: %v\n", err)))
+		fmt.Fprintf(os.Stderr, ColorInfo("Suggestion: Run the command from a valid repository directory\n"))
+		os.Exit(1)
+	}
+
+	canonicalCwd := cwd
+	if resolvedRoot, resolveErr := filepath.EvalSymlinks(cwd); resolveErr == nil {
+		canonicalCwd = resolvedRoot
+	}
+
+	canonicalPath := absPath
+	if resolvedPath, resolveErr := filepath.EvalSymlinks(absPath); resolveErr == nil {
+		canonicalPath = resolvedPath
+	}
+
+	if !isWithinRoot(canonicalCwd, canonicalPath) {
+		err := NewCLIError(
+			ErrorInvalidArgument,
+			fmt.Sprintf("Path escapes repository root: %s", canonicalPath),
+			"Provide a path inside the current repository",
+			nil,
+		)
+		err.Display()
+		fmt.Fprintf(os.Stderr, ColorError(fmt.Sprintf("Error: Path escapes repository root: %s\n", canonicalPath)))
+		fmt.Fprintf(os.Stderr, ColorInfo("Suggestion: Provide a path inside the current repository\n"))
+		os.Exit(1)
+	}
+
+	return canonicalPath
+}
+
+func isWithinRoot(rootPath, targetPath string) bool {
+	rel, err := filepath.Rel(rootPath, targetPath)
+	if err != nil {
+		return false
+	}
+
+	if rel == "." {
+		return true
+	}
+
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+
+	return !filepath.IsAbs(rel)
 }
 
 func extractImports(absPath string, verbose bool) map[string]*ImportMetadata {

--- a/main_analyze_path_test.go
+++ b/main_analyze_path_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveAnalyzePathArg_UsesPositionalWhenNoPathFlag(t *testing.T) {
+	resolved := resolveAnalyzePathArg([]string{"."}, ".", []string{"."})
+	if resolved != "." {
+		t.Fatalf("expected positional path, got %q", resolved)
+	}
+}
+
+func TestResolveAnalyzePathArg_UsesPathFlagWhenProvided(t *testing.T) {
+	resolved := resolveAnalyzePathArg([]string{"./a", "-path", "./b"}, "./b", []string{"./a"})
+	if resolved != "./b" {
+		t.Fatalf("expected -path to win, got %q", resolved)
+	}
+}
+
+func TestResolveAnalyzePathArg_UsesPathEqualsSyntax(t *testing.T) {
+	resolved := resolveAnalyzePathArg([]string{"./a", "-path=./b"}, "./b", []string{"./a"})
+	if resolved != "./b" {
+		t.Fatalf("expected -path= to win, got %q", resolved)
+	}
+}
+
+func TestIsWithinRoot(t *testing.T) {
+	root := t.TempDir()
+	inside := filepath.Join(root, "sub")
+	outsideBase := t.TempDir()
+	outside := filepath.Join(outsideBase, "other")
+
+	if !isWithinRoot(root, inside) {
+		t.Fatalf("expected sub path to be within root")
+	}
+
+	if isWithinRoot(root, outside) {
+		t.Fatalf("expected outside path to be rejected")
+	}
+}


### PR DESCRIPTION
## Summary
- Make `analyze [path]` and `-path` deterministic with explicit precedence (`-path` wins over positional path).
- Add canonical path validation to reject paths escaping current repository root (including symlink-resolved traversal attempts).
- Add focused unit tests for analyze path resolution and root-bound path checks.

## Quality Gate
- `go test ./...` (partial in this environment due to existing unrelated hanging test in `internal/languages`)
- `go vet ./...` (passed)
- `go test -race ./...` (not supported here: `-race requires cgo`)

## Scope Statement
- Scope dışı değişiklik yok.