### PR TITLE
RD-702: Route analyze runtime through detector + adapters

### DIFF
--- a/internal/analysis/orchestrator.go
+++ b/internal/analysis/orchestrator.go
@@ -1,0 +1,62 @@
+package analysis
+
+import (
+	"fmt"
+	"sort"
+
+	"RepoDoctor/internal/languages"
+	"RepoDoctor/internal/model"
+)
+
+// Orchestrator coordinates language detection and adapter-driven analysis steps.
+type Orchestrator struct {
+	detector languages.LanguageDetector
+}
+
+// Result contains adapter-driven analysis output.
+type Result struct {
+	AdapterName string
+	Files       []string
+	Metrics     *model.RepositoryMetrics
+	Graph       *model.DependencyGraph
+}
+
+// NewOrchestrator creates a new analysis orchestrator.
+func NewOrchestrator(detector languages.LanguageDetector) *Orchestrator {
+	return &Orchestrator{detector: detector}
+}
+
+// Analyze executes the runtime pipeline: detect adapter -> detect files -> metrics -> graph.
+func (o *Orchestrator) Analyze(repoPath string) (*Result, error) {
+	if o.detector == nil {
+		return nil, fmt.Errorf("language detector is required")
+	}
+
+	adapter, err := o.detector.DetectLanguage(repoPath)
+	if err != nil {
+		return nil, fmt.Errorf("language detection failed: %w", err)
+	}
+
+	files, err := adapter.DetectFiles(repoPath)
+	if err != nil {
+		return nil, fmt.Errorf("file detection failed for %s: %w", adapter.Name(), err)
+	}
+	sort.Strings(files)
+
+	metrics, err := adapter.CollectMetrics(files)
+	if err != nil {
+		return nil, fmt.Errorf("metrics collection failed for %s: %w", adapter.Name(), err)
+	}
+
+	graph, err := adapter.BuildDependencyGraph(files)
+	if err != nil {
+		return nil, fmt.Errorf("dependency graph build failed for %s: %w", adapter.Name(), err)
+	}
+
+	return &Result{
+		AdapterName: adapter.Name(),
+		Files:       files,
+		Metrics:     metrics,
+		Graph:       graph,
+	}, nil
+}

--- a/internal/analysis/orchestrator_test.go
+++ b/internal/analysis/orchestrator_test.go
@@ -1,0 +1,42 @@
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"RepoDoctor/internal/languages"
+)
+
+func TestOrchestrator_Analyze_SelectsAdapterAndBuildsPipeline(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "main.go"), []byte("package main\nimport \"fmt\"\nfunc main(){fmt.Println(\"ok\")}\n"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	detector := languages.NewRepositoryLanguageDetector()
+	detector.RegisterAdapter(languages.NewGoAdapter())
+	detector.RegisterAdapter(languages.NewPythonAdapter())
+
+	orchestrator := NewOrchestrator(detector)
+	result, err := orchestrator.Analyze(repo)
+	if err != nil {
+		t.Fatalf("Analyze returned error: %v", err)
+	}
+
+	if result.AdapterName != "Go" {
+		t.Fatalf("expected Go adapter, got %s", result.AdapterName)
+	}
+
+	if len(result.Files) == 0 {
+		t.Fatal("expected detected files")
+	}
+
+	if result.Metrics == nil {
+		t.Fatal("expected metrics result")
+	}
+
+	if result.Graph == nil {
+		t.Fatal("expected dependency graph result")
+	}
+}

--- a/internal/model/dependency_graph.go
+++ b/internal/model/dependency_graph.go
@@ -5,11 +5,11 @@ import "sync"
 // DependencyGraph represents a language-agnostic dependency graph
 // Nodes represent files or modules, edges represent import/dependency relationships.
 type DependencyGraph struct {
-	mu         sync.RWMutex
-	nodes      map[string]*Node
-	edges      map[string][]string // adjacency list: node -> [dependencies]
-	reverse    map[string][]string // reverse adjacency: node -> [dependents]
-	cycles     [][]string          // detected cycles
+	mu      sync.RWMutex
+	nodes   map[string]*Node
+	edges   map[string][]string // adjacency list: node -> [dependencies]
+	reverse map[string][]string // reverse adjacency: node -> [dependents]
+	cycles  [][]string          // detected cycles
 }
 
 // Node represents a node in the dependency graph
