### PR TITLE
RD-704: Harden language adapter contract for OCP extension

### DIFF
--- a/internal/analysis/orchestrator.go
+++ b/internal/analysis/orchestrator.go
@@ -37,6 +37,14 @@ func (o *Orchestrator) Analyze(repoPath string) (*Result, error) {
 		return nil, fmt.Errorf("language detection failed: %w", err)
 	}
 
+	capabilities := adapter.Capabilities()
+	if !capabilities.SupportsDependencyGraph {
+		return nil, fmt.Errorf("adapter %s does not support dependency graph capability", adapter.Name())
+	}
+	if !capabilities.SupportsMetrics {
+		return nil, fmt.Errorf("adapter %s does not support metrics capability", adapter.Name())
+	}
+
 	files, err := adapter.DetectFiles(repoPath)
 	if err != nil {
 		return nil, fmt.Errorf("file detection failed for %s: %w", adapter.Name(), err)

--- a/internal/analysis/orchestrator_capability_test.go
+++ b/internal/analysis/orchestrator_capability_test.go
@@ -1,0 +1,46 @@
+package analysis
+
+import (
+	"fmt"
+	"testing"
+
+	"RepoDoctor/internal/languages"
+	"RepoDoctor/internal/model"
+)
+
+type fakeDetector struct {
+	adapter languages.LanguageAdapter
+}
+
+func (d fakeDetector) DetectLanguage(repoPath string) (languages.LanguageAdapter, error) {
+	if d.adapter == nil {
+		return nil, fmt.Errorf("no adapter")
+	}
+	return d.adapter, nil
+}
+
+func (d fakeDetector) GetSupportedLanguages() []string { return []string{"fake"} }
+
+type fakeAdapter struct {
+	caps languages.AdapterCapabilities
+}
+
+func (a fakeAdapter) Name() string                                  { return "Fake" }
+func (a fakeAdapter) FileExtensions() []string                      { return []string{".fake"} }
+func (a fakeAdapter) DetectFiles(repoPath string) ([]string, error) { return []string{}, nil }
+func (a fakeAdapter) CollectMetrics(files []string) (*model.RepositoryMetrics, error) {
+	return model.NewRepositoryMetrics(), nil
+}
+func (a fakeAdapter) BuildDependencyGraph(files []string) (*model.DependencyGraph, error) {
+	return model.NewDependencyGraph(), nil
+}
+func (a fakeAdapter) IsStdlibPackage(importPath string) bool      { return false }
+func (a fakeAdapter) Capabilities() languages.AdapterCapabilities { return a.caps }
+func (a fakeAdapter) NormalizeImport(importPath string) string    { return importPath }
+
+func TestOrchestrator_Analyze_RejectsMissingCapabilities(t *testing.T) {
+	orchestrator := NewOrchestrator(fakeDetector{adapter: fakeAdapter{caps: languages.AdapterCapabilities{}}})
+	if _, err := orchestrator.Analyze(t.TempDir()); err == nil {
+		t.Fatal("expected orchestrator to reject missing capabilities")
+	}
+}

--- a/internal/languages/adapter_contract_test.go
+++ b/internal/languages/adapter_contract_test.go
@@ -1,0 +1,29 @@
+package languages
+
+import "testing"
+
+func TestGoAdapter_CapabilitiesAndNormalizeImport(t *testing.T) {
+	adapter := NewGoAdapter()
+	caps := adapter.Capabilities()
+
+	if !caps.SupportsDependencyGraph || !caps.SupportsMetrics {
+		t.Fatal("expected Go adapter to support graph and metrics")
+	}
+
+	if got := adapter.NormalizeImport("  github.com/foo/bar "); got != "github.com/foo/bar" {
+		t.Fatalf("unexpected normalized import: %q", got)
+	}
+}
+
+func TestPythonAdapter_CapabilitiesAndNormalizeImport(t *testing.T) {
+	adapter := NewPythonAdapter()
+	caps := adapter.Capabilities()
+
+	if !caps.SupportsDependencyGraph || !caps.SupportsMetrics {
+		t.Fatal("expected Python adapter to support graph and metrics")
+	}
+
+	if got := adapter.NormalizeImport(" requests.sessions "); got != "requests" {
+		t.Fatalf("unexpected normalized import: %q", got)
+	}
+}

--- a/internal/languages/go_adapter.go
+++ b/internal/languages/go_adapter.go
@@ -215,3 +215,17 @@ func (a *GoAdapter) IsStdlibPackage(importPath string) bool {
 	// (with some exceptions for internal packages)
 	return !strings.Contains(importPath, ".")
 }
+
+// Capabilities returns Go adapter capabilities.
+func (a *GoAdapter) Capabilities() AdapterCapabilities {
+	return AdapterCapabilities{
+		SupportsDependencyGraph: true,
+		SupportsMetrics:         true,
+		UsesASTParsing:          true,
+	}
+}
+
+// NormalizeImport normalizes Go import declarations.
+func (a *GoAdapter) NormalizeImport(importPath string) string {
+	return strings.TrimSpace(importPath)
+}

--- a/internal/languages/language_adapter.go
+++ b/internal/languages/language_adapter.go
@@ -34,6 +34,20 @@ type LanguageAdapter interface {
 	// IsStdlibPackage determines if a package/module is part of the standard library
 	// This helps filter out external dependencies from internal code analysis
 	IsStdlibPackage(importPath string) bool
+
+	// Capabilities returns adapter-specific runtime capabilities.
+	// Core pipeline must branch on these capabilities instead of language name switches.
+	Capabilities() AdapterCapabilities
+
+	// NormalizeImport converts raw language import tokens into canonical dependency identifiers.
+	NormalizeImport(importPath string) string
+}
+
+// AdapterCapabilities declares optional, stable extension points for adapters.
+type AdapterCapabilities struct {
+	SupportsDependencyGraph bool
+	SupportsMetrics         bool
+	UsesASTParsing          bool
 }
 
 // LanguageDetector is responsible for detecting the primary language of a repository

--- a/internal/languages/python_adapter.go
+++ b/internal/languages/python_adapter.go
@@ -358,6 +358,24 @@ func (a *PythonAdapter) IsStdlibPackage(importPath string) bool {
 	return stdlibModules[baseModule]
 }
 
+// Capabilities returns Python adapter capabilities.
+func (a *PythonAdapter) Capabilities() AdapterCapabilities {
+	return AdapterCapabilities{
+		SupportsDependencyGraph: true,
+		SupportsMetrics:         true,
+		UsesASTParsing:          false,
+	}
+}
+
+// NormalizeImport normalizes Python import module names.
+func (a *PythonAdapter) NormalizeImport(importPath string) string {
+	trimmed := strings.TrimSpace(importPath)
+	if trimmed == "" {
+		return ""
+	}
+	return strings.Split(trimmed, ".")[0]
+}
+
 // GetPythonVersion attempts to detect Python version from the repository
 func (a *PythonAdapter) GetPythonVersion(repoPath string) (string, error) {
 	// Check for .python-version file


### PR DESCRIPTION
## Summary
- Extend `LanguageAdapter` with explicit extension points: `Capabilities()` and `NormalizeImport()`.
- Update Go/Python adapters to implement the new contract and expose stable capability metadata.
- Make orchestrator capability-driven (not language-name-driven) and add contract/capability tests.

## Quality Gate
- `go test ./...` (passed)
- `go vet ./...` (passed)
- `go test -race ./...` (not supported here: `-race requires cgo`)

## Scope Statement
- Scope dışı değişiklik yok.