### PR TITLE
RD-706: Split analyze orchestration into service layer

### DIFF
--- a/analysis_service.go
+++ b/analysis_service.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	analysispkg "RepoDoctor/internal/analysis"
+)
+
+type AnalyzeRequest struct {
+	Path            string
+	Format          string
+	Verbose         bool
+	ColorEnabled    bool
+	ExitOnViolation bool
+}
+
+type AnalysisService struct{}
+
+func NewAnalysisService() *AnalysisService {
+	return &AnalysisService{}
+}
+
+func (s *AnalysisService) Run(request AnalyzeRequest) int {
+	absPath := validatePath(request.Path)
+	InitColorFormatter(request.ColorEnabled)
+
+	progress := NewProgressReporter(!request.Verbose)
+	progress.Start("Scanning repository", getStageCount("Scanning repository", absPath))
+	if request.Verbose {
+		fmt.Printf(ColorInfo("Extracting imports from: ")+"%s\n", absPath)
+	}
+
+	analysisResult, err := runAdapterPipeline(absPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, ColorError(fmt.Sprintf("Error: analysis pipeline failed: %v\n", err)))
+		if request.ExitOnViolation {
+			os.Exit(1)
+		}
+		return 1
+	}
+
+	if request.Verbose {
+		fmt.Printf(ColorInfo("Selected adapter: ")+"%s\n", analysisResult.AdapterName)
+	}
+
+	graph := s.reportAdapterGraph(progress, analysisResult, request.Verbose)
+
+	progress.Start("Collecting metrics", getStageCount("Collecting metrics", absPath))
+	totalFiles, goFiles, totalLines := scanDirectory(absPath, false)
+	_ = totalFiles
+	_ = goFiles
+	_ = totalLines
+	progress.SetProgress(progress.totalSteps)
+	progress.Complete()
+
+	progress.Start("Building dependency graph", getStageCount("Building dependency graph", absPath))
+	progress.SetProgress(progress.totalSteps)
+	progress.Complete()
+
+	config := loadConfiguration(absPath, request.Verbose)
+
+	progress.Start("Running rules", getStageCount("Running rules", absPath))
+	ruleSummary := runInternalRulePipeline(absPath, graph)
+	progress.SetProgress(progress.totalSteps / 2)
+
+	report := generateRuleEngineReport(absPath, request.Format, request.Verbose, request.ColorEnabled, config, ruleSummary)
+	progress.SetProgress(progress.totalSteps)
+	progress.Complete()
+
+	handleTrendAnalysis(absPath, report, request.Verbose)
+
+	exitCode := determineExitCode(report)
+	if request.ExitOnViolation && exitCode != 0 {
+		os.Exit(exitCode)
+	}
+
+	return exitCode
+}
+
+func (s *AnalysisService) reportAdapterGraph(progress *ProgressReporter, result *analysispkg.Result, verbose bool) Graph {
+	progress.SetProgress(progress.totalSteps / 2)
+	graph := buildDependencyGraphFromModel(result.Graph, verbose)
+	progress.SetProgress(progress.totalSteps)
+	progress.Complete()
+	return graph
+}

--- a/main.go
+++ b/main.go
@@ -235,79 +235,14 @@ Examples:
 }
 
 func runAnalyze(path, format string, verbose bool, colorEnabled bool, exitOnViolation bool) int {
-	// Validate and resolve path
-	absPath := validatePath(path)
-
-	// Initialize color formatter
-	InitColorFormatter(colorEnabled)
-
-	// Extract imports and build dependency graph
-	// Create progress reporter (enabled when not verbose)
-	progress := NewProgressReporter(!verbose)
-
-	// Stage 1: Repository scanning
-	progress.Start("Scanning repository", getStageCount("Scanning repository", absPath))
-	if verbose {
-		fmt.Printf(ColorInfo("Extracting imports from: ")+"%s\n", absPath)
-	}
-
-	// Stage 2: Language adapter pipeline
-	analysisResult, err := runAdapterPipeline(absPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, ColorError(fmt.Sprintf("Error: analysis pipeline failed: %v\n", err)))
-		if exitOnViolation {
-			os.Exit(1)
-		}
-		return 1
-	}
-
-	if verbose {
-		fmt.Printf(ColorInfo("Selected adapter: ")+"%s\n", analysisResult.AdapterName)
-	}
-
-	progress.SetProgress(progress.totalSteps / 2)
-
-	graph := buildDependencyGraphFromModel(analysisResult.Graph, verbose)
-	progress.SetProgress(progress.totalSteps)
-	progress.Complete()
-
-	// Stage 2: Metrics collection
-	progress.Start("Collecting metrics", getStageCount("Collecting metrics", absPath))
-	totalFiles, goFiles, totalLines := scanDirectory(absPath, false)
-	_ = totalFiles
-	_ = goFiles
-	_ = totalLines
-	progress.SetProgress(progress.totalSteps)
-	progress.Complete()
-
-	// Stage 3: Dependency graph building
-	progress.Start("Building dependency graph", getStageCount("Building dependency graph", absPath))
-	progress.SetProgress(progress.totalSteps)
-	progress.Complete()
-
-	// Load configuration
-	config := loadConfiguration(absPath, verbose)
-
-	// Run internal rule pipeline
-	progress.Start("Running rules", getStageCount("Running rules", absPath))
-	ruleSummary := runInternalRulePipeline(absPath, graph)
-	progress.SetProgress(progress.totalSteps / 2)
-
-	// Generate and display report
-	report := generateRuleEngineReport(absPath, format, verbose, colorEnabled, config, ruleSummary)
-	progress.SetProgress(progress.totalSteps)
-	progress.Complete()
-
-	// Trend analysis
-	handleTrendAnalysis(absPath, report, verbose)
-
-	// Exit with appropriate code based on violations
-	exitCode := determineExitCode(report)
-	if exitOnViolation && exitCode != 0 {
-		os.Exit(exitCode)
-	}
-
-	return exitCode
+	service := NewAnalysisService()
+	return service.Run(AnalyzeRequest{
+		Path:            path,
+		Format:          format,
+		Verbose:         verbose,
+		ColorEnabled:    colorEnabled,
+		ExitOnViolation: exitOnViolation,
+	})
 }
 
 // determineExitCode returns the appropriate exit code based on report


### PR DESCRIPTION
## Summary
- Extract analyze runtime flow from `main.go` into `AnalysisService` to reduce controller responsibility.
- Keep `runAnalyze` as a thin controller entrypoint that only forwards request data.
- Preserve behavior (progress, adapter pipeline, internal engine execution, reporting, exit policy) while improving separation of concerns.

## Quality Gate
- `go test ./...` (passed)
- `go vet ./...` (passed)
- `go test -race ./...` (not supported here: `-race requires cgo`)

## Scope Statement
- Scope dışı değişiklik yok.