### PR TITLE
[S02][RD-106] Improve Go edge classification precision

### DIFF
--- a/internal/languages/go_adapter.go
+++ b/internal/languages/go_adapter.go
@@ -205,6 +205,10 @@ func goParseFileAndAddToGraph(fset *token.FileSet, path string, graph *model.Dep
 	for _, imp := range node.Imports {
 		importPath := strings.Trim(imp.Path.Value, "\"")
 		graphNode.Imports = append(graphNode.Imports, importPath)
+		if graphNode.Metadata == nil {
+			graphNode.Metadata = make(map[string]string)
+		}
+		graphNode.Metadata["import_class:"+importPath] = string(classifyGoImport(importPath))
 	}
 
 	return graphNode, nil

--- a/internal/languages/go_classification.go
+++ b/internal/languages/go_classification.go
@@ -1,0 +1,29 @@
+package languages
+
+import "strings"
+
+// GoImportClass defines deterministic import edge categories.
+type GoImportClass string
+
+const (
+	GoImportStdlib   GoImportClass = "stdlib"
+	GoImportInternal GoImportClass = "internal"
+	GoImportExternal GoImportClass = "third_party"
+)
+
+func classifyGoImport(importPath string) GoImportClass {
+	normalized := strings.TrimSpace(importPath)
+	if normalized == "" {
+		return GoImportExternal
+	}
+
+	if !strings.Contains(normalized, ".") {
+		return GoImportStdlib
+	}
+
+	if strings.Contains(normalized, "/internal/") || strings.HasSuffix(normalized, "/internal") {
+		return GoImportInternal
+	}
+
+	return GoImportExternal
+}

--- a/internal/languages/go_classification_test.go
+++ b/internal/languages/go_classification_test.go
@@ -1,0 +1,65 @@
+package languages
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClassifyGoImport(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		class GoImportClass
+	}{
+		{name: "stdlib", input: "fmt", class: GoImportStdlib},
+		{name: "stdlib nested", input: "net/http", class: GoImportStdlib},
+		{name: "internal segment", input: "github.com/org/repo/internal/service", class: GoImportInternal},
+		{name: "external", input: "github.com/pkg/errors", class: GoImportExternal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyGoImport(tt.input); got != tt.class {
+				t.Fatalf("expected %s, got %s", tt.class, got)
+			}
+		})
+	}
+}
+
+func TestGoAdapter_BuildDependencyGraph_StoresImportClassificationMetadata(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, "main.go")
+	content := `package main
+import (
+  "fmt"
+  "github.com/pkg/errors"
+  "github.com/myorg/repo/internal/service"
+)
+func main() { _, _, _ = fmt.Println, errors.New, service.Run }
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed writing go fixture: %v", err)
+	}
+
+	adapter := NewGoAdapter()
+	graph, err := adapter.BuildDependencyGraph([]string{path})
+	if err != nil {
+		t.Fatalf("BuildDependencyGraph failed: %v", err)
+	}
+
+	node := graph.GetNode(path)
+	if node == nil {
+		t.Fatalf("expected graph node for %s", path)
+	}
+
+	if got := node.Metadata["import_class:fmt"]; got != string(GoImportStdlib) {
+		t.Fatalf("expected stdlib classification for fmt, got %q", got)
+	}
+	if got := node.Metadata["import_class:github.com/pkg/errors"]; got != string(GoImportExternal) {
+		t.Fatalf("expected external classification for github.com/pkg/errors, got %q", got)
+	}
+	if got := node.Metadata["import_class:github.com/myorg/repo/internal/service"]; got != string(GoImportInternal) {
+		t.Fatalf("expected internal classification for internal import, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add deterministic Go import edge classification helper (stdlib/internal/third-party)
- attach classification metadata per import edge on graph nodes
- add tests for classification outcomes and metadata stability

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #128