### PR TITLE
feat(rd-94): expand machine-readable reporting for ci and automation

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func executeCommand(cmd string, args []string) error {
 func handleAnalyzeCommand(args []string) error {
 	analyzeCmd := flag.NewFlagSet("analyze", flag.ExitOnError)
 	path := analyzeCmd.String("path", ".", "Path to analyze")
-	format := analyzeCmd.String("format", "text", "Output format (text, json)")
+	format := analyzeCmd.String("format", "text", "Output format (text, json, json-v1)")
 	verbose := analyzeCmd.Bool("verbose", false, "Enable verbose output")
 	jsonOut := analyzeCmd.Bool("json", false, "Output in JSON format")
 	watch := analyzeCmd.Bool("watch", false, "Enable watch mode for continuous analysis")
@@ -207,7 +207,7 @@ Commands:
 Arguments:
   analyze [options]
     -path      Directory path to analyze (default: current directory)
-    -format    Output format: text, json (default: text)
+    -format    Output format: text, json, json-v1 (default: text)
     -verbose   Enable verbose output
     -watch     Enable watch mode for continuous analysis
     -no-color  Disable colored output (default: enabled)
@@ -219,7 +219,7 @@ Arguments:
 
   report [options]
     -path      Path to JSON report file (default: repodoctor-report.json)
-    -format    Output format: text, json (default: text)
+    -format    Output format: text, json, json-v1 (default: text)
 
   history [options]
     -path      Path to repository (default: current directory)

--- a/reporter.go
+++ b/reporter.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -9,8 +13,9 @@ import (
 type OutputFormat string
 
 const (
-	FormatText OutputFormat = "text"
-	FormatJSON OutputFormat = "json"
+	FormatText   OutputFormat = "text"
+	FormatJSON   OutputFormat = "json"
+	FormatJSONV1 OutputFormat = "json-v1"
 )
 
 // ColoredReporter extends Reporter with colored output support
@@ -31,12 +36,28 @@ func NewColoredReporter(format OutputFormat, colorEnabled bool) *ColoredReporter
 type StructuralReport struct {
 	Version       string
 	Path          string
+	SchemaVersion string
 	Score         *StructuralScore
 	Circular      []CycleViolation
 	Layer         []LayerViolation
 	Size          []SizeViolation
 	GodObject     []GodObjectViolation
+	Summary       ReportSummary
+	Language      LanguageEvidenceSummary
 	HasViolations bool
+}
+
+type ReportSummary struct {
+	TotalViolations int `json:"totalViolations"`
+	Circular        int `json:"circular"`
+	Layer           int `json:"layer"`
+	Size            int `json:"size"`
+	GodObject       int `json:"godObject"`
+}
+
+type LanguageEvidenceSummary struct {
+	DetectedLanguage string  `json:"detectedLanguage"`
+	Confidence       float64 `json:"confidence"`
 }
 
 // Reporter handles formatting and displaying structural analysis results
@@ -58,11 +79,20 @@ func (r *Reporter) GenerateReport(scorer *StructuralScorer, path, version string
 	return &StructuralReport{
 		Version:       version,
 		Path:          path,
+		SchemaVersion: "v2",
 		Score:         scorer.CalculateScore(),
 		Circular:      violations.Circular,
 		Layer:         violations.Layer,
 		Size:          violations.Size,
 		GodObject:     violations.GodObject,
+		Summary: ReportSummary{
+			TotalViolations: len(violations.Circular) + len(violations.Layer) + len(violations.Size) + len(violations.GodObject),
+			Circular:        len(violations.Circular),
+			Layer:           len(violations.Layer),
+			Size:            len(violations.Size),
+			GodObject:       len(violations.GodObject),
+		},
+		Language:      LanguageEvidenceSummary{DetectedLanguage: "unknown", Confidence: 0.0},
 		HasViolations: len(violations.Circular) > 0 || len(violations.Layer) > 0 || len(violations.Size) > 0 || len(violations.GodObject) > 0,
 	}
 }
@@ -72,6 +102,8 @@ func (r *Reporter) Format(report *StructuralReport) string {
 	switch r.format {
 	case FormatJSON:
 		return r.formatJSON(report)
+	case FormatJSONV1:
+		return r.formatJSONV1(report)
 	default:
 		return r.formatText(report)
 	}
@@ -114,22 +146,118 @@ func formatCyclePath(path []string) string {
 
 // formatJSON formats the report as JSON
 func (r *Reporter) formatJSON(report *StructuralReport) string {
+	relPath := normalizeReportPath(report.Path)
+	payload := map[string]interface{}{
+		"version":       report.Version,
+		"schemaVersion": report.SchemaVersion,
+		"path":          relPath,
+		"score": map[string]interface{}{
+			"total":            report.Score.TotalScore,
+			"max":              report.Score.MaxScore,
+			"circularPenalty":  report.Score.CircularPenalty,
+			"layerPenalty":     report.Score.LayerPenalty,
+			"sizePenalty":      report.Score.SizePenalty,
+			"godObjectPenalty": report.Score.GodObjectPenalty,
+		},
+		"summary": map[string]interface{}{
+			"totalViolations": report.Summary.TotalViolations,
+			"circular":        report.Summary.Circular,
+			"layer":           report.Summary.Layer,
+			"size":            report.Summary.Size,
+			"godObject":       report.Summary.GodObject,
+		},
+		"language": map[string]interface{}{
+			"detectedLanguage": report.Language.DetectedLanguage,
+			"confidence":       report.Language.Confidence,
+		},
+		"circularViolations":  sortedCircular(report.Circular),
+		"layerViolations":     sortedLayer(report.Layer),
+		"sizeViolations":      sortedSize(report.Size),
+		"godObjectViolations": sortedGodObject(report.GodObject),
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return "{}\n"
+	}
+	return string(data) + "\n"
+}
+
+func (r *Reporter) formatJSONV1(report *StructuralReport) string {
 	var sb strings.Builder
 
 	sb.WriteString("{\n")
 	sb.WriteString(fmt.Sprintf("  \"version\": \"%s\",\n", report.Version))
 	sb.WriteString(fmt.Sprintf("  \"path\": \"%s\",\n", report.Path))
-	
+
 	r.formatScoreSection(&sb, report)
 	r.formatViolationsSection(&sb, report)
 	r.formatCircularViolations(&sb, report)
 	r.formatLayerViolations(&sb, report)
 	r.formatSizeViolations(&sb, report)
 	r.formatGodObjectViolations(&sb, report)
-	
+
 	sb.WriteString("}\n")
 
 	return sb.String()
+}
+
+func normalizeReportPath(path string) string {
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	if wd, err := os.Getwd(); err == nil {
+		if rel, relErr := filepath.Rel(wd, cleaned); relErr == nil && !strings.HasPrefix(rel, "..") {
+			return filepath.ToSlash(rel)
+		}
+	}
+	return cleaned
+}
+
+func sortedCircular(in []CycleViolation) []CycleViolation {
+	result := append([]CycleViolation(nil), in...)
+	sort.SliceStable(result, func(i, j int) bool {
+		left := strings.Join(result[i].Path, "/")
+		right := strings.Join(result[j].Path, "/")
+		return left < right
+	})
+	return result
+}
+
+func sortedLayer(in []LayerViolation) []LayerViolation {
+	result := append([]LayerViolation(nil), in...)
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].From != result[j].From {
+			return result[i].From < result[j].From
+		}
+		if result[i].To != result[j].To {
+			return result[i].To < result[j].To
+		}
+		return result[i].Message < result[j].Message
+	})
+	return result
+}
+
+func sortedSize(in []SizeViolation) []SizeViolation {
+	result := append([]SizeViolation(nil), in...)
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].File != result[j].File {
+			return result[i].File < result[j].File
+		}
+		if result[i].Function != result[j].Function {
+			return result[i].Function < result[j].Function
+		}
+		return result[i].Lines < result[j].Lines
+	})
+	return result
+}
+
+func sortedGodObject(in []GodObjectViolation) []GodObjectViolation {
+	result := append([]GodObjectViolation(nil), in...)
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].File != result[j].File {
+			return result[i].File < result[j].File
+		}
+		return result[i].StructName < result[j].StructName
+	})
+	return result
 }
 
 // formatScoreSection formats the score section of JSON output