@@ -36,6 +36,11 @@ func NewDependencyGraph() *DependencyGraph {
 func (g *DependencyGraph) AddNode(id string, path, pkg string) *Node {
 	g.mu.Lock()
 	defer g.mu.Unlock()
+
+	return g.addNodeLocked(id, path, pkg)
+}
+
+func (g *DependencyGraph) addNodeLocked(id string, path, pkg string) *Node {
 
 	if existing, ok := g.nodes[id]; ok {
 		return existing
@@ -64,10 +69,10 @@ func (g *DependencyGraph) AddEdge(source, target string) {
 
 	// Ensure both nodes exist
 	if _, exists := g.nodes[source]; !exists {
-		g.AddNode(source, source, source)
+		g.addNodeLocked(source, source, source)
 	}
 	if _, exists := g.nodes[target]; !exists {
-		g.AddNode(target, target, target)
+		g.addNodeLocked(target, target, target)
 	}
 
 	// Check if edge already exists

--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"RepoDoctor/internal/analysis"
+	"RepoDoctor/internal/languages"
+	"RepoDoctor/internal/model"
 	"flag"
 	"fmt"
 	"os"
@@ -248,11 +251,23 @@ func runAnalyze(path, format string, verbose bool, colorEnabled bool, exitOnViol
 		fmt.Printf(ColorInfo("Extracting imports from: ")+"%s\n", absPath)
 	}
 
-	// Stage 2: Import extraction and dependency graph
-	imports := extractImports(absPath, verbose)
+	// Stage 2: Language adapter pipeline
+	analysisResult, err := runAdapterPipeline(absPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, ColorError(fmt.Sprintf("Error: analysis pipeline failed: %v\n", err)))
+		if exitOnViolation {
+			os.Exit(1)
+		}
+		return 1
+	}
+
+	if verbose {
+		fmt.Printf(ColorInfo("Selected adapter: ")+"%s\n", analysisResult.AdapterName)
+	}
+
 	progress.SetProgress(progress.totalSteps / 2)
 
-	graph := buildDependencyGraph(imports, verbose)
+	graph := buildDependencyGraphFromModel(analysisResult.Graph, verbose)
 	progress.SetProgress(progress.totalSteps)
 	progress.Complete()
 
@@ -405,6 +420,36 @@ func extractImports(absPath string, verbose bool) map[string]*ImportMetadata {
 		fmt.Fprintf(os.Stderr, ColorWarn(fmt.Sprintf("Warning: error extracting imports: %v\n", err)))
 	}
 	return imports
+}
+
+func runAdapterPipeline(absPath string) (*analysis.Result, error) {
+	detector := languages.NewRepositoryLanguageDetector()
+	detector.RegisterAdapter(languages.NewGoAdapter())
+	detector.RegisterAdapter(languages.NewPythonAdapter())
+
+	orchestrator := analysis.NewOrchestrator(detector)
+	return orchestrator.Analyze(absPath)
+}
+
+func buildDependencyGraphFromModel(languageGraph *model.DependencyGraph, verbose bool) Graph {
+	graph := NewDependencyGraph()
+	if languageGraph == nil {
+		return graph
+	}
+
+	for _, node := range languageGraph.GetNodes() {
+		graph.AddNode(node.ID)
+		for _, dep := range languageGraph.GetDependencies(node.ID) {
+			graph.AddEdge(node.ID, dep)
+		}
+	}
+
+	if verbose {
+		fmt.Printf(ColorInfo(fmt.Sprintf("Built dependency graph with %d nodes and %d edges\n",
+			graph.GetNodeCount(), graph.GetEdgeCount())))
+	}
+
+	return graph
 }
 
 func buildDependencyGraph(imports map[string]*ImportMetadata, verbose bool) Graph {


### PR DESCRIPTION
## Summary
- Introduce `internal/analysis` orchestrator to enforce runtime pipeline order: detect adapter -> detect files -> collect metrics -> build graph.
- Wire `runAnalyze` to the orchestrator and show selected adapter in verbose output.
- Fix `internal/model.DependencyGraph` lock recursion in `AddEdge` by using a locked helper for node creation.

## Quality Gate
- `go test ./...` (fails due to pre-existing `internal/languages` test failures unrelated to this PR)
- `go vet ./...` (passed)
- `go test -race ./...` (not supported here: `-race requires cgo`)

## Scope Statement
- Scope dışı değişiklik yok.