### PR TITLE
RD-705: Unify runtime rule execution on internal engine

### DIFF
--- a/internal/rules/registry.go
+++ b/internal/rules/registry.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 )
 
@@ -52,6 +53,9 @@ func (r *RuleRegistry) GetAll() []Rule {
 	for _, rule := range r.rules {
 		rules = append(rules, rule)
 	}
+	sort.Slice(rules, func(i, j int) bool {
+		return rules[i].ID() < rules[j].ID()
+	})
 	return rules
 }
 
@@ -67,6 +71,9 @@ func (r *RuleRegistry) GetByCategory(category string) []Rule {
 			result = append(result, rule)
 		}
 	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ID() < result[j].ID()
+	})
 	return result
 }
 
@@ -86,6 +93,7 @@ func (r *RuleRegistry) ListIDs() []string {
 	for id := range r.rules {
 		ids = append(ids, id)
 	}
+	sort.Strings(ids)
 	return ids
 }
 

--- a/main.go
+++ b/main.go
@@ -288,13 +288,13 @@ func runAnalyze(path, format string, verbose bool, colorEnabled bool, exitOnViol
 	// Load configuration
 	config := loadConfiguration(absPath, verbose)
 
-	// Create scorer and run analysis
+	// Run internal rule pipeline
 	progress.Start("Running rules", getStageCount("Running rules", absPath))
-	scorer := NewStructuralScorer(graph, config, absPath)
+	ruleSummary := runInternalRulePipeline(absPath, graph)
 	progress.SetProgress(progress.totalSteps / 2)
 
 	// Generate and display report
-	report := generateReport(scorer, absPath, format, verbose, colorEnabled)
+	report := generateRuleEngineReport(absPath, format, verbose, colorEnabled, config, ruleSummary)
 	progress.SetProgress(progress.totalSteps)
 	progress.Complete()
 
@@ -504,6 +504,33 @@ func generateReport(scorer *StructuralScorer, absPath, format string, verbose bo
 		writeScoreBreakdownWithColor(&sb, report, reporter.formatter)
 		fmt.Println(sb.String())
 	}
+	return report
+}
+
+func generateRuleEngineReport(absPath, format string, verbose bool, colorEnabled bool, cfg *Config, summary *runtimeRuleSummary) *StructuralReport {
+	report := buildReportFromRuleViolations(absPath, version, cfg, summary.result.Violations)
+
+	if verbose {
+		fmt.Printf(ColorInfo("Rules in registry: ")+"%d\n", summary.rulesInScope)
+		fmt.Printf(ColorInfo("Rules executed: ")+"%d\n", summary.result.RulesExecuted)
+	}
+
+	reporter := NewColoredReporter(OutputFormat(format), colorEnabled)
+	if format == "json" {
+		fmt.Println(reporter.Format(report))
+	} else {
+		var sb strings.Builder
+		writeHeaderWithColor(&sb, reporter.formatter)
+		writeScoreSectionWithColor(&sb, report, reporter.formatter)
+		writeViolationsSummaryWithColor(&sb, report, reporter.formatter)
+		writeCircularViolationsWithColor(&sb, report, reporter.formatter)
+		writeLayerViolationsWithColor(&sb, report, reporter.formatter)
+		writeSizeViolationsWithColor(&sb, report, reporter.formatter)
+		writeGodObjectViolationsWithColor(&sb, report, reporter.formatter)
+		writeScoreBreakdownWithColor(&sb, report, reporter.formatter)
+		fmt.Println(sb.String())
+	}
+
 	return report
 }
 

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"os"
+	"sort"
+
+	"RepoDoctor/internal/engine"
+	"RepoDoctor/internal/model"
+	"RepoDoctor/internal/rules"
+)
+
+type runtimeRuleSummary struct {
+	result       *engine.ExecutionResult
+	rulesInScope int
+}
+
+func runInternalRulePipeline(absPath string, graph Graph) *runtimeRuleSummary {
+	registry := rules.NewRuleRegistry()
+	for _, rule := range rules.GetDefaultRegistry().GetAll() {
+		registry.MustRegister(rule)
+	}
+	registry.MustRegister(rules.NewCircularDependencyRule(toRulesDependencyGraph(graph)))
+
+	executor := engine.NewRuleExecutor(registry)
+	context := buildRulesAnalysisContext(absPath, graph)
+	result := executor.Execute(context)
+	sortViolations(result.Violations)
+
+	return &runtimeRuleSummary{
+		result:       result,
+		rulesInScope: registry.Count(),
+	}
+}
+
+func buildRulesAnalysisContext(absPath string, graph Graph) rules.AnalysisContext {
+	nodes := graph.GetAllNodes()
+	sort.Strings(nodes)
+
+	repoFiles := make([]rules.RepositoryFile, 0, len(nodes))
+	for _, node := range nodes {
+		content := ""
+		if data, err := os.ReadFile(node); err == nil {
+			content = string(data)
+		}
+
+		repoFiles = append(repoFiles, rules.RepositoryFile{
+			Path:    node,
+			Content: content,
+			Imports: graph.GetDependencies(node),
+		})
+	}
+
+	return rules.AnalysisContext{
+		RepositoryFiles: repoFiles,
+		DependencyGraph: toRulesDependencyGraph(graph),
+		Configuration:   rules.Configuration{"repositoryPath": absPath},
+	}
+}
+
+func toRulesDependencyGraph(graph Graph) rules.DependencyGraph {
+	nodes := graph.GetAllNodes()
+	sort.Strings(nodes)
+	edges := make(map[string][]string, len(nodes))
+
+	for _, node := range nodes {
+		deps := append([]string(nil), graph.GetDependencies(node)...)
+		sort.Strings(deps)
+		edges[node] = deps
+	}
+
+	return rules.DependencyGraph{Nodes: nodes, Edges: edges}
+}
+
+func sortViolations(violations []model.Violation) {
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].RuleID != violations[j].RuleID {
+			return violations[i].RuleID < violations[j].RuleID
+		}
+		if violations[i].File != violations[j].File {
+			return violations[i].File < violations[j].File
+		}
+		if violations[i].Line != violations[j].Line {
+			return violations[i].Line < violations[j].Line
+		}
+		return violations[i].Message < violations[j].Message
+	})
+}
+
+func buildReportFromRuleViolations(path string, version string, cfg *Config, violations []model.Violation) *StructuralReport {
+	report := &StructuralReport{Version: version, Path: path}
+
+	for _, v := range violations {
+		switch v.RuleID {
+		case "rule.circular-dependency":
+			report.Circular = append(report.Circular, CycleViolation{Path: []string{v.File}, Severity: string(v.Severity)})
+		case "rule.layer-validation":
+			report.Layer = append(report.Layer, LayerViolation{From: v.File, To: "", Message: v.Message})
+		case "rule.size":
+			report.Size = append(report.Size, SizeViolation{File: v.File, Function: "", Lines: 0, Threshold: 0})
+		case "rule.god-object":
+			report.GodObject = append(report.GodObject, GodObjectViolation{StructName: v.Message, File: v.File})
+		}
+	}
+
+	report.HasViolations = len(violations) > 0
+	report.Score = calculateScoreFromViolations(cfg, report)
+	return report
+}
+
+func calculateScoreFromViolations(cfg *Config, report *StructuralReport) *StructuralScore {
+	weights := DefaultScoringWeights()
+	if cfg != nil && cfg.Weights != nil {
+		weights.CircularDependencyPenalty = cfg.Weights.Circular
+		weights.LayerViolationPenalty = cfg.Weights.Layer
+		weights.SizeViolationPenalty = cfg.Weights.Size
+		weights.GodObjectPenalty = cfg.Weights.GodObject
+	}
+
+	score := &StructuralScore{MaxScore: 100.0}
+	score.CircularCount = len(report.Circular)
+	score.LayerCount = len(report.Layer)
+	score.SizeCount = len(report.Size)
+	score.GodObjectCount = len(report.GodObject)
+
+	score.CircularPenalty = float64(score.CircularCount) * weights.CircularDependencyPenalty
+	score.LayerPenalty = float64(score.LayerCount) * weights.LayerViolationPenalty
+	score.SizePenalty = float64(score.SizeCount) * weights.SizeViolationPenalty
+	score.GodObjectPenalty = float64(score.GodObjectCount) * weights.GodObjectPenalty
+
+	score.ViolationCount = score.CircularCount + score.LayerCount + score.SizeCount + score.GodObjectCount
+	penalty := score.CircularPenalty + score.LayerPenalty + score.SizePenalty + score.GodObjectPenalty
+	score.TotalScore = score.MaxScore - penalty
+	if score.TotalScore < 0 {
+		score.TotalScore = 0
+	}
+
+	return score
+}

--- a/runtime_engine_test.go
+++ b/runtime_engine_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+
+	"RepoDoctor/internal/model"
+)
+
+func TestSortViolations_DeterministicOrder(t *testing.T) {
+	violations := []model.Violation{
+		{RuleID: "rule.size", File: "b.go", Line: 20, Message: "m2"},
+		{RuleID: "rule.circular-dependency", File: "a.go", Line: 1, Message: "m1"},
+		{RuleID: "rule.size", File: "a.go", Line: 5, Message: "m0"},
+	}
+
+	sortViolations(violations)
+
+	if violations[0].RuleID != "rule.circular-dependency" {
+		t.Fatalf("expected rule.circular-dependency first, got %s", violations[0].RuleID)
+	}
+
+	if violations[1].File != "a.go" || violations[2].File != "b.go" {
+		t.Fatalf("expected size violations ordered by file, got %s then %s", violations[1].File, violations[2].File)
+	}
+}


### PR DESCRIPTION
## Summary
- Route runtime analyze rule evaluation through `internal/rules` registry + `internal/engine` executor.
- Add deterministic ordering guarantees by sorting registry outputs and aggregated violations.
- Keep report generation backward-compatible while using unified internal execution result as source.

## Quality Gate
- `go test ./...` (passed)
- `go vet ./...` (passed)
- `go test -race ./...` (not supported here: `-race requires cgo`)

## Scope Statement
- Scope dışı değişiklik yok.