### PR TITLE
feat(rd-90): deepen python module/import resolution for deterministic language evidence

### DIFF
--- a/internal/languages/language_adapter.go
+++ b/internal/languages/language_adapter.go
@@ -43,6 +43,21 @@ type LanguageAdapter interface {
 	NormalizeImport(importPath string) string
 }
 
+// EvidenceSignal is a language-neutral detection signal produced by adapters.
+// Domain scoring must depend on this structure instead of parser internals.
+type EvidenceSignal struct {
+	Language    string
+	SignalType  string
+	WeightInput float64
+	SourcePath  string
+}
+
+// EvidenceProvider is an optional adapter extension for richer language detection.
+// Implementations must keep output deterministic for the same repository input.
+type EvidenceProvider interface {
+	CollectEvidence(repoPath string, files []string) ([]EvidenceSignal, []string, error)
+}
+
 // AdapterCapabilities declares optional, stable extension points for adapters.
 type AdapterCapabilities struct {
 	SupportsDependencyGraph bool

--- a/internal/languages/language_detector.go
+++ b/internal/languages/language_detector.go
@@ -5,26 +5,88 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"RepoDoctor/internal/domain"
 )
 
 // RepositoryLanguageDetector detects the primary language of a repository
-// based on file extension distribution.
+// based on deterministic extension, layout and adapter evidence.
 type RepositoryLanguageDetector struct {
 	adapters       map[string]LanguageAdapter
 	ignoreStrategy domain.IgnoreStrategy
 }
 
-// LanguageStat holds statistics about detected language files
+// LanguageStat holds statistics about detected language files.
 type LanguageStat struct {
-	Language string
-	Count    int
-	Lines    int
+	Language     string
+	Count        int
+	Lines        int
+	Score        float64
+	ProductScore float64
 }
 
-// NewRepositoryLanguageDetector creates a new language detector
+type pathRole int
+
+const (
+	roleUnknown pathRole = iota
+	roleProduct
+	roleTest
+	roleTooling
+)
+
+func roleWeight(role pathRole) float64 {
+	switch role {
+	case roleProduct:
+		return 1.0
+	case roleTest:
+		return 0.6
+	case roleTooling:
+		return 0.2
+	default:
+		return 0.8
+	}
+}
+
+func classifyPathRole(path string) pathRole {
+	normalized := strings.ToLower(filepath.ToSlash(path))
+	segments := strings.Split(normalized, "/")
+
+	for _, seg := range segments {
+		switch seg {
+		case "src", "app", "pkg":
+			return roleProduct
+		case "test", "tests":
+			return roleTest
+		case "tools", "scripts", "hack", "examples", "third_party":
+			return roleTooling
+		}
+	}
+
+	return roleUnknown
+}
+
+func markerBoost(repoPath, language string) float64 {
+	if language == "Python" {
+		pythonMarkers := []string{"pyproject.toml", "requirements.txt", "setup.py"}
+		for _, marker := range pythonMarkers {
+			if _, err := os.Stat(filepath.Join(repoPath, marker)); err == nil {
+				return 5.0
+			}
+		}
+	}
+
+	if language == "Go" {
+		if _, err := os.Stat(filepath.Join(repoPath, "go.mod")); err == nil {
+			return 5.0
+		}
+	}
+
+	return 0
+}
+
+// NewRepositoryLanguageDetector creates a new language detector.
 func NewRepositoryLanguageDetector(ignoreStrategy domain.IgnoreStrategy) *RepositoryLanguageDetector {
 	return &RepositoryLanguageDetector{
 		adapters:       make(map[string]LanguageAdapter),
@@ -32,95 +94,226 @@ func NewRepositoryLanguageDetector(ignoreStrategy domain.IgnoreStrategy) *Reposi
 	}
 }
 
-// RegisterAdapter registers a language adapter for detection
+// RegisterAdapter registers a language adapter for detection.
 func (d *RepositoryLanguageDetector) RegisterAdapter(adapter LanguageAdapter) {
 	d.adapters[adapter.Name()] = adapter
 }
 
-// DetectLanguage analyzes the repository and returns the primary language adapter
+// DetectLanguage analyzes the repository and returns the primary language adapter.
 func (d *RepositoryLanguageDetector) DetectLanguage(repoPath string) (LanguageAdapter, error) {
-	stats := make(map[string]*LanguageStat)
+	normalizedRepoPath, err := normalizeRepoRoot(repoPath)
+	if err != nil {
+		return nil, err
+	}
 
-	// WalkDir is faster than Walk because it doesn't call os.Lstat for every file/directory
-	err := filepath.WalkDir(repoPath, func(path string, dEntry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
+	stats := make(map[string]*LanguageStat)
+	matchedFiles := make(map[string][]string)
+	adapters := d.orderedAdapters()
+
+	err = filepath.WalkDir(normalizedRepoPath, func(path string, dEntry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
 
-		// Directory handling
+		normalizedPath, ok := normalizePathWithinRoot(normalizedRepoPath, path)
+		if !ok {
+			if dEntry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
 		if dEntry.IsDir() {
-			// Do not skip the root directory itself
-			if path == repoPath {
+			if normalizedPath == normalizedRepoPath {
 				return nil
 			}
-
-			// Check ignore strategy or hidden directories
 			if strings.HasPrefix(dEntry.Name(), ".") || (d.ignoreStrategy != nil && d.ignoreStrategy.ShouldIgnore(dEntry.Name())) {
 				return filepath.SkipDir
 			}
 			return nil
 		}
 
-		// Security: skip symlinks to prevent infinite loops and path traversal
 		if dEntry.Type()&fs.ModeSymlink != 0 {
 			return nil
 		}
 
-		// Skip hidden files
 		if strings.HasPrefix(dEntry.Name(), ".") {
 			return nil
 		}
 
-		// Check file extension against registered adapters
-		ext := strings.ToLower(filepath.Ext(path))
-		for _, adapter := range d.adapters {
-			for _, supportedExt := range adapter.FileExtensions() {
-				if ext == strings.ToLower(supportedExt) {
-					lang := adapter.Name()
-					if stats[lang] == nil {
-						stats[lang] = &LanguageStat{
-							Language: lang,
-							Count:    0,
-							Lines:    0,
-						}
-					}
-					stats[lang].Count++
+		ext := strings.ToLower(filepath.Ext(normalizedPath))
+		role := classifyPathRole(normalizedPath)
+		weight := roleWeight(role)
 
-					// Count lines (rough estimate)
-					lines, _ := countLines(path)
-					stats[lang].Lines += lines
-					break
+		for _, adapter := range adapters {
+			for _, supportedExt := range adapter.FileExtensions() {
+				if ext != strings.ToLower(supportedExt) {
+					continue
 				}
+
+				lang := adapter.Name()
+				if stats[lang] == nil {
+					stats[lang] = &LanguageStat{Language: lang}
+				}
+
+				stats[lang].Count++
+				stats[lang].Score += 0.35 * weight
+				matchedFiles[lang] = append(matchedFiles[lang], normalizedPath)
+
+				lines, _ := countLines(normalizedPath)
+				stats[lang].Lines += lines
+				stats[lang].Score += float64(lines) * weight
+				if role == roleProduct {
+					stats[lang].ProductScore += float64(lines) + 0.35
+				}
+				break
 			}
 		}
 
 		return nil
 	})
-
 	if err != nil {
 		return nil, fmt.Errorf("error scanning repository: %w", err)
 	}
 
-	// Find the dominant language
+	d.applyAdapterEvidence(normalizedRepoPath, adapters, matchedFiles, stats)
+
+	for lang, stat := range stats {
+		stat.Score += markerBoost(normalizedRepoPath, lang)
+	}
+
 	return d.findDominantLanguage(stats)
 }
 
-// findDominantLanguage returns the adapter for the most common language
+func (d *RepositoryLanguageDetector) orderedAdapters() []LanguageAdapter {
+	ordered := make([]LanguageAdapter, 0, len(d.adapters))
+	for _, adapter := range d.adapters {
+		ordered = append(ordered, adapter)
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].Name() < ordered[j].Name()
+	})
+	return ordered
+}
+
+func (d *RepositoryLanguageDetector) applyAdapterEvidence(repoPath string, adapters []LanguageAdapter, matchedFiles map[string][]string, stats map[string]*LanguageStat) {
+	evidence := make([]EvidenceSignal, 0)
+
+	for _, adapter := range adapters {
+		provider, ok := adapter.(EvidenceProvider)
+		if !ok {
+			continue
+		}
+
+		files := append([]string(nil), matchedFiles[adapter.Name()]...)
+		sort.Strings(files)
+		signals, _, err := provider.CollectEvidence(repoPath, files)
+		if err != nil {
+			continue
+		}
+		evidence = append(evidence, signals...)
+	}
+
+	sort.SliceStable(evidence, func(i, j int) bool {
+		if evidence[i].SourcePath != evidence[j].SourcePath {
+			return evidence[i].SourcePath < evidence[j].SourcePath
+		}
+		if evidence[i].SignalType != evidence[j].SignalType {
+			return evidence[i].SignalType < evidence[j].SignalType
+		}
+		if evidence[i].Language != evidence[j].Language {
+			return evidence[i].Language < evidence[j].Language
+		}
+		return evidence[i].WeightInput < evidence[j].WeightInput
+	})
+
+	for _, signal := range evidence {
+		if signal.Language == "" || signal.WeightInput <= 0 {
+			continue
+		}
+		if stats[signal.Language] == nil {
+			stats[signal.Language] = &LanguageStat{Language: signal.Language}
+		}
+		stats[signal.Language].Score += signal.WeightInput
+	}
+}
+
+func normalizeRepoRoot(repoPath string) (string, error) {
+	if strings.TrimSpace(repoPath) == "" {
+		return "", fmt.Errorf("repository path is required")
+	}
+	absPath, err := filepath.Abs(repoPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve repository path: %w", err)
+	}
+	cleaned := filepath.Clean(absPath)
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err == nil {
+		cleaned = filepath.Clean(resolved)
+	}
+	return cleaned, nil
+}
+
+func normalizePathWithinRoot(root, candidate string) (string, bool) {
+	cleaned := filepath.Clean(candidate)
+	abs, err := filepath.Abs(cleaned)
+	if err != nil {
+		return "", false
+	}
+	abs = filepath.Clean(abs)
+	resolved := abs
+	if eval, err := filepath.EvalSymlinks(abs); err == nil {
+		resolved = filepath.Clean(eval)
+	}
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil {
+		return "", false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return resolved, true
+}
+
+// findDominantLanguage returns the adapter for the strongest language.
 func (d *RepositoryLanguageDetector) findDominantLanguage(stats map[string]*LanguageStat) (LanguageAdapter, error) {
 	if len(stats) == 0 {
 		return nil, fmt.Errorf("no supported language files found in repository")
 	}
 
-	var dominantLang string
-	maxCount := 0
-
-	for lang, stat := range stats {
-		if stat.Count > maxCount {
-			maxCount = stat.Count
-			dominantLang = lang
-		}
+	candidates := make([]LanguageStat, 0, len(stats))
+	for _, stat := range stats {
+		candidates = append(candidates, *stat)
 	}
 
+	sort.SliceStable(candidates, func(i, j int) bool {
+		left := candidates[i]
+		right := candidates[j]
+
+		if left.ProductScore != right.ProductScore {
+			return left.ProductScore > right.ProductScore
+		}
+		if left.Score != right.Score {
+			return left.Score > right.Score
+		}
+		if left.Lines != right.Lines {
+			return left.Lines > right.Lines
+		}
+		if left.Count != right.Count {
+			return left.Count > right.Count
+		}
+
+		priority := map[string]int{"Python": 0, "Go": 1}
+		lp, lok := priority[left.Language]
+		rp, rok := priority[right.Language]
+		if lok && rok && lp != rp {
+			return lp < rp
+		}
+
+		return left.Language < right.Language
+	})
+
+	dominantLang := candidates[0].Language
 	if dominantLang == "" {
 		return nil, fmt.Errorf("could not determine dominant language")
 	}
@@ -133,16 +326,17 @@ func (d *RepositoryLanguageDetector) findDominantLanguage(stats map[string]*Lang
 	return adapter, nil
 }
 
-// GetSupportedLanguages returns a list of all supported language names
+// GetSupportedLanguages returns a list of all supported language names.
 func (d *RepositoryLanguageDetector) GetSupportedLanguages() []string {
 	languages := make([]string, 0, len(d.adapters))
 	for lang := range d.adapters {
 		languages = append(languages, lang)
 	}
+	sort.Strings(languages)
 	return languages
 }
 
-// countLines counts the number of lines in a file
+// countLines counts the number of lines in a file.
 func countLines(path string) (int, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -151,18 +345,32 @@ func countLines(path string) (int, error) {
 	return len(strings.Split(string(data), "\n")), nil
 }
 
-// GetLanguageStats returns detailed statistics about languages in the repository
+// GetLanguageStats returns detailed statistics about languages in the repository.
 func (d *RepositoryLanguageDetector) GetLanguageStats(repoPath string) ([]LanguageStat, error) {
-	stats := make(map[string]*LanguageStat)
+	normalizedRepoPath, err := normalizeRepoRoot(repoPath)
+	if err != nil {
+		return nil, err
+	}
 
-	err := filepath.WalkDir(repoPath, func(path string, dEntry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
+	stats := make(map[string]*LanguageStat)
+	matchedFiles := make(map[string][]string)
+	adapters := d.orderedAdapters()
+
+	err = filepath.WalkDir(normalizedRepoPath, func(path string, dEntry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
 
-		// Directory handling
+		normalizedPath, ok := normalizePathWithinRoot(normalizedRepoPath, path)
+		if !ok {
+			if dEntry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
 		if dEntry.IsDir() {
-			if path == repoPath {
+			if normalizedPath == normalizedRepoPath {
 				return nil
 			}
 			if strings.HasPrefix(dEntry.Name(), ".") || (d.ignoreStrategy != nil && d.ignoreStrategy.ShouldIgnore(dEntry.Name())) {
@@ -171,51 +379,62 @@ func (d *RepositoryLanguageDetector) GetLanguageStats(repoPath string) ([]Langua
 			return nil
 		}
 
-		// Security: skip symlinks
 		if dEntry.Type()&fs.ModeSymlink != 0 {
 			return nil
 		}
-
 		if strings.HasPrefix(dEntry.Name(), ".") {
 			return nil
 		}
 
-		ext := strings.ToLower(filepath.Ext(path))
-		for _, adapter := range d.adapters {
+		ext := strings.ToLower(filepath.Ext(normalizedPath))
+		role := classifyPathRole(normalizedPath)
+		weight := roleWeight(role)
+
+		for _, adapter := range adapters {
 			for _, supportedExt := range adapter.FileExtensions() {
-				if ext == strings.ToLower(supportedExt) {
-					lang := adapter.Name()
-					if stats[lang] == nil {
-						stats[lang] = &LanguageStat{
-							Language: lang,
-							Count:    0,
-							Lines:    0,
-						}
-					}
-					stats[lang].Count++
-					lines, _ := countLines(path)
-					stats[lang].Lines += lines
-					break
+				if ext != strings.ToLower(supportedExt) {
+					continue
 				}
+
+				lang := adapter.Name()
+				if stats[lang] == nil {
+					stats[lang] = &LanguageStat{Language: lang}
+				}
+
+				stats[lang].Count++
+				matchedFiles[lang] = append(matchedFiles[lang], normalizedPath)
+				lines, _ := countLines(normalizedPath)
+				stats[lang].Lines += lines
+				stats[lang].Score += 0.35*weight + float64(lines)*weight
+				if role == roleProduct {
+					stats[lang].ProductScore += float64(lines) + 0.35
+				}
+				break
 			}
 		}
 
 		return nil
 	})
-
 	if err != nil {
 		return nil, fmt.Errorf("error scanning repository: %w", err)
+	}
+
+	d.applyAdapterEvidence(normalizedRepoPath, adapters, matchedFiles, stats)
+
+	for lang, stat := range stats {
+		stat.Score += markerBoost(normalizedRepoPath, lang)
 	}
 
 	result := make([]LanguageStat, 0, len(stats))
 	for _, stat := range stats {
 		result = append(result, *stat)
 	}
+	sort.SliceStable(result, func(i, j int) bool { return result[i].Language < result[j].Language })
 
 	return result, nil
 }
 
-// IsMultiLanguageRepository checks if the repository contains multiple supported languages
+// IsMultiLanguageRepository checks if the repository contains multiple supported languages.
 func (d *RepositoryLanguageDetector) IsMultiLanguageRepository(repoPath string) (bool, []string, error) {
 	stats, err := d.GetLanguageStats(repoPath)
 	if err != nil {

--- a/internal/languages/language_detector_test.go
+++ b/internal/languages/language_detector_test.go
@@ -3,6 +3,7 @@ package languages_test
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"RepoDoctor/internal/domain"
@@ -41,37 +42,25 @@ func (d *DummyAdapter) Capabilities() languages.AdapterCapabilities {
 func (d *DummyAdapter) NormalizeImport(importPath string) string { return importPath }
 
 func TestLanguageDetector_DetectLanguage(t *testing.T) {
-	// Create a temporary directory structure
 	tempDir, err := os.MkdirTemp("", "detector_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tempDir)
 
-	// Create some normal files
-	os.WriteFile(filepath.Join(tempDir, "main.go"), []byte("package main"), 0644)
-	os.WriteFile(filepath.Join(tempDir, "utils.go"), []byte("package utils"), 0644)
+	_ = os.WriteFile(filepath.Join(tempDir, "main.go"), []byte("package main"), 0644)
+	_ = os.WriteFile(filepath.Join(tempDir, "utils.go"), []byte("package utils"), 0644)
 
-	// Create an ignored directory with many files
 	nodeModulesDir := filepath.Join(tempDir, "node_modules")
-	os.MkdirAll(nodeModulesDir, 0755)
+	_ = os.MkdirAll(nodeModulesDir, 0755)
 	for i := 0; i < 5; i++ {
-		os.WriteFile(filepath.Join(nodeModulesDir, "index"+string(rune(i+48))+".py"), []byte("print('hello')"), 0644)
+		_ = os.WriteFile(filepath.Join(nodeModulesDir, "index"+strconv.Itoa(i)+".py"), []byte("print('hello')"), 0644)
 	}
 
-	mockStrategy := &MockIgnoreStrategy{
-		ignored: map[string]bool{
-			"node_modules": true,
-		},
-	}
-
+	mockStrategy := &MockIgnoreStrategy{ignored: map[string]bool{"node_modules": true}}
 	detector := languages.NewRepositoryLanguageDetector(mockStrategy)
-
-	goAdapter := &DummyAdapter{name: "Go", exts: []string{".go"}}
-	pyAdapter := &DummyAdapter{name: "Python", exts: []string{".py"}}
-
-	detector.RegisterAdapter(goAdapter)
-	detector.RegisterAdapter(pyAdapter)
+	detector.RegisterAdapter(&DummyAdapter{name: "Go", exts: []string{".go"}})
+	detector.RegisterAdapter(&DummyAdapter{name: "Python", exts: []string{".py"}})
 
 	adapter, err := detector.DetectLanguage(tempDir)
 	if err != nil {
@@ -83,26 +72,217 @@ func TestLanguageDetector_DetectLanguage(t *testing.T) {
 	}
 }
 
+func TestLanguageDetector_DetectLanguage_DeterministicTieBreak(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "detector_tie_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	if err := os.WriteFile(filepath.Join(tempDir, "a.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("failed to write go file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "a.py"), []byte("print('x')\n"), 0o644); err != nil {
+		t.Fatalf("failed to write python file: %v", err)
+	}
+
+	strategy := domain.NewDefaultIgnoreStrategy(domain.DefaultIgnoredDirs)
+	detector := languages.NewRepositoryLanguageDetector(strategy)
+	detector.RegisterAdapter(&DummyAdapter{name: "Go", exts: []string{".go"}})
+	detector.RegisterAdapter(&DummyAdapter{name: "Python", exts: []string{".py"}})
+
+	for i := 0; i < 20; i++ {
+		adapter, detectErr := detector.DetectLanguage(tempDir)
+		if detectErr != nil {
+			t.Fatalf("detect language failed on iteration %d: %v", i, detectErr)
+		}
+		if adapter.Name() != "Python" {
+			t.Fatalf("expected deterministic tie break to pick Python, got %s on iteration %d", adapter.Name(), i)
+		}
+	}
+}
+
+func TestLanguageDetector_DetectLanguage_WeightedProductOverTooling(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "detector_weighted_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	srcDir := filepath.Join(tempDir, "src")
+	toolsDir := filepath.Join(tempDir, "tools")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("failed creating src dir: %v", err)
+	}
+	if err := os.MkdirAll(toolsDir, 0o755); err != nil {
+		t.Fatalf("failed creating tools dir: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(srcDir, "app.py"), []byte("def run():\n    return 1\n"), 0o644); err != nil {
+		t.Fatalf("failed writing src python file: %v", err)
+	}
+
+	for i := 0; i < 30; i++ {
+		name := filepath.Join(toolsDir, "tool_file_"+strconv.Itoa(i)+".go")
+		if err := os.WriteFile(name, []byte("package tools\n"), 0o644); err != nil {
+			t.Fatalf("failed writing tooling go file: %v", err)
+		}
+	}
+
+	strategy := domain.NewDefaultIgnoreStrategy(domain.DefaultIgnoredDirs)
+	detector := languages.NewRepositoryLanguageDetector(strategy)
+	detector.RegisterAdapter(&DummyAdapter{name: "Go", exts: []string{".go"}})
+	detector.RegisterAdapter(&DummyAdapter{name: "Python", exts: []string{".py"}})
+
+	adapter, detectErr := detector.DetectLanguage(tempDir)
+	if detectErr != nil {
+		t.Fatalf("detect language failed: %v", detectErr)
+	}
+
+	if adapter.Name() != "Python" {
+		t.Fatalf("expected product Python to win over tooling Go, got %s", adapter.Name())
+	}
+}
+
+func TestLanguageDetector_DetectLanguage_PythonRelativeImportsPreferred(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "detector_py_relative")
+	if err != nil {
+		t.Fatalf("failed creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	if err := os.WriteFile(filepath.Join(tempDir, "pyproject.toml"), []byte("[project]\nname='demo'\n"), 0o644); err != nil {
+		t.Fatalf("failed writing pyproject marker: %v", err)
+	}
+
+	appDir := filepath.Join(tempDir, "src", "pkg", "app")
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatalf("failed creating package dirs: %v", err)
+	}
+
+	for _, rel := range []string{"src/pkg/__init__.py", "src/pkg/app/__init__.py"} {
+		if err := os.WriteFile(filepath.Join(tempDir, rel), []byte(""), 0o644); err != nil {
+			t.Fatalf("failed writing __init__.py: %v", err)
+		}
+	}
+
+	pythonMain := "from .service import run\nfrom ..shared import util\n"
+	if err := os.WriteFile(filepath.Join(appDir, "main.py"), []byte(pythonMain), 0o644); err != nil {
+		t.Fatalf("failed writing python source: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(tempDir, "scripts.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("failed writing go script: %v", err)
+	}
+
+	strategy := domain.NewDefaultIgnoreStrategy(domain.DefaultIgnoredDirs)
+	detector := languages.NewRepositoryLanguageDetector(strategy)
+	detector.RegisterAdapter(languages.NewGoAdapter())
+	detector.RegisterAdapter(languages.NewPythonAdapter())
+
+	for i := 0; i < 10; i++ {
+		adapter, detectErr := detector.DetectLanguage(tempDir)
+		if detectErr != nil {
+			t.Fatalf("detect language failed: %v", detectErr)
+		}
+		if adapter.Name() != "Python" {
+			t.Fatalf("expected Python, got %s on iteration %d", adapter.Name(), i)
+		}
+	}
+}
+
+func TestLanguageDetector_DetectLanguage_SkipsSymlinkOutsideRoot(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "detector_symlink")
+	if err != nil {
+		t.Fatalf("failed creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	outside, err := os.MkdirTemp("", "detector_outside")
+	if err != nil {
+		t.Fatalf("failed creating outside dir: %v", err)
+	}
+	defer os.RemoveAll(outside)
+
+	if err := os.WriteFile(filepath.Join(tempDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("failed writing go file: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(outside, "danger.py"), []byte("print('x')\n"), 0o644); err != nil {
+		t.Fatalf("failed writing outside file: %v", err)
+	}
+
+	if err := os.Symlink(outside, filepath.Join(tempDir, "linked_outside")); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	strategy := domain.NewDefaultIgnoreStrategy(domain.DefaultIgnoredDirs)
+	detector := languages.NewRepositoryLanguageDetector(strategy)
+	detector.RegisterAdapter(languages.NewGoAdapter())
+	detector.RegisterAdapter(languages.NewPythonAdapter())
+
+	adapter, detectErr := detector.DetectLanguage(tempDir)
+	if detectErr != nil {
+		t.Fatalf("detect language failed: %v", detectErr)
+	}
+
+	if adapter.Name() != "Go" {
+		t.Fatalf("expected Go after skipping outside symlink, got %s", adapter.Name())
+	}
+}
+
+func TestLanguageDetector_DetectLanguage_DeterministicAcrossRuns(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "detector_deterministic")
+	if err != nil {
+		t.Fatalf("failed creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	if err := os.WriteFile(filepath.Join(tempDir, "app.py"), []byte("from .mod import run\n"), 0o644); err != nil {
+		t.Fatalf("failed writing app.py: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "mod.py"), []byte("def run():\n    return 1\n"), 0o644); err != nil {
+		t.Fatalf("failed writing mod.py: %v", err)
+	}
+
+	strategy := domain.NewDefaultIgnoreStrategy(domain.DefaultIgnoredDirs)
+	detector := languages.NewRepositoryLanguageDetector(strategy)
+	detector.RegisterAdapter(languages.NewGoAdapter())
+	detector.RegisterAdapter(languages.NewPythonAdapter())
+
+	first, err := detector.DetectLanguage(tempDir)
+	if err != nil {
+		t.Fatalf("initial detection failed: %v", err)
+	}
+
+	for i := 0; i < 100; i++ {
+		adapter, detectErr := detector.DetectLanguage(tempDir)
+		if detectErr != nil {
+			t.Fatalf("detection failed on iteration %d: %v", i, detectErr)
+		}
+		if adapter.Name() != first.Name() {
+			t.Fatalf("non-deterministic result: got %s, expected %s", adapter.Name(), first.Name())
+		}
+	}
+}
+
 func BenchmarkLanguageDetector_WalkDir(b *testing.B) {
-	// Create a mock filesystem
 	tempDir, err := os.MkdirTemp("", "benchmark_test")
 	if err != nil {
 		b.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tempDir)
 
-	// Create deep ignored directory structure
 	ignoredDir := filepath.Join(tempDir, "node_modules", "package")
-	os.MkdirAll(ignoredDir, 0755)
+	_ = os.MkdirAll(ignoredDir, 0755)
 	for i := 0; i < 1000; i++ {
-		os.WriteFile(filepath.Join(ignoredDir, "file"+string(rune(i))+".py"), []byte("pass"), 0644)
+		_ = os.WriteFile(filepath.Join(ignoredDir, "file"+strconv.Itoa(i)+".py"), []byte("pass"), 0644)
 	}
 
-	// Create some go files
 	srcDir := filepath.Join(tempDir, "src")
-	os.MkdirAll(srcDir, 0755)
+	_ = os.MkdirAll(srcDir, 0755)
 	for i := 0; i < 100; i++ {
-		os.WriteFile(filepath.Join(srcDir, "main"+string(rune(i))+".go"), []byte("package main\n\nfunc main() {}"), 0644)
+		_ = os.WriteFile(filepath.Join(srcDir, "main"+strconv.Itoa(i)+".go"), []byte("package main\n\nfunc main() {}"), 0644)
 	}
 
 	strategy := domain.NewDefaultIgnoreStrategy(domain.DefaultIgnoredDirs)

--- a/internal/languages/python_adapter.go
+++ b/internal/languages/python_adapter.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"RepoDoctor/internal/model"
@@ -17,10 +18,17 @@ type PythonAdapter struct {
 }
 
 const maxPythonFileBytes = 2 * 1024 * 1024
+const maxPythonEvidenceFiles = 5000
 
 // pythonImportExtractor helps extract imports from Python files
 type pythonImportExtractor struct {
 	patterns []*regexp.Regexp
+}
+
+type importEvidence struct {
+	modulePath string
+	relative   bool
+	level      int
 }
 
 // newPythonImportExtractor creates a new import extractor
@@ -376,6 +384,197 @@ func (a *PythonAdapter) NormalizeImport(importPath string) string {
 		return ""
 	}
 	return strings.Split(trimmed, ".")[0]
+}
+
+// CollectEvidence extracts normalized import evidence for language detection.
+func (a *PythonAdapter) CollectEvidence(repoPath string, files []string) ([]EvidenceSignal, []string, error) {
+	root, err := normalizeRepoRoot(repoPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sortedFiles := append([]string(nil), files...)
+	sort.Strings(sortedFiles)
+
+	if len(sortedFiles) > maxPythonEvidenceFiles {
+		sortedFiles = sortedFiles[:maxPythonEvidenceFiles]
+	}
+
+	signals := make([]EvidenceSignal, 0, len(sortedFiles)*2)
+	warnings := make([]string, 0)
+
+	for _, file := range sortedFiles {
+		normalizedPath, ok := normalizePathWithinRoot(root, file)
+		if !ok {
+			warnings = append(warnings, fmt.Sprintf("skipped path outside repo root: %s", file))
+			continue
+		}
+
+		info, statErr := os.Lstat(normalizedPath)
+		if statErr != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to stat python file: %s", normalizedPath))
+			continue
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			warnings = append(warnings, fmt.Sprintf("skipped symlink python file: %s", normalizedPath))
+			continue
+		}
+		if info.Size() > maxPythonFileBytes {
+			warnings = append(warnings, fmt.Sprintf("skipped oversized python file: %s", normalizedPath))
+			continue
+		}
+
+		evidence, parseErr := parsePythonImportEvidence(normalizedPath)
+		if parseErr != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to parse python imports: %s", normalizedPath))
+			continue
+		}
+
+		moduleRoot := detectPythonModuleRoot(root, normalizedPath)
+		for _, item := range evidence {
+			weight := 0.40
+			signalType := "python_import_absolute"
+			if item.relative {
+				signalType = "python_import_relative"
+				weight = 2.10
+			}
+
+			normalizedImport := normalizePythonImport(item, normalizedPath, root, moduleRoot)
+			if normalizedImport == "" {
+				continue
+			}
+
+			signals = append(signals, EvidenceSignal{
+				Language:    "Python",
+				SignalType:  signalType,
+				WeightInput: weight,
+				SourcePath:  normalizedPath,
+			})
+		}
+	}
+
+	return signals, warnings, nil
+}
+
+func parsePythonImportEvidence(path string) ([]importEvidence, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	result := make([]importEvidence, 0)
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "import ") {
+			entry := strings.TrimSpace(strings.TrimPrefix(line, "import "))
+			for _, part := range strings.Split(entry, ",") {
+				modulePath := strings.TrimSpace(strings.Split(strings.TrimSpace(part), " as ")[0])
+				if modulePath == "" {
+					continue
+				}
+				result = append(result, importEvidence{modulePath: modulePath})
+			}
+			continue
+		}
+
+		if strings.HasPrefix(line, "from ") {
+			remainder := strings.TrimSpace(strings.TrimPrefix(line, "from "))
+			parts := strings.SplitN(remainder, " import ", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			fromModule := strings.TrimSpace(parts[0])
+			level := 0
+			for level < len(fromModule) && fromModule[level] == '.' {
+				level++
+			}
+			modulePath := strings.TrimPrefix(fromModule, strings.Repeat(".", level))
+			result = append(result, importEvidence{
+				modulePath: modulePath,
+				relative:   level > 0,
+				level:      level,
+			})
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func detectPythonModuleRoot(repoRoot, filePath string) string {
+	current := filepath.Dir(filePath)
+	moduleRoot := current
+
+	for {
+		candidate := filepath.Join(current, "__init__.py")
+		if _, err := os.Stat(candidate); err != nil {
+			break
+		}
+		moduleRoot = current
+		if current == repoRoot {
+			break
+		}
+		next := filepath.Dir(current)
+		if next == current {
+			break
+		}
+		current = next
+	}
+
+	return moduleRoot
+}
+
+func normalizePythonImport(item importEvidence, filePath, repoRoot, moduleRoot string) string {
+	if !item.relative {
+		normalized := strings.TrimSpace(item.modulePath)
+		if normalized == "" {
+			return ""
+		}
+		parts := strings.Split(normalized, ".")
+		return strings.TrimSpace(parts[0])
+	}
+
+	base := filepath.Dir(filePath)
+	for i := 1; i < item.level; i++ {
+		next := filepath.Dir(base)
+		if next == base || len(next) < len(moduleRoot) {
+			break
+		}
+		base = next
+	}
+
+	rel, err := filepath.Rel(repoRoot, base)
+	if err != nil {
+		return ""
+	}
+	rel = filepath.ToSlash(rel)
+	if strings.HasPrefix(rel, "../") || rel == ".." {
+		return ""
+	}
+
+	if strings.TrimSpace(item.modulePath) != "" {
+		if rel == "." {
+			rel = item.modulePath
+		} else {
+			rel = rel + "." + item.modulePath
+		}
+	}
+
+	if rel == "." || rel == "" {
+		return ""
+	}
+	root := strings.Split(strings.ReplaceAll(rel, "/", "."), ".")[0]
+	return strings.TrimSpace(root)
 }
 
 // DetectPythonVersion attempts to detect Python version from the repository.

--- a/internal/languages/python_adapter_test.go
+++ b/internal/languages/python_adapter_test.go
@@ -3,6 +3,7 @@ package languages
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -261,5 +262,65 @@ func TestPythonAdapter_ExtractImports_RejectsLargeFile(t *testing.T) {
 	adapter := NewPythonAdapter()
 	if _, _, err := adapter.extractImports(path); err == nil {
 		t.Fatal("expected extractImports to reject oversized file")
+	}
+}
+
+func TestPythonAdapter_CollectEvidence_RelativeImports(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "pkg", "app"), 0o755); err != nil {
+		t.Fatalf("failed to create package dirs: %v", err)
+	}
+	for _, rel := range []string{"pkg/__init__.py", "pkg/app/__init__.py"} {
+		if err := os.WriteFile(filepath.Join(repo, rel), []byte(""), 0o644); err != nil {
+			t.Fatalf("failed to write __init__: %v", err)
+		}
+	}
+
+	source := filepath.Join(repo, "pkg", "app", "main.py")
+	content := "from .service import run\nfrom ..shared import helper\n"
+	if err := os.WriteFile(source, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+
+	adapter := NewPythonAdapter()
+	signals, warnings, err := adapter.CollectEvidence(repo, []string{source})
+	if err != nil {
+		t.Fatalf("CollectEvidence failed: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
+	}
+	if len(signals) < 2 {
+		t.Fatalf("expected evidence signals for relative imports, got %d", len(signals))
+	}
+
+	for _, signal := range signals {
+		if signal.Language != "Python" {
+			t.Fatalf("unexpected language evidence: %s", signal.Language)
+		}
+		if !strings.HasPrefix(signal.SignalType, "python_import_") {
+			t.Fatalf("unexpected signal type: %s", signal.SignalType)
+		}
+	}
+}
+
+func TestPythonAdapter_CollectEvidence_SkipsOutsidePath(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+	outsideFile := filepath.Join(outside, "outside.py")
+	if err := os.WriteFile(outsideFile, []byte("import os\n"), 0o644); err != nil {
+		t.Fatalf("failed writing outside file: %v", err)
+	}
+
+	adapter := NewPythonAdapter()
+	signals, warnings, err := adapter.CollectEvidence(repo, []string{outsideFile})
+	if err != nil {
+		t.Fatalf("CollectEvidence failed: %v", err)
+	}
+	if len(signals) != 0 {
+		t.Fatalf("expected zero signals for outside path, got %d", len(signals))
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected warning for outside path")
 	}
 }


### PR DESCRIPTION
## Summary
- add normalized adapter evidence contract and deterministic language ranking with stable tie-breaks
- deepen Python import evidence extraction to account for relative imports and package roots with repo-root path safety checks
- add determinism, mixed-repo, and symlink escape tests for Python-focused language detection behavior

## Scope Checklist
- [x] RD-90 only (Python module/import resolution)
- [x] Domain scoring consumes normalized evidence only
- [x] Deterministic ordering for evidence aggregation
- [x] Symlink/outside-root safety coverage

## Gates
- [x] go test ./...
- [x] go vet ./...
- [x] go run . analyze -path .