### PR TITLE
fix: build command and path validation for cross-repo analysis

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -24,13 +24,13 @@ jobs:
         run: go mod download
 
       - name: Build RepoDoctor
-        run: go build -o repodoctor
+        run: go build .
 
       - name: Run RepoDoctor analysis
-        run: ./repodoctor analyze -path . -format text || ./repodoctor analyze -path . -format text
+        run: ./RepoDoctor analyze -path . -format text || ./RepoDoctor analyze -path . -format text
 
       - name: Run RepoDoctor analysis (JSON output)
-        run: ./repodoctor analyze -path . -format json -verbose || true
+        run: ./RepoDoctor analyze -path . -format json -verbose || true
         if: always()
 
       - name: Upload analysis results

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ git clone https://github.com/AdemFurkanATA/RepoDoctor.git
 cd RepoDoctor
 
 # Build
-go build -o repodoctor
+go build .
 
 # Run analysis on any repository
-./repodoctor analyze -path /path/to/your/project
+./RepoDoctor analyze -path /path/to/your/project
 
 # Run analysis on current directory
-./repodoctor analyze -path .
+./RepoDoctor analyze -path .
 ```
 
 ### What You Get
@@ -346,10 +346,10 @@ jobs:
         run: go mod download
 
       - name: Build RepoDoctor
-        run: go build -o repodoctor
+        run: go build .
 
       - name: Run structural analysis
-        run: ./repodoctor analyze -path . -format text
+        run: ./RepoDoctor analyze -path . -format text
 ```
 
 ### Exit Codes
@@ -401,7 +401,7 @@ The score starts at 100 and decreases with each violation. A score of **100** me
 ```bash
 git clone https://github.com/AdemFurkanATA/RepoDoctor.git
 cd RepoDoctor
-go build -o repodoctor
+go build .
 ```
 
 ### Run Tests

--- a/main.go
+++ b/main.go
@@ -288,52 +288,12 @@ func validatePath(path string) string {
 		os.Exit(1)
 	}
 
-	cwd, err := filepath.Abs(".")
-	if err != nil {
-		cliErr := HandleInvalidPathError(".", err)
-		cliErr.Display()
-		os.Exit(1)
-	}
-
-	canonicalCwd := cwd
-	if resolvedRoot, resolveErr := filepath.EvalSymlinks(cwd); resolveErr == nil {
-		canonicalCwd = resolvedRoot
-	}
-
 	canonicalPath := absPath
 	if resolvedPath, resolveErr := filepath.EvalSymlinks(absPath); resolveErr == nil {
 		canonicalPath = resolvedPath
 	}
 
-	if !isWithinRoot(canonicalCwd, canonicalPath) {
-		cliErr := NewCLIError(
-			ErrorInvalidArgument,
-			fmt.Sprintf("Path escapes repository root: %s", canonicalPath),
-			"Provide a path inside the current repository",
-			nil,
-		)
-		cliErr.Display()
-		os.Exit(1)
-	}
-
 	return canonicalPath
-}
-
-func isWithinRoot(rootPath, targetPath string) bool {
-	rel, err := filepath.Rel(rootPath, targetPath)
-	if err != nil {
-		return false
-	}
-
-	if rel == "." {
-		return true
-	}
-
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return false
-	}
-
-	return !filepath.IsAbs(rel)
 }
 
 func extractImports(absPath string, verbose bool) map[string]*ImportMetadata {

--- a/main_analyze_path_test.go
+++ b/main_analyze_path_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"path/filepath"
 	"testing"
 )
 
@@ -37,20 +36,5 @@ func TestResolveAnalyzePathArg_UsesLongPathEqualsSyntax(t *testing.T) {
 	resolved := resolveAnalyzePathArg([]string{"./a", "--path=./b"}, "./b", []string{"./a"})
 	if resolved != "./b" {
 		t.Fatalf("expected --path= to win, got %q", resolved)
-	}
-}
-
-func TestIsWithinRoot(t *testing.T) {
-	root := t.TempDir()
-	inside := filepath.Join(root, "sub")
-	outsideBase := t.TempDir()
-	outside := filepath.Join(outsideBase, "other")
-
-	if !isWithinRoot(root, inside) {
-		t.Fatalf("expected sub path to be within root")
-	}
-
-	if isWithinRoot(root, outside) {
-		t.Fatalf("expected outside path to be rejected")
 	}
 }


### PR DESCRIPTION
## Summary

- Fixed `go build -o repodoctor` producing extensionless binary on Windows → changed to `go build .`
- Removed CWD restriction from `validatePath()` so users can analyze any repo path, not just subdirectories

## Verification

```
✅ go build ./...  — clean
✅ go test ./...   — all pass
✅ go vet ./...    — clean
✅ Self-analysis:  100/100
```