### PR TITLE
[S02][RD-107] Enable deterministic Python core rule parity path

### DIFF
--- a/analysis_service.go
+++ b/analysis_service.go
@@ -61,7 +61,7 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	config := loadConfiguration(absPath, request.Verbose)
 
 	progress.Start("Running rules", getStageCount("Running rules", absPath))
-	ruleSummary := runInternalRulePipeline(absPath, graph)
+	ruleSummary := runInternalRulePipeline(absPath, graph, analysisResult.AdapterName)
 	progress.SetProgress(progress.totalSteps / 2)
 
 	report := generateRuleEngineReport(absPath, request.Format, request.Verbose, request.ColorEnabled, config, ruleSummary)

--- a/internal/rules/size_rule.go
+++ b/internal/rules/size_rule.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -42,7 +43,7 @@ func (r *SizeRule) Severity() string {
 }
 
 func (r *SizeRule) Capabilities() RuleCapabilities {
-	return RuleCapabilities{SupportedLanguages: []string{"Go"}, SupportsMultipleLanguages: false}
+	return RuleCapabilities{SupportedLanguages: []string{"Go", "Python"}, SupportsMultipleLanguages: false}
 }
 
 // Evaluate executes the rule logic against the provided context
@@ -90,6 +91,12 @@ func (r *SizeRule) countNonEmptyLines(content string) int {
 
 // checkFunctions checks function sizes in a file
 func (r *SizeRule) checkFunctions(file RepositoryFile, violations *[]model.Violation) {
+	ext := strings.ToLower(filepath.Ext(file.Path))
+	if ext == ".py" {
+		r.checkPythonFunctions(file, violations)
+		return
+	}
+
 	// Parse AST
 	node, err := parser.ParseFile(r.fset, file.Path, file.Content, 0)
 	if err != nil {
@@ -121,4 +128,66 @@ func (r *SizeRule) checkFunctions(file RepositoryFile, violations *[]model.Viola
 
 		return true
 	})
+}
+
+func (r *SizeRule) checkPythonFunctions(file RepositoryFile, violations *[]model.Violation) {
+	lines := strings.Split(file.Content, "\n")
+	for i := 0; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if !(strings.HasPrefix(trimmed, "def ") || strings.HasPrefix(trimmed, "async def ")) {
+			continue
+		}
+
+		startLine := i + 1
+		startIndent := leadingSpaces(lines[i])
+		endLine := startLine
+
+		for j := i + 1; j < len(lines); j++ {
+			candidate := lines[j]
+			candidateTrimmed := strings.TrimSpace(candidate)
+			if candidateTrimmed == "" || strings.HasPrefix(candidateTrimmed, "#") {
+				endLine = j + 1
+				continue
+			}
+
+			if leadingSpaces(candidate) <= startIndent {
+				break
+			}
+			endLine = j + 1
+		}
+
+		funcLines := endLine - startLine + 1
+		if funcLines > r.MaxFunctionLines {
+			name := extractPythonFunctionName(trimmed)
+			*violations = append(*violations, model.Violation{
+				RuleID:      r.ID(),
+				Severity:    model.SeverityWarning,
+				Message:     "Function '" + name + "' has " + strconv.Itoa(funcLines) + " lines (threshold: " + strconv.Itoa(r.MaxFunctionLines) + ")",
+				File:        file.Path,
+				Line:        startLine,
+				ScoreImpact: -3.0,
+			})
+		}
+	}
+}
+
+func leadingSpaces(line string) int {
+	count := 0
+	for _, ch := range line {
+		if ch != ' ' {
+			break
+		}
+		count++
+	}
+	return count
+}
+
+func extractPythonFunctionName(trimmedDef string) string {
+	namePart := strings.TrimSpace(trimmedDef)
+	namePart = strings.TrimPrefix(namePart, "async ")
+	namePart = strings.TrimPrefix(namePart, "def ")
+	if idx := strings.Index(namePart, "("); idx > 0 {
+		return strings.TrimSpace(namePart[:idx])
+	}
+	return "unknown"
 }

--- a/internal/rules/size_rule_python_test.go
+++ b/internal/rules/size_rule_python_test.go
@@ -1,0 +1,32 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSizeRule_Evaluate_PythonFunctionSizeViolation(t *testing.T) {
+	rule := NewSizeRule()
+	rule.MaxFunctionLines = 5
+
+	content := strings.Join([]string{
+		"def too_long():",
+		"    a = 1",
+		"    b = 2",
+		"    c = 3",
+		"    d = 4",
+		"    e = 5",
+		"    f = 6",
+		"    return a + b + c + d + e + f",
+	}, "\n")
+
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{{Path: "service.py", Content: content}}}
+	violations := rule.Evaluate(ctx)
+
+	if len(violations) == 0 {
+		t.Fatal("expected python function size violation")
+	}
+	if violations[0].RuleID != "rule.size" {
+		t.Fatalf("expected rule.size violation, got %s", violations[0].RuleID)
+	}
+}

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -16,7 +16,7 @@ type runtimeRuleSummary struct {
 	rulesInScope int
 }
 
-func runInternalRulePipeline(absPath string, graph Graph) *runtimeRuleSummary {
+func runInternalRulePipeline(absPath string, graph Graph, primaryLanguage string) *runtimeRuleSummary {
 	registry := rules.NewRuleRegistry()
 	for _, rule := range rules.GetDefaultRegistry().GetAll() {
 		registry.MustRegister(rule)
@@ -24,7 +24,7 @@ func runInternalRulePipeline(absPath string, graph Graph) *runtimeRuleSummary {
 	registry.MustRegister(rules.NewCircularDependencyRule(toRulesDependencyGraph(graph)))
 
 	executor := engine.NewRuleExecutor(registry)
-	context := buildRulesAnalysisContext(absPath, graph)
+	context := buildRulesAnalysisContext(absPath, graph, primaryLanguage)
 	result := executor.Execute(context)
 	sortViolations(result.Violations)
 
@@ -34,7 +34,7 @@ func runInternalRulePipeline(absPath string, graph Graph) *runtimeRuleSummary {
 	}
 }
 
-func buildRulesAnalysisContext(absPath string, graph Graph) rules.AnalysisContext {
+func buildRulesAnalysisContext(absPath string, graph Graph, primaryLanguage string) rules.AnalysisContext {
 	nodes := graph.GetAllNodes()
 	sort.Strings(nodes)
 
@@ -52,11 +52,16 @@ func buildRulesAnalysisContext(absPath string, graph Graph) rules.AnalysisContex
 		})
 	}
 
+	languages := []string{"Go", "Python", "JavaScript", "TypeScript"}
+	if primaryLanguage != "" {
+		languages = []string{primaryLanguage}
+	}
+
 	return rules.AnalysisContext{
 		RepositoryFiles: repoFiles,
 		DependencyGraph: toRulesDependencyGraph(graph),
 		Configuration:   rules.Configuration{"repositoryPath": absPath},
-		Languages:       []string{"Go", "Python", "JavaScript", "TypeScript"},
+		Languages:       languages,
 	}
 }
 


### PR DESCRIPTION
## Summary
- pass detected adapter language into runtime rule context for deterministic language-aware rule selection
- extend size rule language capabilities to include Python
- add Python function-size evaluation path and tests

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #129