### PR TITLE
RD-703: Enable Python adapter in runtime analyze flow

### DIFF
--- a/internal/analysis/orchestrator_integration_test.go
+++ b/internal/analysis/orchestrator_integration_test.go
@@ -1,0 +1,43 @@
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"RepoDoctor/internal/languages"
+)
+
+func TestOrchestrator_Analyze_PythonDominantRepository(t *testing.T) {
+	repo := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(repo, "app.py"), []byte("import os\nfrom collections import defaultdict\n\n\ndef main():\n    return os.getcwd()\n"), 0644); err != nil {
+		t.Fatalf("failed to create app.py: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(repo, "util.py"), []byte("import json\n"), 0644); err != nil {
+		t.Fatalf("failed to create util.py: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(repo, "helper.go"), []byte("package helper\n"), 0644); err != nil {
+		t.Fatalf("failed to create helper.go: %v", err)
+	}
+
+	detector := languages.NewRepositoryLanguageDetector()
+	detector.RegisterAdapter(languages.NewGoAdapter())
+	detector.RegisterAdapter(languages.NewPythonAdapter())
+
+	orchestrator := NewOrchestrator(detector)
+	result, err := orchestrator.Analyze(repo)
+	if err != nil {
+		t.Fatalf("Analyze returned error: %v", err)
+	}
+
+	if result.AdapterName != "Python" {
+		t.Fatalf("expected Python adapter, got %s", result.AdapterName)
+	}
+
+	if result.Graph == nil || result.Graph.NodeCount() == 0 {
+		t.Fatal("expected non-empty dependency graph for python repository")
+	}
+}

--- a/internal/languages/python_adapter.go
+++ b/internal/languages/python_adapter.go
@@ -16,6 +16,8 @@ type PythonAdapter struct {
 	importPatterns []*regexp.Regexp
 }
 
+const maxPythonFileBytes = 2 * 1024 * 1024
+
 // pythonImportExtractor helps extract imports from Python files
 type pythonImportExtractor struct {
 	patterns []*regexp.Regexp
@@ -144,6 +146,10 @@ func (a *PythonAdapter) collectFileMetrics(path string) (*model.FileMetrics, err
 		return nil, err
 	}
 
+	if len(content) > maxPythonFileBytes {
+		return nil, fmt.Errorf("python file too large for safe parsing: %s", path)
+	}
+
 	lines := strings.Split(string(content), "\n")
 	fm := &model.FileMetrics{
 		Path:      path,
@@ -197,7 +203,7 @@ func (a *PythonAdapter) extractFunctionMetrics(line, path string, lineNum int) *
 		end := strings.Index(line, "(")
 		if end > start {
 			name = line[start:end]
-			
+
 			// Count parameters
 			paramStr := line[end+1:]
 			closeParen := strings.Index(paramStr, ")")
@@ -277,6 +283,15 @@ func (a *PythonAdapter) BuildDependencyGraph(files []string) (*model.DependencyG
 
 // extractImports extracts import statements from a Python file
 func (a *PythonAdapter) extractImports(path string) ([]string, string, error) {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if fileInfo.Size() > maxPythonFileBytes {
+		return nil, "", fmt.Errorf("python file too large for safe parsing: %s", path)
+	}
+
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, "", err
@@ -295,7 +310,7 @@ func (a *PythonAdapter) extractImports(path string) ([]string, string, error) {
 			matches := pattern.FindStringSubmatch(line)
 			if len(matches) > 1 {
 				importPath := matches[1]
-				
+
 				// Get base module
 				parts := strings.Split(importPath, ".")
 				if len(parts) > 0 {
@@ -304,13 +319,6 @@ func (a *PythonAdapter) extractImports(path string) ([]string, string, error) {
 			}
 		}
 
-		// Try to get package name from file
-		if pkgName == "" && strings.HasPrefix(strings.TrimSpace(line), "import ") {
-			parts := strings.Fields(strings.TrimSpace(line))
-			if len(parts) > 1 {
-				pkgName = parts[1]
-			}
-		}
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -328,6 +336,8 @@ func (a *PythonAdapter) extractImports(path string) ([]string, string, error) {
 
 // IsStdlibPackage checks if a module is part of Python standard library
 func (a *PythonAdapter) IsStdlibPackage(importPath string) bool {
+	baseModule := strings.Split(importPath, ".")[0]
+
 	// Common Python standard library modules
 	stdlibModules := map[string]bool{
 		"os": true, "sys": true, "re": true, "json": true,
@@ -341,9 +351,11 @@ func (a *PythonAdapter) IsStdlibPackage(importPath string) bool {
 		"asyncio": true, "threading": true, "multiprocessing": true,
 		"logging": true, "unittest": true, "pytest": false,
 		"csv": true, "configparser": true, "argparse": true,
+		"xml": true, "email": true, "subprocess": true,
+		"tempfile": true, "inspect": true,
 	}
 
-	return stdlibModules[importPath] || !strings.Contains(importPath, ".")
+	return stdlibModules[baseModule]
 }
 
 // GetPythonVersion attempts to detect Python version from the repository

--- a/internal/languages/python_adapter_test.go
+++ b/internal/languages/python_adapter_test.go
@@ -33,8 +33,8 @@ func TestPythonAdapter_DetectFiles(t *testing.T) {
 	testFiles := []string{
 		"module1.py",
 		"module2.py",
-		"test_module.py",  // Should be skipped
-		"readme.md",       // Should be skipped
+		"test_module.py", // Should be skipped
+		"readme.md",      // Should be skipped
 	}
 
 	for _, file := range testFiles {
@@ -144,8 +144,8 @@ func TestPythonAdapter_IsStdlibPackage(t *testing.T) {
 		{"sys", true},
 		{"json", true},
 		{"collections", true},
-		{"requests", false},  // Third-party
-		{"flask", false},     // Third-party
+		{"requests", false}, // Third-party
+		{"flask", false},    // Third-party
 	}
 
 	for _, test := range tests {
@@ -242,5 +242,24 @@ from collections import defaultdict
 
 	if graph.NodeCount() < 1 {
 		t.Errorf("expected at least 1 node, got %d", graph.NodeCount())
+	}
+}
+
+func TestPythonAdapter_ExtractImports_RejectsLargeFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "python-large-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	path := filepath.Join(tmpDir, "large.py")
+	large := make([]byte, maxPythonFileBytes+1)
+	if err := os.WriteFile(path, large, 0644); err != nil {
+		t.Fatalf("failed to create large file: %v", err)
+	}
+
+	adapter := NewPythonAdapter()
+	if _, _, err := adapter.extractImports(path); err == nil {
+		t.Fatal("expected extractImports to reject oversized file")
 	}
 }


### PR DESCRIPTION
## Summary
- Make Python adapter runtime path production-safe by fixing import/package detection and stdlib checks.
- Add oversized file guard for Python parsing (`maxPythonFileBytes`) as a safe fallback against heavy files.
- Add integration coverage to assert Python-dominant repositories are analyzed through Python adapter in orchestrator flow.

## Quality Gate
- `go test ./...` (passed)
- `go vet ./...` (passed)
- `go test -race ./...` (not supported here: `-race requires cgo`)

## Scope Statement
- Scope dışı değişiklik yok.