### PR TITLE
feat(rd-92): introduce config-driven monorepo-aware language detection policy

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,19 +1,28 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
 // Config represents the root configuration structure
 type Config struct {
-	Size      *SizeConfig      `yaml:"size,omitempty"`
-	GodObject *GodObjectConfig `yaml:"god_object,omitempty"`
-	Rules     *RulesConfig     `yaml:"rules,omitempty"`
-	Weights   *WeightsConfig   `yaml:"weights,omitempty"`
+	Size              *SizeConfig              `yaml:"size,omitempty"`
+	GodObject         *GodObjectConfig         `yaml:"god_object,omitempty"`
+	Rules             *RulesConfig             `yaml:"rules,omitempty"`
+	Weights           *WeightsConfig           `yaml:"weights,omitempty"`
+	LanguageDetection *LanguageDetectionConfig `yaml:"language_detection,omitempty"`
+}
+
+type LanguageDetectionConfig struct {
+	Weights        map[string]float64 `yaml:"weights,omitempty"`
+	TieBreakOrder  []string           `yaml:"tie_break_order,omitempty"`
+	SegmentWeights map[string]float64 `yaml:"segment_weights,omitempty"`
 }
 
 // SizeConfig holds size rule configuration
@@ -80,6 +89,9 @@ func (l *ConfigLoader) Load() (*Config, error) {
 
 	// Parse YAML
 	var config Config
+	if err := rejectUnknownConfigKeys(data); err != nil {
+		return nil, err
+	}
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("invalid YAML in config file: %w", err)
 	}
@@ -138,6 +150,30 @@ func (l *ConfigLoader) validate(cfg *Config) error {
 		}
 	}
 
+	if cfg.LanguageDetection != nil {
+		for lang, weight := range cfg.LanguageDetection.Weights {
+			if lang == "" {
+				return fmt.Errorf("language_detection.weights contains empty language key")
+			}
+			if weight < 0 || weight > 100 {
+				return fmt.Errorf("language_detection weight for '%s' must be between 0 and 100", lang)
+			}
+		}
+		for _, lang := range cfg.LanguageDetection.TieBreakOrder {
+			if strings.TrimSpace(lang) == "" {
+				return fmt.Errorf("language_detection.tie_break_order cannot include empty values")
+			}
+		}
+		for segment, value := range cfg.LanguageDetection.SegmentWeights {
+			if strings.TrimSpace(segment) == "" {
+				return fmt.Errorf("language_detection.segment_weights contains empty segment key")
+			}
+			if value < 0 || value > 10 {
+				return fmt.Errorf("language_detection segment weight for '%s' must be between 0 and 10", segment)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -174,6 +210,22 @@ func (l *ConfigLoader) getDefaultConfig() *Config {
 			Layer:     5.0,
 			Size:      3.0,
 			GodObject: 5.0,
+		},
+		LanguageDetection: &LanguageDetectionConfig{
+			Weights: map[string]float64{
+				"Go":         1.0,
+				"Python":     1.0,
+				"JavaScript": 1.0,
+				"TypeScript": 1.0,
+			},
+			TieBreakOrder: []string{"Python", "TypeScript", "JavaScript", "Go"},
+			SegmentWeights: map[string]float64{
+				"src":     1.0,
+				"app":     1.0,
+				"pkg":     1.0,
+				"tools":   0.2,
+				"scripts": 0.2,
+			},
 		},
 	}
 }
@@ -254,7 +306,51 @@ func (l *ConfigLoader) mergeWithDefaults(cfg *Config) *Config {
 		}
 	}
 
+	if cfg.LanguageDetection == nil {
+		cfg.LanguageDetection = defaults.LanguageDetection
+	} else {
+		if cfg.LanguageDetection.Weights == nil {
+			cfg.LanguageDetection.Weights = defaults.LanguageDetection.Weights
+		}
+		if len(cfg.LanguageDetection.TieBreakOrder) == 0 {
+			cfg.LanguageDetection.TieBreakOrder = defaults.LanguageDetection.TieBreakOrder
+		}
+		if cfg.LanguageDetection.SegmentWeights == nil {
+			cfg.LanguageDetection.SegmentWeights = defaults.LanguageDetection.SegmentWeights
+		}
+	}
+
 	return cfg
+}
+
+func rejectUnknownConfigKeys(data []byte) error {
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("invalid YAML in config file: %w", err)
+	}
+
+	allowed := map[string]bool{
+		"size": true, "god_object": true, "rules": true, "weights": true, "language_detection": true,
+	}
+	for key := range raw {
+		if !allowed[key] {
+			return fmt.Errorf("config validation error: unknown config key '%s'", key)
+		}
+	}
+
+	if ldRaw, ok := raw["language_detection"]; ok {
+		encoded, _ := json.Marshal(ldRaw)
+		var ld map[string]interface{}
+		_ = json.Unmarshal(encoded, &ld)
+		allowedLD := map[string]bool{"weights": true, "tie_break_order": true, "segment_weights": true}
+		for key := range ld {
+			if !allowedLD[key] {
+				return fmt.Errorf("config validation error: unknown language_detection key '%s'", key)
+			}
+		}
+	}
+
+	return nil
 }
 
 // GetConfigPath returns the default config path for a given directory

--- a/config_test.go
+++ b/config_test.go
@@ -186,3 +186,58 @@ rules:
 		t.Error("Expected EnableGodObjectRule to be false")
 	}
 }
+
+func TestConfigLoader_RejectsUnknownTopLevelKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := "unknown_key: true\n"
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	loader := NewConfigLoader(configPath)
+	_, err := loader.Load()
+	if err == nil {
+		t.Fatal("expected error for unknown top-level key")
+	}
+}
+
+func TestConfigLoader_RejectsUnknownLanguageDetectionKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+language_detection:
+  unknown: 1
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	loader := NewConfigLoader(configPath)
+	_, err := loader.Load()
+	if err == nil {
+		t.Fatal("expected error for unknown language_detection key")
+	}
+}
+
+func TestConfigLoader_LanguageDetectionValidation(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+language_detection:
+  weights:
+    Go: -1
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	loader := NewConfigLoader(configPath)
+	_, err := loader.Load()
+	if err == nil {
+		t.Fatal("expected validation error for negative language weight")
+	}
+}

--- a/internal/languages/language_detector.go
+++ b/internal/languages/language_detector.go
@@ -16,6 +16,13 @@ import (
 type RepositoryLanguageDetector struct {
 	adapters       map[string]LanguageAdapter
 	ignoreStrategy domain.IgnoreStrategy
+	policy         DetectionPolicy
+}
+
+type DetectionPolicy struct {
+	LanguageWeights map[string]float64
+	TieBreakOrder   []string
+	SegmentWeights  map[string]float64
 }
 
 // LanguageStat holds statistics about detected language files.
@@ -103,7 +110,54 @@ func NewRepositoryLanguageDetector(ignoreStrategy domain.IgnoreStrategy) *Reposi
 	return &RepositoryLanguageDetector{
 		adapters:       make(map[string]LanguageAdapter),
 		ignoreStrategy: ignoreStrategy,
+		policy:         defaultDetectionPolicy(),
 	}
+}
+
+func NewRepositoryLanguageDetectorWithPolicy(ignoreStrategy domain.IgnoreStrategy, policy DetectionPolicy) *RepositoryLanguageDetector {
+	merged := defaultDetectionPolicy()
+	if policy.LanguageWeights != nil {
+		merged.LanguageWeights = policy.LanguageWeights
+	}
+	if len(policy.TieBreakOrder) > 0 {
+		merged.TieBreakOrder = policy.TieBreakOrder
+	}
+	if policy.SegmentWeights != nil {
+		merged.SegmentWeights = policy.SegmentWeights
+	}
+
+	return &RepositoryLanguageDetector{
+		adapters:       make(map[string]LanguageAdapter),
+		ignoreStrategy: ignoreStrategy,
+		policy:         merged,
+	}
+}
+
+func defaultDetectionPolicy() DetectionPolicy {
+	return DetectionPolicy{
+		LanguageWeights: map[string]float64{"Go": 1, "Python": 1, "JavaScript": 1, "TypeScript": 1},
+		TieBreakOrder:   []string{"Python", "TypeScript", "JavaScript", "Go"},
+		SegmentWeights:  map[string]float64{"src": 1.0, "app": 1.0, "pkg": 1.0, "tools": 0.2, "scripts": 0.2},
+	}
+}
+
+func (d *RepositoryLanguageDetector) languageWeight(language string) float64 {
+	if weight, ok := d.policy.LanguageWeights[language]; ok && weight > 0 {
+		return weight
+	}
+	return 1.0
+}
+
+func (d *RepositoryLanguageDetector) segmentWeight(path string) float64 {
+	normalized := strings.ToLower(filepath.ToSlash(path))
+	for segment, weight := range d.policy.SegmentWeights {
+		if strings.Contains(normalized, "/"+strings.ToLower(segment)+"/") || strings.HasSuffix(normalized, "/"+strings.ToLower(segment)) {
+			if weight > 0 {
+				return weight
+			}
+		}
+	}
+	return 1.0
 }
 
 // RegisterAdapter registers a language adapter for detection.
