### PR TITLE
refactor(rd-93): evolve rule engine contracts for multi-language-aware analysis

### DIFF
--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -3,6 +3,8 @@ package engine
 import (
 	"RepoDoctor/internal/model"
 	"RepoDoctor/internal/rules"
+	"sort"
+	"time"
 )
 
 // RuleExecutor is responsible for executing all registered rules.
@@ -24,16 +26,23 @@ type ExecutionResult struct {
 	Violations []model.Violation
 	// RulesExecuted is the number of rules that were executed
 	RulesExecuted int
+	TimedOut      bool
 }
+
+const defaultExecutionBudget = 2 * time.Second
 
 // Execute runs all registered rules against the provided analysis context.
 // Rules are executed sequentially to maintain deterministic output.
 // Returns aggregated violations from all rules.
 func (e *RuleExecutor) Execute(context rules.AnalysisContext) *ExecutionResult {
-	allRules := e.registry.GetAll()
+	allRules := e.selectEligibleRules(context)
 	allViolations := make([]model.Violation, 0)
+	start := time.Now()
 
 	for _, rule := range allRules {
+		if time.Since(start) > defaultExecutionBudget {
+			return &ExecutionResult{Violations: allViolations, RulesExecuted: len(allRules), TimedOut: true}
+		}
 		violations := e.executeRule(rule, context)
 		allViolations = append(allViolations, violations...)
 	}
@@ -41,7 +50,43 @@ func (e *RuleExecutor) Execute(context rules.AnalysisContext) *ExecutionResult {
 	return &ExecutionResult{
 		Violations:    allViolations,
 		RulesExecuted: len(allRules),
+		TimedOut:      false,
 	}
+}
+
+func (e *RuleExecutor) selectEligibleRules(context rules.AnalysisContext) []rules.Rule {
+	allRules := e.registry.GetAll()
+	if len(context.Languages) == 0 {
+		return allRules
+	}
+
+	langSet := make(map[string]struct{}, len(context.Languages))
+	for _, lang := range context.Languages {
+		langSet[lang] = struct{}{}
+	}
+
+	eligible := make([]rules.Rule, 0, len(allRules))
+	for _, rule := range allRules {
+		aware, ok := rule.(rules.LanguageAwareRule)
+		if !ok {
+			eligible = append(eligible, rule)
+			continue
+		}
+		caps := aware.Capabilities()
+		if caps.SupportsMultipleLanguages {
+			eligible = append(eligible, rule)
+			continue
+		}
+		for _, supported := range caps.SupportedLanguages {
+			if _, found := langSet[supported]; found {
+				eligible = append(eligible, rule)
+				break
+			}
+		}
+	}
+
+	sort.SliceStable(eligible, func(i, j int) bool { return eligible[i].ID() < eligible[j].ID() })
+	return eligible
 }
 
 // ExecuteByCategory runs only rules belonging to a specific category

--- a/internal/engine/executor_language_test.go
+++ b/internal/engine/executor_language_test.go
@@ -1,0 +1,48 @@
+package engine
+
+import (
+	"testing"
+
+	"RepoDoctor/internal/model"
+	"RepoDoctor/internal/rules"
+)
+
+type stubRule struct {
+	id   string
+	caps rules.RuleCapabilities
+	hits *int
+}
+
+func (r *stubRule) ID() string                           { return r.id }
+func (r *stubRule) Category() string                     { return "testing" }
+func (r *stubRule) Severity() string                     { return "info" }
+func (r *stubRule) Capabilities() rules.RuleCapabilities { return r.caps }
+func (r *stubRule) Evaluate(context rules.AnalysisContext) []model.Violation {
+	*r.hits = *r.hits + 1
+	return nil
+}
+
+func TestRuleExecutor_SelectEligibleRules_ByLanguageContext(t *testing.T) {
+	registry := rules.NewRuleRegistry()
+
+	goHits := 0
+	pyHits := 0
+	sharedHits := 0
+
+	registry.MustRegister(&stubRule{id: "rule.go-only", caps: rules.RuleCapabilities{SupportedLanguages: []string{"Go"}}, hits: &goHits})
+	registry.MustRegister(&stubRule{id: "rule.py-only", caps: rules.RuleCapabilities{SupportedLanguages: []string{"Python"}}, hits: &pyHits})
+	registry.MustRegister(&stubRule{id: "rule.shared", caps: rules.RuleCapabilities{SupportsMultipleLanguages: true}, hits: &sharedHits})
+
+	executor := NewRuleExecutor(registry)
+	executor.Execute(rules.AnalysisContext{Languages: []string{"Go", "TypeScript"}})
+
+	if goHits != 1 {
+		t.Fatalf("expected go rule to execute once, got %d", goHits)
+	}
+	if pyHits != 0 {
+		t.Fatalf("expected python rule to be skipped, got %d", pyHits)
+	}
+	if sharedHits != 1 {
+		t.Fatalf("expected shared rule to execute once, got %d", sharedHits)
+	}
+}

--- a/internal/rules/circular_dependency_rule.go
+++ b/internal/rules/circular_dependency_rule.go
@@ -31,6 +31,10 @@ func (r *CircularDependencyRule) Severity() string {
 	return string(model.SeverityCritical)
 }
 
+func (r *CircularDependencyRule) Capabilities() RuleCapabilities {
+	return RuleCapabilities{SupportedLanguages: []string{"Go", "Python", "JavaScript", "TypeScript"}, SupportsMultipleLanguages: true}
+}
+
 // Evaluate executes the rule logic against the provided context
 func (r *CircularDependencyRule) Evaluate(context AnalysisContext) []model.Violation {
 	var violations []model.Violation

--- a/internal/rules/god_object_rule.go
+++ b/internal/rules/god_object_rule.go
@@ -43,6 +43,10 @@ func (r *GodObjectRule) Severity() string {
 	return string(model.SeverityWarning)
 }
 
+func (r *GodObjectRule) Capabilities() RuleCapabilities {
+	return RuleCapabilities{SupportedLanguages: []string{"Go"}, SupportsMultipleLanguages: false}
+}
+
 // Evaluate executes the rule logic against the provided context
 func (r *GodObjectRule) Evaluate(context AnalysisContext) []model.Violation {
 	var violations []model.Violation

--- a/internal/rules/layer_validation_rule.go
+++ b/internal/rules/layer_validation_rule.go
@@ -41,6 +41,10 @@ func (r *LayerValidationRule) Severity() string {
 	return string(model.SeverityError)
 }
 
+func (r *LayerValidationRule) Capabilities() RuleCapabilities {
+	return RuleCapabilities{SupportedLanguages: []string{"Go", "Python", "JavaScript", "TypeScript"}, SupportsMultipleLanguages: true}
+}
+
 // Evaluate executes the rule logic against the provided context
 func (r *LayerValidationRule) Evaluate(context AnalysisContext) []model.Violation {
 	var violations []model.Violation

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -14,6 +14,20 @@ type AnalysisContext struct {
 	DependencyGraph DependencyGraph
 	// Configuration contains rule configuration settings
 	Configuration Configuration
+	// Languages contains detected language context for multi-language-aware rule dispatch.
+	Languages []string
+}
+
+type RuleCapabilities struct {
+	SupportedLanguages        []string
+	SupportsMultipleLanguages bool
+}
+
+// LanguageAwareRule is an optional extension for rules that participate in
+// language-targeted dispatch while keeping core engine language-agnostic.
+type LanguageAwareRule interface {
+	Rule
+	Capabilities() RuleCapabilities
 }
 
 // RepositoryFile represents a Go file in the repository

--- a/internal/rules/size_rule.go
+++ b/internal/rules/size_rule.go
@@ -41,6 +41,10 @@ func (r *SizeRule) Severity() string {
 	return string(model.SeverityWarning)
 }
 
+func (r *SizeRule) Capabilities() RuleCapabilities {
+	return RuleCapabilities{SupportedLanguages: []string{"Go"}, SupportsMultipleLanguages: false}
+}
+
 // Evaluate executes the rule logic against the provided context
 func (r *SizeRule) Evaluate(context AnalysisContext) []model.Violation {
 	var violations []model.Violation

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -56,6 +56,7 @@ func buildRulesAnalysisContext(absPath string, graph Graph) rules.AnalysisContex
 		RepositoryFiles: repoFiles,
 		DependencyGraph: toRulesDependencyGraph(graph),
 		Configuration:   rules.Configuration{"repositoryPath": absPath},
+		Languages:       []string{"Go", "Python", "JavaScript", "TypeScript"},
 	}
 }
 


### PR DESCRIPTION
## Summary
- introduce language-aware rule capability contracts while preserving existing Rule interface compatibility
- update rule executor with deterministic language-context eligibility filtering and bounded execution budget guard
- add contract test coverage for language-targeted dispatch and keep runtime pipeline language context explicit

## Scope Checklist
- [x] RD-93 only (rule engine contract evolution)
- [x] Legacy rules remain compatible through optional capability interface
- [x] Stable deterministic rule selection/ordering retained
- [x] No runtime plugin loading introduced

## Gates
- [x] go test ./...
- [x] go vet ./...
- [x] go run . analyze -path .