### PR TITLE
[S03][RD-109] Harden JS/TS export-from and safe require extraction

### DIFF
--- a/internal/languages/js_ts_adapter.go
+++ b/internal/languages/js_ts_adapter.go
@@ -120,59 +120,69 @@ func (a *jsTsAdapter) BuildDependencyGraph(files []string) (*model.DependencyGra
 		}
 		lines := strings.Split(string(content), "\n")
 		for _, line := range lines {
-			trimmed := strings.TrimSpace(line)
-
-			// import x from 'pkg' / import {x} from 'pkg'
-			if strings.HasPrefix(trimmed, "import ") && strings.Contains(trimmed, " from ") {
-				parts := strings.Split(trimmed, " from ")
-				candidate := strings.Trim(parts[len(parts)-1], " ';\"")
-				if candidate != "" {
-					normalized := a.NormalizeImport(candidate)
-					node.Imports = append(node.Imports, normalized)
-					graph.AddEdge(file, normalized)
-				}
-			}
-
-			// import 'pkg' (side-effect imports)
-			if strings.HasPrefix(trimmed, "import ") && !strings.Contains(trimmed, " from ") {
-				if quoted := extractQuotedJSImport(trimmed); quoted != "" {
-					normalized := a.NormalizeImport(quoted)
-					node.Imports = append(node.Imports, normalized)
-					graph.AddEdge(file, normalized)
-				}
-			}
-
-			// export ... from 'pkg'
-			if strings.HasPrefix(trimmed, "export ") && strings.Contains(trimmed, " from ") {
-				parts := strings.Split(trimmed, " from ")
-				candidate := strings.Trim(parts[len(parts)-1], " ';\"")
-				if candidate != "" {
-					normalized := a.NormalizeImport(candidate)
-					node.Imports = append(node.Imports, normalized)
-					graph.AddEdge(file, normalized)
-				}
-			}
-
-			// const x = require('pkg') / require("pkg")
-			for _, m := range requireRe.FindAllStringSubmatch(trimmed, -1) {
-				if len(m) > 1 {
-					normalized := a.NormalizeImport(m[1])
-					node.Imports = append(node.Imports, normalized)
-					graph.AddEdge(file, normalized)
-				}
-			}
-
-			// import('pkg') dynamic import safe subset
-			for _, m := range dynamicImportRe.FindAllStringSubmatch(trimmed, -1) {
-				if len(m) > 1 {
-					normalized := a.NormalizeImport(m[1])
-					node.Imports = append(node.Imports, normalized)
-					graph.AddEdge(file, normalized)
-				}
-			}
+			collectJSImportLine(a, file, strings.TrimSpace(line), node, graph, requireRe, dynamicImportRe)
 		}
 	}
 	return graph, nil
+}
+
+func collectJSImportLine(a *jsTsAdapter, file, trimmed string, node *model.Node, graph *model.DependencyGraph, requireRe, dynamicImportRe *regexp.Regexp) {
+	if strings.HasPrefix(trimmed, "//") {
+		return
+	}
+
+	collectStaticJSImport(a, file, trimmed, node, graph)
+	collectStaticExportFrom(a, file, trimmed, node, graph)
+	collectRequireImports(a, file, trimmed, node, graph, requireRe)
+	collectDynamicImports(a, file, trimmed, node, graph, dynamicImportRe)
+}
+
+func collectStaticJSImport(a *jsTsAdapter, file, trimmed string, node *model.Node, graph *model.DependencyGraph) {
+	if strings.HasPrefix(trimmed, "import ") && strings.Contains(trimmed, " from ") {
+		parts := strings.Split(trimmed, " from ")
+		candidate := strings.Trim(parts[len(parts)-1], " ';\"")
+		appendJSImportDependency(a, file, candidate, node, graph)
+	}
+
+	if strings.HasPrefix(trimmed, "import ") && !strings.Contains(trimmed, " from ") {
+		appendJSImportDependency(a, file, extractQuotedJSImport(trimmed), node, graph)
+	}
+}
+
+func collectStaticExportFrom(a *jsTsAdapter, file, trimmed string, node *model.Node, graph *model.DependencyGraph) {
+	if strings.HasPrefix(trimmed, "export ") && strings.Contains(trimmed, " from ") {
+		parts := strings.Split(trimmed, " from ")
+		candidate := strings.Trim(parts[len(parts)-1], " ';\"")
+		appendJSImportDependency(a, file, candidate, node, graph)
+	}
+}
+
+func collectRequireImports(a *jsTsAdapter, file, trimmed string, node *model.Node, graph *model.DependencyGraph, requireRe *regexp.Regexp) {
+	if strings.Contains(trimmed, "require(") && strings.Contains(trimmed, "+") {
+		return
+	}
+	for _, m := range requireRe.FindAllStringSubmatch(trimmed, -1) {
+		if len(m) > 1 {
+			appendJSImportDependency(a, file, m[1], node, graph)
+		}
+	}
+}
+
+func collectDynamicImports(a *jsTsAdapter, file, trimmed string, node *model.Node, graph *model.DependencyGraph, dynamicImportRe *regexp.Regexp) {
+	for _, m := range dynamicImportRe.FindAllStringSubmatch(trimmed, -1) {
+		if len(m) > 1 {
+			appendJSImportDependency(a, file, m[1], node, graph)
+		}
+	}
+}
+
+func appendJSImportDependency(a *jsTsAdapter, file, raw string, node *model.Node, graph *model.DependencyGraph) {
+	if raw == "" {
+		return
+	}
+	normalized := a.NormalizeImport(raw)
+	node.Imports = append(node.Imports, normalized)
+	graph.AddEdge(file, normalized)
 }
 
 func extractQuotedJSImport(line string) string {

--- a/internal/languages/js_ts_adapter_test.go
+++ b/internal/languages/js_ts_adapter_test.go
@@ -210,3 +210,39 @@ func TestJSTSAdapter_BuildDependencyGraph_ImportRequireCoverage(t *testing.T) {
 		}
 	}
 }
+
+func TestJSTSAdapter_BuildDependencyGraph_ExportFromAndSafeRequireSubset(t *testing.T) {
+	repo := t.TempDir()
+	file := filepath.Join(repo, "mod.ts")
+	fixture := strings.Join([]string{
+		"export * from 'rxjs/operators'",
+		"export * as utils from '@scope/pkg/utils'",
+		"const stable = require('axios/lib/core')",
+		"const dynamic = require('./' + name)",
+	}, "\n")
+
+	if err := os.WriteFile(file, []byte(fixture), 0o644); err != nil {
+		t.Fatalf("failed writing fixture: %v", err)
+	}
+
+	adapter := NewTypeScriptAdapter()
+	graph, err := adapter.BuildDependencyGraph([]string{file})
+	if err != nil {
+		t.Fatalf("BuildDependencyGraph failed: %v", err)
+	}
+	node := graph.GetNode(file)
+	if node == nil {
+		t.Fatalf("expected node for %s", file)
+	}
+
+	joined := strings.Join(node.Imports, "|")
+	for _, expected := range []string{"rxjs", "@scope/pkg", "axios"} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("expected normalized import %q in %v", expected, node.Imports)
+		}
+	}
+
+	if strings.Contains(joined, "./") {
+		t.Fatalf("expected dynamic require subset to be ignored, got %v", node.Imports)
+	}
+}


### PR DESCRIPTION
## Summary
- harden JS/TS extraction for export-from forms and safe require subset handling
- keep deterministic adapter behavior and malformed-safe parsing paths
- add coverage tests for export * and ignored dynamic require concatenation

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #136