### PR TITLE
[S01][RD-104] Add tri-language determinism and fail-soft adapter suite

### DIFF
--- a/internal/languages/adapter_contract_test.go
+++ b/internal/languages/adapter_contract_test.go
@@ -20,6 +20,92 @@ func TestGoAdapter_CapabilitiesAndNormalizeImport(t *testing.T) {
 	}
 }
 
+func TestAdapterContract_DeterministicBuildDependencyGraphAcrossRuns(t *testing.T) {
+	repo := t.TempDir()
+	filesByAdapter := map[string]string{
+		"Go":         filepath.Join(repo, "main.go"),
+		"Python":     filepath.Join(repo, "main.py"),
+		"JavaScript": filepath.Join(repo, "main.js"),
+		"TypeScript": filepath.Join(repo, "main.ts"),
+	}
+
+	fixtures := map[string]string{
+		"Go":         "package main\nimport (\"fmt\"; \"net/http\")\nfunc main(){fmt.Println(http.MethodGet)}\n",
+		"Python":     "import os\nfrom collections import defaultdict\n",
+		"JavaScript": "import x from 'react'\nconst y = require('lodash')\n",
+		"TypeScript": "export {x} from '@scope/pkg/utils'\n",
+	}
+
+	for name, file := range filesByAdapter {
+		if err := os.WriteFile(file, []byte(fixtures[name]), 0o644); err != nil {
+			t.Fatalf("failed writing %s fixture: %v", name, err)
+		}
+	}
+
+	adapters := []LanguageAdapter{NewGoAdapter(), NewPythonAdapter(), NewJavaScriptAdapter(), NewTypeScriptAdapter()}
+	for _, adapter := range adapters {
+		file := filesByAdapter[adapter.Name()]
+		firstGraph, err := adapter.BuildDependencyGraph([]string{file})
+		if err != nil {
+			t.Fatalf("%s BuildDependencyGraph failed: %v", adapter.Name(), err)
+		}
+		firstNode := firstGraph.GetNode(file)
+		if firstNode == nil {
+			t.Fatalf("%s expected node for %s", adapter.Name(), file)
+		}
+		baseline := strings.Join(firstNode.Imports, "|")
+
+		for i := 0; i < 10; i++ {
+			nextGraph, nextErr := adapter.BuildDependencyGraph([]string{file})
+			if nextErr != nil {
+				t.Fatalf("%s BuildDependencyGraph failed on iteration %d: %v", adapter.Name(), i, nextErr)
+			}
+			nextNode := nextGraph.GetNode(file)
+			if nextNode == nil {
+				t.Fatalf("%s expected node for %s on iteration %d", adapter.Name(), file, i)
+			}
+			current := strings.Join(nextNode.Imports, "|")
+			if baseline != current {
+				t.Fatalf("%s BuildDependencyGraph not deterministic\nfirst=%v\nnext=%v", adapter.Name(), baseline, current)
+			}
+		}
+	}
+}
+
+func TestAdapterContract_MalformedCorpusFailSoftNoPanic(t *testing.T) {
+	repo := t.TempDir()
+	filesByAdapter := map[string]string{
+		"Go":         filepath.Join(repo, "broken.go"),
+		"Python":     filepath.Join(repo, "broken.py"),
+		"JavaScript": filepath.Join(repo, "broken.js"),
+		"TypeScript": filepath.Join(repo, "broken.ts"),
+	}
+
+	malformed := map[string]string{
+		"Go":         "package main\nimport (\"fmt\"\nfunc main() {",
+		"Python":     "from . import\n",
+		"JavaScript": "import from 'x'\nconst a = require(\n",
+		"TypeScript": "export { from 'pkg'\n",
+	}
+
+	for name, file := range filesByAdapter {
+		if err := os.WriteFile(file, []byte(malformed[name]), 0o644); err != nil {
+			t.Fatalf("failed writing malformed %s fixture: %v", name, err)
+		}
+	}
+
+	adapters := []LanguageAdapter{NewGoAdapter(), NewPythonAdapter(), NewJavaScriptAdapter(), NewTypeScriptAdapter()}
+	for _, adapter := range adapters {
+		file := filesByAdapter[adapter.Name()]
+		_, _ = adapter.CollectMetrics([]string{file})
+		_, _ = adapter.BuildDependencyGraph([]string{file})
+
+		if provider, ok := adapter.(EvidenceProvider); ok {
+			_, _, _ = provider.CollectEvidence(repo, []string{file})
+		}
+	}
+}
+
 func TestPythonAdapter_CapabilitiesAndNormalizeImport(t *testing.T) {
 	adapter := NewPythonAdapter()
 	caps := adapter.Capabilities()


### PR DESCRIPTION
## Summary
- add repeated-run deterministic graph tests for Go, Python, JavaScript, and TypeScript adapters
- add malformed corpus fail-soft tests to ensure no adapter panic path on broken inputs
- reinforce cross-language adapter contract boundaries

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #122