### PR TITLE
[S02][RD-105] Add bounded Python token pass for size signals

### DIFF
--- a/internal/languages/python_adapter.go
+++ b/internal/languages/python_adapter.go
@@ -99,11 +99,12 @@ func collectPythonFileMetrics(path string) (*model.FileMetrics, error) {
 	}
 
 	lines := strings.Split(string(content), "\n")
+	signals := collectPythonSignalsBounded(content)
 	fm := &model.FileMetrics{
 		Path:      path,
 		Lines:     len(lines),
-		Functions: 0,
-		Imports:   0,
+		Functions: signals.funcs,
+		Imports:   signals.imports,
 	}
 
 	localMetrics := model.NewRepositoryMetrics()
@@ -117,14 +118,8 @@ func collectPythonFileMetrics(path string) (*model.FileMetrics, error) {
 			continue
 		}
 
-		// Count imports
-		if strings.HasPrefix(trimmed, "import ") || strings.HasPrefix(trimmed, "from ") {
-			fm.Imports++
-		}
-
-		// Count function definitions
+		// Function definitions
 		if strings.HasPrefix(trimmed, "def ") {
-			fm.Functions++
 			funcMetrics := pyExtractFunctionMetrics(trimmed, path, i+1)
 			localMetrics.AddFunctionMetrics(*funcMetrics)
 		}

--- a/internal/languages/python_token_pass.go
+++ b/internal/languages/python_token_pass.go
@@ -1,0 +1,71 @@
+package languages
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+)
+
+type pythonSignalCounts struct {
+	imports int
+	funcs   int
+	classes int
+}
+
+func collectPythonSignalsBounded(content []byte) pythonSignalCounts {
+	counts := pythonSignalCounts{}
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 256*1024)
+
+	inTripleSingle := false
+	inTripleDouble := false
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		if inTripleSingle {
+			if strings.Contains(line, "'''") {
+				inTripleSingle = false
+			}
+			continue
+		}
+		if inTripleDouble {
+			if strings.Contains(line, `"""`) {
+				inTripleDouble = false
+			}
+			continue
+		}
+
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "'''") {
+			if !strings.Contains(line[3:], "'''") {
+				inTripleSingle = true
+			}
+			continue
+		}
+		if strings.HasPrefix(line, `"""`) {
+			if !strings.Contains(line[3:], `"""`) {
+				inTripleDouble = true
+			}
+			continue
+		}
+
+		if strings.HasPrefix(line, "import ") || strings.HasPrefix(line, "from ") {
+			counts.imports++
+		}
+		if strings.HasPrefix(line, "def ") || strings.HasPrefix(line, "async def ") {
+			counts.funcs++
+		}
+		if strings.HasPrefix(line, "class ") {
+			counts.classes++
+		}
+	}
+
+	return counts
+}

--- a/internal/languages/python_token_pass_test.go
+++ b/internal/languages/python_token_pass_test.go
@@ -1,0 +1,31 @@
+package languages
+
+import "testing"
+
+func TestCollectPythonSignalsBounded_IgnoresCommentsAndDocstrings(t *testing.T) {
+	content := []byte(`# comment
+"""module docstring
+still docstring
+"""
+import os
+from collections import defaultdict
+
+class Service:
+    def run(self):
+        return 1
+
+async def handle():
+    return 2
+`)
+
+	counts := collectPythonSignalsBounded(content)
+	if counts.imports != 2 {
+		t.Fatalf("expected 2 imports, got %d", counts.imports)
+	}
+	if counts.funcs != 2 {
+		t.Fatalf("expected 2 funcs, got %d", counts.funcs)
+	}
+	if counts.classes != 1 {
+		t.Fatalf("expected 1 class, got %d", counts.classes)
+	}
+}


### PR DESCRIPTION
## Summary
- introduce bounded token-pass signal extraction for Python imports/functions/classes
- improve metric signal quality while preserving fail-soft behavior
- add dedicated token-pass regression tests for comments/docstrings handling

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #127