### PR TITLE
[S03][RD-110] Enable JS/TS core rule parity path

### DIFF
--- a/internal/rules/size_rule.go
+++ b/internal/rules/size_rule.go
@@ -43,7 +43,7 @@ func (r *SizeRule) Severity() string {
 }
 
 func (r *SizeRule) Capabilities() RuleCapabilities {
-	return RuleCapabilities{SupportedLanguages: []string{"Go", "Python"}, SupportsMultipleLanguages: false}
+	return RuleCapabilities{SupportedLanguages: []string{"Go", "Python", "JavaScript", "TypeScript"}, SupportsMultipleLanguages: false}
 }
 
 // Evaluate executes the rule logic against the provided context
@@ -96,6 +96,10 @@ func (r *SizeRule) checkFunctions(file RepositoryFile, violations *[]model.Viola
 		r.checkPythonFunctions(file, violations)
 		return
 	}
+	if ext == ".js" || ext == ".jsx" || ext == ".ts" || ext == ".tsx" {
+		r.checkJSTSFunctions(file, violations)
+		return
+	}
 
 	// Parse AST
 	node, err := parser.ParseFile(r.fset, file.Path, file.Content, 0)
@@ -128,6 +132,79 @@ func (r *SizeRule) checkFunctions(file RepositoryFile, violations *[]model.Viola
 
 		return true
 	})
+}
+
+func (r *SizeRule) checkJSTSFunctions(file RepositoryFile, violations *[]model.Violation) {
+	lines := strings.Split(file.Content, "\n")
+	for i := 0; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if !looksLikeJSTSFunctionStart(trimmed) {
+			continue
+		}
+
+		startLine := i + 1
+		braceDepth := 0
+		seenOpen := false
+		endLine := startLine
+
+		for j := i; j < len(lines); j++ {
+			line := lines[j]
+			for _, ch := range line {
+				switch ch {
+				case '{':
+					braceDepth++
+					seenOpen = true
+				case '}':
+					if braceDepth > 0 {
+						braceDepth--
+					}
+				}
+			}
+			endLine = j + 1
+			if seenOpen && braceDepth == 0 {
+				break
+			}
+		}
+
+		funcLines := endLine - startLine + 1
+		if funcLines > r.MaxFunctionLines {
+			*violations = append(*violations, model.Violation{
+				RuleID:      r.ID(),
+				Severity:    model.SeverityWarning,
+				Message:     "Function '" + extractJSTSFunctionName(trimmed) + "' has " + strconv.Itoa(funcLines) + " lines (threshold: " + strconv.Itoa(r.MaxFunctionLines) + ")",
+				File:        file.Path,
+				Line:        startLine,
+				ScoreImpact: -3.0,
+			})
+		}
+	}
+}
+
+func looksLikeJSTSFunctionStart(trimmed string) bool {
+	return strings.HasPrefix(trimmed, "function ") ||
+		strings.Contains(trimmed, "=>") ||
+		strings.HasPrefix(trimmed, "async function ") ||
+		strings.Contains(trimmed, " = function")
+}
+
+func extractJSTSFunctionName(trimmed string) string {
+	if strings.HasPrefix(trimmed, "async function ") {
+		trimmed = strings.TrimPrefix(trimmed, "async ")
+	}
+	if strings.HasPrefix(trimmed, "function ") {
+		rest := strings.TrimSpace(strings.TrimPrefix(trimmed, "function "))
+		if idx := strings.Index(rest, "("); idx > 0 {
+			return strings.TrimSpace(rest[:idx])
+		}
+	}
+	if idx := strings.Index(trimmed, "="); idx > 0 {
+		left := strings.TrimSpace(trimmed[:idx])
+		parts := strings.Fields(left)
+		if len(parts) > 0 {
+			return parts[len(parts)-1]
+		}
+	}
+	return "anonymous"
 }
 
 func (r *SizeRule) checkPythonFunctions(file RepositoryFile, violations *[]model.Violation) {

--- a/internal/rules/size_rule_jsts_test.go
+++ b/internal/rules/size_rule_jsts_test.go
@@ -1,0 +1,33 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSizeRule_Evaluate_JSTSFunctionSizeViolation(t *testing.T) {
+	rule := NewSizeRule()
+	rule.MaxFunctionLines = 5
+
+	content := strings.Join([]string{
+		"function tooLong() {",
+		"  const a = 1",
+		"  const b = 2",
+		"  const c = 3",
+		"  const d = 4",
+		"  const e = 5",
+		"  const f = 6",
+		"  return a+b+c+d+e+f",
+		"}",
+	}, "\n")
+
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{{Path: "service.ts", Content: content}}}
+	violations := rule.Evaluate(ctx)
+
+	if len(violations) == 0 {
+		t.Fatal("expected JS/TS function size violation")
+	}
+	if violations[0].RuleID != "rule.size" {
+		t.Fatalf("expected rule.size violation, got %s", violations[0].RuleID)
+	}
+}


### PR DESCRIPTION
## Summary
- extend size rule language capabilities to include JavaScript and TypeScript
- add deterministic JS/TS function-size evaluation path
- add JS/TS parity tests for size violations

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #137