### PR TITLE
refactor(languages): unify detect/stats traversal via shared scan contract

### DIFF
--- a/internal/languages/language_detector.go
+++ b/internal/languages/language_detector.go
@@ -1,6 +1,7 @@
 package languages
 
 import (
+	"bufio"
 	"fmt"
 	"io/fs"
 	"os"
@@ -23,6 +24,11 @@ type detectionScanContext struct {
 	stats        map[string]*LanguageStat
 	matchedFiles map[string][]string
 	adapters     []LanguageAdapter
+}
+
+type scanOutcome struct {
+	stats map[string]*LanguageStat
+	files map[string][]string
 }
 
 type DetectionPolicy struct {
@@ -173,21 +179,11 @@ func (d *RepositoryLanguageDetector) RegisterAdapter(adapter LanguageAdapter) {
 
 // DetectLanguage analyzes the repository and returns the primary language adapter.
 func (d *RepositoryLanguageDetector) DetectLanguage(repoPath string) (LanguageAdapter, error) {
-	normalizedRepoPath, err := normalizeRepoRoot(repoPath)
+	result, err := runSharedScanContract(d, repoPath)
 	if err != nil {
 		return nil, err
 	}
-
-	scanCtx := newDetectionScanContext(d.orderedAdapters())
-	err = scanRepository(d, normalizedRepoPath, scanCtx)
-	if err != nil {
-		return nil, fmt.Errorf("error scanning repository: %w", err)
-	}
-
-	d.applyAdapterEvidence(normalizedRepoPath, scanCtx.adapters, scanCtx.matchedFiles, scanCtx.stats)
-	applyMarkerBoost(normalizedRepoPath, scanCtx.stats)
-
-	return d.findDominantLanguage(scanCtx.stats)
+	return d.findDominantLanguage(result.stats)
 }
 
 func newDetectionScanContext(adapters []LanguageAdapter) *detectionScanContext {
@@ -332,6 +328,24 @@ func (d *RepositoryLanguageDetector) applyAdapterEvidence(repoPath string, adapt
 	}
 }
 
+func runSharedScanContract(detector *RepositoryLanguageDetector, repoPath string) (*scanOutcome, error) {
+	normalizedRepoPath, err := normalizeRepoRoot(repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	scanCtx := newDetectionScanContext(detector.orderedAdapters())
+	err = scanRepository(detector, normalizedRepoPath, scanCtx)
+	if err != nil {
+		return nil, fmt.Errorf("error scanning repository: %w", err)
+	}
+
+	detector.applyAdapterEvidence(normalizedRepoPath, scanCtx.adapters, scanCtx.matchedFiles, scanCtx.stats)
+	applyMarkerBoost(normalizedRepoPath, scanCtx.stats)
+
+	return &scanOutcome{stats: scanCtx.stats, files: scanCtx.matchedFiles}, nil
+}
+
 func normalizeRepoRoot(repoPath string) (string, error) {
 	if strings.TrimSpace(repoPath) == "" {
 		return "", fmt.Errorf("repository path is required")
@@ -435,36 +449,43 @@ func (d *RepositoryLanguageDetector) GetSupportedLanguages() []string {
 
 // countLines counts the number of lines in a file.
 func countLines(path string) (int, error) {
-	data, err := os.ReadFile(path)
+	file, err := os.Open(path)
 	if err != nil {
 		return 0, err
 	}
-	return len(strings.Split(string(data), "\n")), nil
+	defer file.Close()
+
+	count := 0
+	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+	for scanner.Scan() {
+		count++
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+
+	if count == 0 {
+		return 1, nil
+	}
+	return count, nil
 }
 
 // GetLanguageStats returns detailed statistics about languages in the repository.
 func (d *RepositoryLanguageDetector) GetLanguageStats(repoPath string) ([]LanguageStat, error) {
-	normalizedRepoPath, err := normalizeRepoRoot(repoPath)
+	result, err := runSharedScanContract(d, repoPath)
 	if err != nil {
 		return nil, err
 	}
 
-	scanCtx := newDetectionScanContext(d.orderedAdapters())
-	err = scanRepository(d, normalizedRepoPath, scanCtx)
-	if err != nil {
-		return nil, fmt.Errorf("error scanning repository: %w", err)
+	stats := make([]LanguageStat, 0, len(result.stats))
+	for _, stat := range result.stats {
+		stats = append(stats, *stat)
 	}
+	sort.SliceStable(stats, func(i, j int) bool { return stats[i].Language < stats[j].Language })
 
-	d.applyAdapterEvidence(normalizedRepoPath, scanCtx.adapters, scanCtx.matchedFiles, scanCtx.stats)
-	applyMarkerBoost(normalizedRepoPath, scanCtx.stats)
-
-	result := make([]LanguageStat, 0, len(scanCtx.stats))
-	for _, stat := range scanCtx.stats {
-		result = append(result, *stat)
-	}
-	sort.SliceStable(result, func(i, j int) bool { return result[i].Language < result[j].Language })
-
-	return result, nil
+	return stats, nil
 }
 
 // IsMultiLanguageRepository checks if the repository contains multiple supported languages.

--- a/internal/languages/language_stats_test.go
+++ b/internal/languages/language_stats_test.go
@@ -3,6 +3,7 @@ package languages
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"RepoDoctor/internal/domain"
@@ -53,6 +54,53 @@ func TestRepositoryLanguageDetector_GetLanguageStats_SortedAndStable(t *testing.
 				t.Fatalf("stats changed on iteration %d index %d: %+v vs %+v", i, idx, next[idx], first[idx])
 			}
 		}
+	}
+}
+
+func TestRepositoryLanguageDetector_GetLanguageStats_SkipsOutsideSymlinkLoop(t *testing.T) {
+	repo := t.TempDir()
+	outside := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(repo, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("failed writing root go file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "outside.py"), []byte("print('x')\n"), 0o644); err != nil {
+		t.Fatalf("failed writing outside python file: %v", err)
+	}
+
+	if err := os.Symlink(outside, filepath.Join(repo, "linked_outside")); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	detector := NewRepositoryLanguageDetector(domain.NewDefaultIgnoreStrategy(domain.DefaultIgnoredDirs))
+	detector.RegisterAdapter(NewGoAdapter())
+	detector.RegisterAdapter(NewPythonAdapter())
+
+	stats, err := detector.GetLanguageStats(repo)
+	if err != nil {
+		t.Fatalf("GetLanguageStats failed: %v", err)
+	}
+
+	if len(stats) != 1 || stats[0].Language != "Go" {
+		t.Fatalf("expected outside symlink to be skipped and only Go stat kept, got %+v", stats)
+	}
+}
+
+func TestCountLines_StreamedMemoryBoundedBehavior(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, "large.go")
+
+	lines := strings.Repeat("package main\n", 10000)
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatalf("failed writing large fixture: %v", err)
+	}
+
+	count, err := countLines(path)
+	if err != nil {
+		t.Fatalf("countLines failed: %v", err)
+	}
+	if count != 10000 {
+		t.Fatalf("expected streamed line count 10000, got %d", count)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Consolidate DetectLanguage and GetLanguageStats on one shared scan contract to prevent drift and duplicate traversal logic.
- Keep dominant-language and stats behavior deterministic while hardening symlink-outside-root handling tests.
- Stream line counting to avoid full-file buffering in metadata-only scan paths.

## Local gates
- `go test ./...` ✅
- `go vet ./...` ✅
- `go run . analyze -path .` ✅ (local analyze score = **100/100**)
- `go test -race ./...` ⚠️ blocked in environment (`gcc` missing for cgo race runtime)

## Workflow confirmation
- [x] One issue = one branch
- [x] Separate commit/push/PR for this issue