### PR TITLE
test(rules): add deterministic registry and execution invariant coverage

### DIFF
--- a/internal/engine/executor_language_test.go
+++ b/internal/engine/executor_language_test.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"RepoDoctor/internal/model"
@@ -12,6 +14,90 @@ type stubRule struct {
 	caps rules.RuleCapabilities
 	hits *int
 }
+
+func TestRuleExecutor_ExecuteByCategory_DeterministicAndFiltered(t *testing.T) {
+	registry := rules.NewRuleRegistry()
+
+	firstHits := 0
+	secondHits := 0
+	otherHits := 0
+
+	registry.MustRegister(&stubRule{id: "rule.cat.2", caps: rules.RuleCapabilities{}, hits: &secondHits})
+	registry.MustRegister(&stubRule{id: "rule.cat.1", caps: rules.RuleCapabilities{}, hits: &firstHits})
+	registry.MustRegister(&executorCategorizedRule{stubRule: stubRule{id: "rule.other", caps: rules.RuleCapabilities{}, hits: &otherHits}, category: "other"})
+
+	// Replace category for first two rules with testing category via wrappers.
+	registry = rules.NewRuleRegistry()
+	registry.MustRegister(&executorCategorizedRule{stubRule: stubRule{id: "rule.cat.2", caps: rules.RuleCapabilities{}, hits: &secondHits}, category: "testing"})
+	registry.MustRegister(&executorCategorizedRule{stubRule: stubRule{id: "rule.cat.1", caps: rules.RuleCapabilities{}, hits: &firstHits}, category: "testing"})
+	registry.MustRegister(&executorCategorizedRule{stubRule: stubRule{id: "rule.other", caps: rules.RuleCapabilities{}, hits: &otherHits}, category: "other"})
+
+	executor := NewRuleExecutor(registry)
+	result := executor.ExecuteByCategory(rules.AnalysisContext{}, "testing")
+
+	if result.RulesExecuted != 2 {
+		t.Fatalf("expected 2 testing rules executed, got %d", result.RulesExecuted)
+	}
+	if firstHits != 1 || secondHits != 1 {
+		t.Fatalf("expected both testing rules to execute once, got first=%d second=%d", firstHits, secondHits)
+	}
+	if otherHits != 0 {
+		t.Fatalf("expected non-matching category to be skipped, got %d", otherHits)
+	}
+}
+
+func TestRuleExecutor_ExecuteByIDs_CountInvariant(t *testing.T) {
+	registry := rules.NewRuleRegistry()
+	hitA := 0
+	hitB := 0
+
+	registry.MustRegister(&stubRule{id: "rule.a", caps: rules.RuleCapabilities{}, hits: &hitA})
+	registry.MustRegister(&stubRule{id: "rule.b", caps: rules.RuleCapabilities{}, hits: &hitB})
+
+	executor := NewRuleExecutor(registry)
+	result := executor.ExecuteByIDs(rules.AnalysisContext{}, []string{"rule.a", "rule.missing", "rule.b"})
+
+	if result.RulesExecuted != 2 {
+		t.Fatalf("expected 2 executed rules, got %d", result.RulesExecuted)
+	}
+	if hitA != 1 || hitB != 1 {
+		t.Fatalf("expected both existing IDs to execute once, got a=%d b=%d", hitA, hitB)
+	}
+}
+
+func TestRuleExecutor_ConcurrentExecute_NoRaceOnSharedRegistry(t *testing.T) {
+	registry := rules.NewRuleRegistry()
+	const ruleCount = 20
+	const workers = 16
+
+	hits := make([]int, ruleCount)
+	for i := 0; i < ruleCount; i++ {
+		registry.MustRegister(&stubRule{id: fmt.Sprintf("rule.concurrent.%03d", i), caps: rules.RuleCapabilities{SupportsMultipleLanguages: true}, hits: &hits[i]})
+	}
+
+	executor := NewRuleExecutor(registry)
+	ctx := rules.AnalysisContext{Languages: []string{"Go", "Python", "TypeScript"}}
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			res := executor.Execute(ctx)
+			if res.RulesExecuted != ruleCount {
+				t.Errorf("expected %d executed rules, got %d", ruleCount, res.RulesExecuted)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+type executorCategorizedRule struct {
+	stubRule
+	category string
+}
+
+func (r *executorCategorizedRule) Category() string { return r.category }
 
 func (r *stubRule) ID() string                           { return r.id }
 func (r *stubRule) Category() string                     { return "testing" }

--- a/internal/rules/registry_invariant_test.go
+++ b/internal/rules/registry_invariant_test.go
@@ -1,0 +1,101 @@
+package rules
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"RepoDoctor/internal/model"
+)
+
+type registryStubRule struct {
+	id       string
+	category string
+}
+
+func (r *registryStubRule) ID() string       { return r.id }
+func (r *registryStubRule) Category() string { return r.category }
+func (r *registryStubRule) Severity() string { return "info" }
+func (r *registryStubRule) Evaluate(AnalysisContext) []model.Violation {
+	return nil
+}
+
+func TestRuleRegistry_GetAll_DeterministicOrder(t *testing.T) {
+	registry := NewRuleRegistry()
+	registry.MustRegister(&registryStubRule{id: "rule.zeta", category: "testing"})
+	registry.MustRegister(&registryStubRule{id: "rule.alpha", category: "testing"})
+	registry.MustRegister(&registryStubRule{id: "rule.beta", category: "architecture"})
+
+	ordered := registry.GetAll()
+	if len(ordered) != 3 {
+		t.Fatalf("expected 3 rules, got %d", len(ordered))
+	}
+	if ordered[0].ID() != "rule.alpha" || ordered[1].ID() != "rule.beta" || ordered[2].ID() != "rule.zeta" {
+		t.Fatalf("unexpected deterministic order: [%s, %s, %s]", ordered[0].ID(), ordered[1].ID(), ordered[2].ID())
+	}
+}
+
+func TestRuleRegistry_GetByCategory_DeterministicOrder(t *testing.T) {
+	registry := NewRuleRegistry()
+	registry.MustRegister(&registryStubRule{id: "rule.zeta", category: "architecture"})
+	registry.MustRegister(&registryStubRule{id: "rule.alpha", category: "architecture"})
+	registry.MustRegister(&registryStubRule{id: "rule.beta", category: "testing"})
+
+	arch := registry.GetByCategory("architecture")
+	if len(arch) != 2 {
+		t.Fatalf("expected 2 architecture rules, got %d", len(arch))
+	}
+	if arch[0].ID() != "rule.alpha" || arch[1].ID() != "rule.zeta" {
+		t.Fatalf("unexpected category ordering: [%s, %s]", arch[0].ID(), arch[1].ID())
+	}
+}
+
+func TestRuleRegistry_Register_DuplicateIDFails(t *testing.T) {
+	registry := NewRuleRegistry()
+	rule := &registryStubRule{id: "rule.duplicate", category: "testing"}
+	registry.MustRegister(rule)
+
+	err := registry.Register(&registryStubRule{id: "rule.duplicate", category: "architecture"})
+	if err == nil {
+		t.Fatal("expected duplicate registration to fail")
+	}
+}
+
+func TestRuleRegistry_Register_ConcurrentAccessInvariant(t *testing.T) {
+	registry := NewRuleRegistry()
+	const ruleCount = 50
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, ruleCount)
+
+	for i := 0; i < ruleCount; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			id := fmt.Sprintf("rule.concurrent.%03d", idx)
+			if err := registry.Register(&registryStubRule{id: id, category: "testing"}); err != nil {
+				errCh <- err
+			}
+
+			_ = registry.GetAll()
+			_ = registry.ListIDs()
+			_ = registry.GetByCategory("testing")
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Fatalf("unexpected concurrent registration error: %v", err)
+	}
+
+	if registry.Count() != ruleCount {
+		t.Fatalf("expected %d rules after concurrent register, got %d", ruleCount, registry.Count())
+	}
+
+	ids := registry.ListIDs()
+	if len(ids) != ruleCount {
+		t.Fatalf("expected %d sorted IDs, got %d", ruleCount, len(ids))
+	}
+}


### PR DESCRIPTION
## Summary
- Add explicit rule registry invariants for deterministic ordering, category filtering, and duplicate ID rejection.
- Expand rule executor invariants for category/ID filtering and concurrent execution safety on shared registry state.
- Codify concurrency behavior with stress-style tests to prevent silent future regressions.

## Local gates
- `go test ./...` ✅
- `go vet ./...` ✅
- `go run . analyze -path .` ✅ (local analyze score = **100/100**)
- `go test -race ./...` ⚠️ blocked in environment (`gcc` missing for cgo race runtime)

## Workflow confirmation
- [x] One issue = one branch
- [x] Separate commit/push/PR for this issue