### PR TITLE
RD-707: Split interactive session and generator responsibilities

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -34,6 +34,11 @@ func (g *RuleTemplateGenerator) Generate(ruleName string) error {
 		return err
 	}
 
+	return g.generateTemplateFiles(sanitized)
+}
+
+func (g *RuleTemplateGenerator) generateTemplateFiles(sanitized string) error {
+
 	// Create rules directory if it doesn't exist
 	if err := os.MkdirAll(g.rulesDir, 0755); err != nil {
 		return fmt.Errorf("failed to create rules directory: %w", err)
@@ -289,7 +294,7 @@ func (g *RuleTemplateGenerator) GenerateWithTest(ruleName string) error {
 		return err
 	}
 
-	if err := g.Generate(sanitized); err != nil {
+	if err := g.generateTemplateFiles(sanitized); err != nil {
 		return err
 	}
 

--- a/interactive.go
+++ b/interactive.go
@@ -15,6 +15,7 @@ import (
 type InteractiveMode struct {
 	io               *interactiveIO
 	configController *InteractiveConfigController
+	session          *InteractiveSession
 }
 
 type interactiveIO struct {
@@ -33,6 +34,7 @@ func NewInteractiveMode() *InteractiveMode {
 	return &InteractiveMode{
 		io:               io,
 		configController: NewInteractiveConfigController(io),
+		session:          nil,
 	}
 }
 
@@ -46,25 +48,11 @@ func (i *InteractiveMode) Run() {
 	fmt.Println(strings.Repeat("═", 50))
 	fmt.Println()
 
-	for {
-		i.showMainMenu()
-
-		choice := i.io.readChoice()
-
-		switch choice {
-		case 1:
-			i.analyzeMenu()
-		case 2:
-			i.viewHistory()
-		case 3:
-			i.configController.configureRules()
-		case 4:
-			fmt.Println("\nExiting RepoDoctor Interactive Mode...")
-			return
-		default:
-			fmt.Println("\nInvalid choice. Please try again.")
-		}
+	if i.session == nil {
+		i.session = NewInteractiveSession(i)
 	}
+
+	i.session.Run()
 }
 
 // showMainMenu displays the main menu

--- a/interactive_session.go
+++ b/interactive_session.go
@@ -1,0 +1,33 @@
+package main
+
+import "fmt"
+
+type InteractiveSession struct {
+	mode *InteractiveMode
+}
+
+func NewInteractiveSession(mode *InteractiveMode) *InteractiveSession {
+	return &InteractiveSession{mode: mode}
+}
+
+func (s *InteractiveSession) Run() {
+	for {
+		s.mode.showMainMenu()
+
+		choice := s.mode.io.readChoice()
+
+		switch choice {
+		case 1:
+			s.mode.analyzeMenu()
+		case 2:
+			s.mode.viewHistory()
+		case 3:
+			s.mode.configController.configureRules()
+		case 4:
+			fmt.Println("\nExiting RepoDoctor Interactive Mode...")
+			return
+		default:
+			fmt.Println("\nInvalid choice. Please try again.")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Extract interactive main-loop responsibilities into `InteractiveSession` and keep `InteractiveMode` focused on composition.
- Further split generator workflow by introducing dedicated template-file generation orchestration helper.
- Preserve CLI behavior while reducing method concentration in interactive/generator code paths.

## Quality Gate
- `go test ./...` (passed)
- `go vet ./...` (passed)
- `go test -race ./...` (not supported here: `-race requires cgo`)

## Scope Statement
- Scope dışı değişiklik yok.