--- a/reporter_json_test.go
+++ b/reporter_json_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReporter_JSONV2_ContainsSchemaAndSummary(t *testing.T) {
+	reporter := NewReporter(FormatJSON)
+	report := &StructuralReport{
+		Version:       "0.5.0-dev",
+		SchemaVersion: "v2",
+		Path:          "/repo/demo",
+		Score: &StructuralScore{
+			TotalScore: 95, MaxScore: 100,
+		},
+		Summary:  ReportSummary{TotalViolations: 1, Circular: 0, Layer: 0, Size: 1, GodObject: 0},
+		Language: LanguageEvidenceSummary{DetectedLanguage: "Go", Confidence: 0.99},
+	}
+
+	jsonOut := reporter.Format(report)
+	if !strings.Contains(jsonOut, "\"schemaVersion\": \"v2\"") {
+		t.Fatalf("expected v2 schema marker in output: %s", jsonOut)
+	}
+	if !strings.Contains(jsonOut, "\"summary\"") {
+		t.Fatalf("expected summary section in output: %s", jsonOut)
+	}
+	if !strings.Contains(jsonOut, "\"language\"") {
+		t.Fatalf("expected language section in output: %s", jsonOut)
+	}
+}
+
+func TestReporter_JSONV1_CompatibilitySwitch(t *testing.T) {
+	reporter := NewReporter(FormatJSONV1)
+	report := &StructuralReport{
+		Version: "0.5.0-dev",
+		Path:    "/repo/demo",
+		Score:   &StructuralScore{TotalScore: 90, MaxScore: 100},
+	}
+
+	jsonOut := reporter.Format(report)
+	if strings.Contains(jsonOut, "schemaVersion") {
+		t.Fatalf("v1 output must not include schemaVersion: %s", jsonOut)
+	}
+	if strings.Contains(jsonOut, "\"summary\"") {
+		t.Fatalf("v1 output must not include summary section: %s", jsonOut)
+	}
+}


### PR DESCRIPTION
## Summary
- introduce versioned JSON v2 reporting schema with summary and language evidence sections
- switch JSON serialization to standard encoder for safe escaping and deterministic section ordering
- add explicit json-v1 compatibility mode and contract tests for v1/v2 output separation

## Scope Checklist
- [x] RD-94 only (machine-readable reporting v2)
- [x] Versioned schema marker included
- [x] Deterministic ordering of report arrays
- [x] Backward compatibility switch for legacy consumers

## Gates
- [x] go test ./...
- [x] go vet ./...
- [x] go run . analyze -path .