### PR TITLE
test(languages): enforce adapter contract compliance across all adapters

### DIFF
--- a/internal/languages/adapter_contract_test.go
+++ b/internal/languages/adapter_contract_test.go
@@ -1,6 +1,11 @@
 package languages
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestGoAdapter_CapabilitiesAndNormalizeImport(t *testing.T) {
 	adapter := NewGoAdapter()
@@ -25,5 +30,64 @@ func TestPythonAdapter_CapabilitiesAndNormalizeImport(t *testing.T) {
 
 	if got := adapter.NormalizeImport(" requests.sessions "); got != "requests" {
 		t.Fatalf("unexpected normalized import: %q", got)
+	}
+}
+
+func TestJavaScriptAdapter_CapabilitiesAndNormalizeImport(t *testing.T) {
+	adapter := NewJavaScriptAdapter()
+	caps := adapter.Capabilities()
+
+	if !caps.SupportsDependencyGraph || !caps.SupportsMetrics {
+		t.Fatal("expected JavaScript adapter to support graph and metrics")
+	}
+
+	if got := adapter.NormalizeImport(" @scope/pkg/utils "); got != "@scope/pkg" {
+		t.Fatalf("unexpected normalized JS import: %q", got)
+	}
+}
+
+func TestTypeScriptAdapter_CapabilitiesAndNormalizeImport(t *testing.T) {
+	adapter := NewTypeScriptAdapter()
+	caps := adapter.Capabilities()
+
+	if !caps.SupportsDependencyGraph || !caps.SupportsMetrics {
+		t.Fatal("expected TypeScript adapter to support graph and metrics")
+	}
+
+	if got := adapter.NormalizeImport(" node:fs "); got != "fs" {
+		t.Fatalf("unexpected normalized TS import: %q", got)
+	}
+}
+
+func TestAdapterContract_DeterministicDetectFilesAcrossRuns(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "a.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("failed writing go fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "b.py"), []byte("print('x')\n"), 0o644); err != nil {
+		t.Fatalf("failed writing python fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "c.js"), []byte("import x from 'react'\n"), 0o644); err != nil {
+		t.Fatalf("failed writing js fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "d.ts"), []byte("export type X = string\n"), 0o644); err != nil {
+		t.Fatalf("failed writing ts fixture: %v", err)
+	}
+
+	adapters := []LanguageAdapter{NewGoAdapter(), NewPythonAdapter(), NewJavaScriptAdapter(), NewTypeScriptAdapter()}
+	for _, adapter := range adapters {
+		first, err := adapter.DetectFiles(repo)
+		if err != nil {
+			t.Fatalf("%s DetectFiles failed: %v", adapter.Name(), err)
+		}
+		for i := 0; i < 10; i++ {
+			next, nextErr := adapter.DetectFiles(repo)
+			if nextErr != nil {
+				t.Fatalf("%s DetectFiles failed on iteration %d: %v", adapter.Name(), i, nextErr)
+			}
+			if strings.Join(first, "|") != strings.Join(next, "|") {
+				t.Fatalf("%s DetectFiles not deterministic\nfirst=%v\nnext=%v", adapter.Name(), first, next)
+			}
+		}
 	}
 }

--- a/internal/languages/js_ts_adapter_test.go
+++ b/internal/languages/js_ts_adapter_test.go
@@ -3,6 +3,7 @@ package languages
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -126,3 +127,52 @@ func TestLanguageDetector_DeterministicWithAdapterRegistrationOrder(t *testing.T
 type fixedIgnore struct{}
 
 func (f *fixedIgnore) ShouldIgnore(string, string) bool { return false }
+
+func TestJSTSAdapter_CollectEvidence_SkipsOutsideScope(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+
+	outsideFile := filepath.Join(outside, "outside.js")
+	if err := os.WriteFile(outsideFile, []byte("import x from 'left-pad'\n"), 0o644); err != nil {
+		t.Fatalf("failed writing outside fixture: %v", err)
+	}
+
+	adapter := NewJavaScriptAdapter().(EvidenceProvider)
+	signals, warnings, err := adapter.CollectEvidence(repo, []string{outsideFile})
+	if err != nil {
+		t.Fatalf("CollectEvidence failed: %v", err)
+	}
+	if len(signals) != 0 {
+		t.Fatalf("expected no signals outside root scope, got %d", len(signals))
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected warning for outside-scope path")
+	}
+}
+
+func TestJSTSAdapter_MetadataDepthGuard(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "main.ts"), []byte("export const x = 1\n"), 0o644); err != nil {
+		t.Fatalf("failed writing ts file: %v", err)
+	}
+
+	deep := `{"a":{"b":{"c":{"d":{"e":{"f":{"g":{"h":{"i":1}}}}}}}}}`
+	if err := os.WriteFile(filepath.Join(repo, "package.json"), []byte(deep), 0o644); err != nil {
+		t.Fatalf("failed writing deep package.json: %v", err)
+	}
+
+	provider := NewTypeScriptAdapter().(EvidenceProvider)
+	files, err := NewTypeScriptAdapter().DetectFiles(repo)
+	if err != nil {
+		t.Fatalf("DetectFiles failed: %v", err)
+	}
+	_, warnings, collectErr := provider.CollectEvidence(repo, files)
+	if collectErr != nil {
+		t.Fatalf("CollectEvidence should stay safe with deep metadata: %v", collectErr)
+	}
+
+	warnJoined := strings.Join(warnings, "|")
+	if !strings.Contains(warnJoined, "metadata nested too deeply") {
+		t.Fatalf("expected depth warning, got %v", warnings)
+	}
+}

--- a/internal/languages/python_adapter_test.go
+++ b/internal/languages/python_adapter_test.go
@@ -361,3 +361,29 @@ def run(arg1, arg2):
 		t.Fatalf("expected 2 functions, got %d", fm.Functions)
 	}
 }
+
+func TestPythonAdapter_CollectEvidence_MalformedAndOversizedSafeFailure(t *testing.T) {
+	repo := t.TempDir()
+
+	malformed := filepath.Join(repo, "bad.py")
+	if err := os.WriteFile(malformed, []byte("from . import\n"), 0o644); err != nil {
+		t.Fatalf("failed writing malformed fixture: %v", err)
+	}
+
+	oversized := filepath.Join(repo, "huge.py")
+	if err := os.WriteFile(oversized, make([]byte, maxPythonFileBytes+10), 0o644); err != nil {
+		t.Fatalf("failed writing oversized fixture: %v", err)
+	}
+
+	adapter := NewPythonAdapter()
+	signals, warnings, err := adapter.CollectEvidence(repo, []string{malformed, oversized})
+	if err != nil {
+		t.Fatalf("CollectEvidence must fail safely without returning error, got: %v", err)
+	}
+	if len(signals) != 0 {
+		t.Fatalf("expected zero signals for malformed/oversized input, got %d", len(signals))
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected warnings for malformed/oversized fixtures")
+	}
+}


### PR DESCRIPTION
## Summary
- Expand adapter contract coverage to include Go, Python, JavaScript, and TypeScript capability/normalization checks.
- Add deterministic parity tests and malicious-fixture safety tests (outside-scope files, malformed/oversized input, deep metadata).
- Keep adapter behavior fail-safe and deterministic without changing adapter interfaces.

## Local gates
- `go test ./...` ✅
- `go vet ./...` ✅
- `go run . analyze -path .` ✅ (local analyze score = **100/100**)

## Workflow confirmation
- [x] One issue = one branch
- [x] Separate commit/push/PR for this issue