@@ -156,6 +210,7 @@ func (d *RepositoryLanguageDetector) DetectLanguage(repoPath string) (LanguageAd
 		ext := strings.ToLower(filepath.Ext(normalizedPath))
 		role := classifyPathRole(normalizedPath)
 		weight := roleWeight(role)
+		weight *= d.segmentWeight(normalizedPath)
 
 		for _, adapter := range adapters {
 			for _, supportedExt := range adapter.FileExtensions() {
@@ -169,12 +224,12 @@ func (d *RepositoryLanguageDetector) DetectLanguage(repoPath string) (LanguageAd
 				}
 
 				stats[lang].Count++
-				stats[lang].Score += 0.35 * weight
+				stats[lang].Score += 0.35 * weight * d.languageWeight(lang)
 				matchedFiles[lang] = append(matchedFiles[lang], normalizedPath)
 
 				lines, _ := countLines(normalizedPath)
 				stats[lang].Lines += lines
-				stats[lang].Score += float64(lines) * weight
+				stats[lang].Score += float64(lines) * weight * d.languageWeight(lang)
 				if role == roleProduct {
 					stats[lang].ProductScore += float64(lines) + 0.35
 				}
@@ -315,7 +370,10 @@ func (d *RepositoryLanguageDetector) findDominantLanguage(stats map[string]*Lang
 			return left.Count > right.Count
 		}
 
-		priority := map[string]int{"Python": 0, "TypeScript": 1, "JavaScript": 2, "Go": 3}
+		priority := make(map[string]int, len(d.policy.TieBreakOrder))
+		for i, lang := range d.policy.TieBreakOrder {
+			priority[lang] = i
+		}
 		lp, lok := priority[left.Language]
 		rp, rok := priority[right.Language]
 		if lok && rok && lp != rp {
@@ -401,6 +459,7 @@ func (d *RepositoryLanguageDetector) GetLanguageStats(repoPath string) ([]Langua
 		ext := strings.ToLower(filepath.Ext(normalizedPath))
 		role := classifyPathRole(normalizedPath)
 		weight := roleWeight(role)
+		weight *= d.segmentWeight(normalizedPath)
 
 		for _, adapter := range adapters {
 			for _, supportedExt := range adapter.FileExtensions() {
@@ -417,7 +476,7 @@ func (d *RepositoryLanguageDetector) GetLanguageStats(repoPath string) ([]Langua
 				matchedFiles[lang] = append(matchedFiles[lang], normalizedPath)
 				lines, _ := countLines(normalizedPath)
 				stats[lang].Lines += lines
-				stats[lang].Score += 0.35*weight + float64(lines)*weight
+				stats[lang].Score += (0.35*weight + float64(lines)*weight) * d.languageWeight(lang)
 				if role == roleProduct {
 					stats[lang].ProductScore += float64(lines) + 0.35
 				}

--- a/internal/languages/language_detector_test.go
+++ b/internal/languages/language_detector_test.go
@@ -295,3 +295,48 @@ func BenchmarkLanguageDetector_WalkDir(b *testing.B) {
 		_, _ = detector.DetectLanguage(tempDir)
 	}
 }
+
+func TestLanguageDetector_WithPolicy_MonorepoSegmentAware(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "detector_monorepo")
+	if err != nil {
+		t.Fatalf("failed creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	if err := os.MkdirAll(filepath.Join(tempDir, "apps", "frontend"), 0o755); err != nil {
+		t.Fatalf("failed creating frontend dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tempDir, "tools"), 0o755); err != nil {
+		t.Fatalf("failed creating tools dir: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(tempDir, "apps", "frontend", "main.ts"), []byte("export const app = 1\n"), 0o644); err != nil {
+		t.Fatalf("failed writing ts file: %v", err)
+	}
+	for i := 0; i < 20; i++ {
+		if err := os.WriteFile(filepath.Join(tempDir, "tools", "tool_"+strconv.Itoa(i)+".go"), []byte("package tools\n"), 0o644); err != nil {
+			t.Fatalf("failed writing tooling go file: %v", err)
+		}
+	}
+
+	policy := languages.DetectionPolicy{
+		LanguageWeights: map[string]float64{"Go": 0.5, "TypeScript": 3.0, "JavaScript": 1.0, "Python": 1.0},
+		TieBreakOrder:   []string{"TypeScript", "Python", "JavaScript", "Go"},
+		SegmentWeights:  map[string]float64{"tools": 0.1, "apps": 1.2},
+	}
+
+	strategy := domain.NewDefaultIgnoreStrategy(domain.DefaultIgnoredDirs)
+	detector := languages.NewRepositoryLanguageDetectorWithPolicy(strategy, policy)
+	detector.RegisterAdapter(languages.NewGoAdapter())
+	detector.RegisterAdapter(languages.NewTypeScriptAdapter())
+	detector.RegisterAdapter(languages.NewJavaScriptAdapter())
+	detector.RegisterAdapter(languages.NewPythonAdapter())
+
+	adapter, detectErr := detector.DetectLanguage(tempDir)
+	if detectErr != nil {
+		t.Fatalf("detect language failed: %v", detectErr)
+	}
+	if adapter.Name() != "TypeScript" {
+		t.Fatalf("expected TypeScript with configured monorepo policy, got %s", adapter.Name())
+	}
+}

--- a/main.go
+++ b/main.go
@@ -309,7 +309,14 @@ func extractImports(absPath string, verbose bool) map[string]*ImportMetadata {
 
 func runAdapterPipeline(absPath string) (*analysis.Result, error) {
 	ignoreStrategy := domain.NewDefaultIgnoreStrategy(domain.DefaultIgnoredDirs)
-	detector := languages.NewRepositoryLanguageDetector(ignoreStrategy)
+	config := loadConfiguration(absPath, false)
+	policy := languages.DetectionPolicy{}
+	if config != nil && config.LanguageDetection != nil {
+		policy.LanguageWeights = config.LanguageDetection.Weights
+		policy.TieBreakOrder = config.LanguageDetection.TieBreakOrder
+		policy.SegmentWeights = config.LanguageDetection.SegmentWeights
+	}
+	detector := languages.NewRepositoryLanguageDetectorWithPolicy(ignoreStrategy, policy)
 	detector.RegisterAdapter(languages.NewGoAdapter())
 	detector.RegisterAdapter(languages.NewPythonAdapter())
 	detector.RegisterAdapter(languages.NewJavaScriptAdapter())


### PR DESCRIPTION
## Summary
- add config-driven language detection policy inputs (language weights, tie-break order, segment weights)
- enforce fail-closed config validation for unknown keys and hostile language-detection payloads
- wire policy into detector construction and add monorepo-aware deterministic detection tests

## Scope Checklist
- [x] RD-92 only (config + monorepo policy)
- [x] Config validation errors are explicit and actionable
- [x] Deterministic comparator remains total-order stable
- [x] Defaults remain backward compatible for existing flow

## Gates
- [x] go test ./...
- [x] go vet ./...
- [x] go run . analyze -path .