### PR TITLE
[S01][RD-102] Expand Python import normalization baseline

### DIFF
--- a/internal/languages/python_adapter_test.go
+++ b/internal/languages/python_adapter_test.go
@@ -387,3 +387,55 @@ func TestPythonAdapter_CollectEvidence_MalformedAndOversizedSafeFailure(t *testi
 		t.Fatal("expected warnings for malformed/oversized fixtures")
 	}
 }
+
+func TestParsePythonImportEvidence_AbsoluteRelativeAndDynamic(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "imports.py")
+
+	content := strings.Join([]string{
+		"from pkg.services import service_a, service_b as alias",
+		"from .local import helper",
+		"from ..shared import common as c",
+		"module = importlib.import_module('requests.sessions')",
+		"loaded = __import__(\"json.encoder\")",
+	}, "\n")
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	evidence, err := parsePythonImportEvidence(path)
+	if err != nil {
+		t.Fatalf("parsePythonImportEvidence failed: %v", err)
+	}
+
+	joined := make([]string, 0, len(evidence))
+	for _, e := range evidence {
+		joined = append(joined, e.modulePath)
+	}
+
+	mustContain := []string{"pkg.services.service_a", "pkg.services.service_b", "local.helper", "shared.common", "requests.sessions", "json.encoder"}
+	combined := strings.Join(joined, "|")
+	for _, expected := range mustContain {
+		if !strings.Contains(combined, expected) {
+			t.Fatalf("expected module path %q in parsed evidence %v", expected, joined)
+		}
+	}
+}
+
+func TestParsePythonImportEvidence_IgnoresUnsafeDynamicRelative(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "unsafe.py")
+	content := "mod = importlib.import_module('.private')\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	evidence, err := parsePythonImportEvidence(path)
+	if err != nil {
+		t.Fatalf("parsePythonImportEvidence failed: %v", err)
+	}
+	if len(evidence) != 0 {
+		t.Fatalf("expected unsafe dynamic relative import to be ignored, got %v", evidence)
+	}
+}

--- a/internal/languages/python_evidence.go
+++ b/internal/languages/python_evidence.go
@@ -24,41 +24,7 @@ func parsePythonImportEvidence(path string) ([]importEvidence, error) {
 	scanner := bufio.NewScanner(file)
 
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		if strings.HasPrefix(line, "import ") {
-			entry := strings.TrimSpace(strings.TrimPrefix(line, "import "))
-			for _, part := range strings.Split(entry, ",") {
-				modulePath := strings.TrimSpace(strings.Split(strings.TrimSpace(part), " as ")[0])
-				if modulePath == "" {
-					continue
-				}
-				result = append(result, importEvidence{modulePath: modulePath})
-			}
-			continue
-		}
-
-		if strings.HasPrefix(line, "from ") {
-			remainder := strings.TrimSpace(strings.TrimPrefix(line, "from "))
-			parts := strings.SplitN(remainder, " import ", 2)
-			if len(parts) != 2 {
-				continue
-			}
-			fromModule := strings.TrimSpace(parts[0])
-			level := 0
-			for level < len(fromModule) && fromModule[level] == '.' {
-				level++
-			}
-			modulePath := strings.TrimPrefix(fromModule, strings.Repeat(".", level))
-			result = append(result, importEvidence{
-				modulePath: modulePath,
-				relative:   level > 0,
-				level:      level,
-			})
-		}
+		result = append(result, parsePythonImportLine(scanner.Text())...)
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -66,6 +32,132 @@ func parsePythonImportEvidence(path string) ([]importEvidence, error) {
 	}
 
 	return result, nil
+}
+
+func parsePythonImportLine(raw string) []importEvidence {
+	line := strings.TrimSpace(raw)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return nil
+	}
+
+	if dynamic := parsePythonDynamicImport(line); dynamic != "" {
+		return []importEvidence{{modulePath: dynamic}}
+	}
+
+	if strings.HasPrefix(line, "import ") {
+		return parsePythonDirectImportLine(line)
+	}
+
+	if strings.HasPrefix(line, "from ") {
+		return parsePythonFromImportLine(line)
+	}
+
+	return nil
+}
+
+func parsePythonDirectImportLine(line string) []importEvidence {
+	entry := strings.TrimSpace(strings.TrimPrefix(line, "import "))
+	parts := strings.Split(entry, ",")
+	result := make([]importEvidence, 0, len(parts))
+	for _, part := range parts {
+		modulePath := strings.TrimSpace(strings.Split(strings.TrimSpace(part), " as ")[0])
+		if modulePath == "" {
+			continue
+		}
+		result = append(result, importEvidence{modulePath: modulePath})
+	}
+	return result
+}
+
+func parsePythonFromImportLine(line string) []importEvidence {
+	remainder := strings.TrimSpace(strings.TrimPrefix(line, "from "))
+	parts := strings.SplitN(remainder, " import ", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+	fromModule := strings.TrimSpace(parts[0])
+	targets := parsePythonImportTargets(parts[1])
+	level := parsePythonRelativeLevel(fromModule)
+	modulePath := strings.TrimPrefix(fromModule, strings.Repeat(".", level))
+
+	if len(targets) == 0 {
+		return []importEvidence{{
+			modulePath: modulePath,
+			relative:   level > 0,
+			level:      level,
+		}}
+	}
+
+	result := make([]importEvidence, 0, len(targets))
+	for _, target := range targets {
+		if target == "*" {
+			continue
+		}
+		combined := modulePath
+		if combined == "" {
+			combined = target
+		} else {
+			combined = combined + "." + target
+		}
+		result = append(result, importEvidence{
+			modulePath: combined,
+			relative:   level > 0,
+			level:      level,
+		})
+	}
+	return result
+}
+
+func parsePythonRelativeLevel(fromModule string) int {
+	level := 0
+	for level < len(fromModule) && fromModule[level] == '.' {
+		level++
+	}
+	return level
+}
+
+func parsePythonImportTargets(importPart string) []string {
+	parts := strings.Split(importPart, ",")
+	targets := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(strings.Split(strings.TrimSpace(part), " as ")[0])
+		if trimmed == "" {
+			continue
+		}
+		targets = append(targets, trimmed)
+	}
+	return targets
+}
+
+func parsePythonDynamicImport(line string) string {
+	if !strings.Contains(line, "import_module(") && !strings.Contains(line, "__import__(") {
+		return ""
+	}
+
+	for _, prefix := range []string{"importlib.import_module", "__import__"} {
+		idx := strings.Index(line, prefix+"(")
+		if idx < 0 {
+			continue
+		}
+		args := line[idx+len(prefix)+1:]
+		for _, quote := range []string{"'", "\""} {
+			start := strings.Index(args, quote)
+			if start < 0 {
+				continue
+			}
+			end := strings.Index(args[start+1:], quote)
+			if end < 0 {
+				continue
+			}
+			candidate := strings.TrimSpace(args[start+1 : start+1+end])
+			if candidate == "" || strings.HasPrefix(candidate, ".") {
+				return ""
+			}
+			return candidate
+		}
+	}
+
+	return ""
 }
 
 func detectPythonModuleRoot(repoRoot, filePath string) string {


### PR DESCRIPTION
## Summary
- expand Python import evidence parsing to better normalize absolute, relative, and safe dynamic import forms
- keep fail-soft behavior and deterministic extraction
- add tests for normalization coverage and unsafe dynamic-import filtering

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #120