### PR TITLE
[S03][RD-111] Add language reason codes and confidence metadata

### DIFF
--- a/analysis_language_evidence.go
+++ b/analysis_language_evidence.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"RepoDoctor/internal/domain"
+	"RepoDoctor/internal/languages"
+	"math"
+	"sort"
+)
+
+func collectLanguageEvidenceSummary(absPath, detectedLanguage string) LanguageEvidenceSummary {
+	stats, err := collectLanguageStats(absPath)
+	if err != nil || len(stats) == 0 {
+		return LanguageEvidenceSummary{DetectedLanguage: detectedLanguage, Confidence: 0.0, ReasonCodes: []string{"STATS_UNAVAILABLE"}}
+	}
+
+	ranked := rankLanguageStats(stats, loadLanguageTieBreak(absPath))
+	if len(ranked) == 0 {
+		return LanguageEvidenceSummary{DetectedLanguage: detectedLanguage, Confidence: 0.0, ReasonCodes: []string{"STATS_UNAVAILABLE"}}
+	}
+
+	winner := ranked[0]
+	if detectedLanguage == "" {
+		detectedLanguage = winner.Language
+	}
+
+	reasons := []string{"SCORING_ORDER_RESOLVED"}
+	confidence := 1.0
+	if len(ranked) > 1 {
+		runner := ranked[1]
+		if winner.ProductScore > runner.ProductScore {
+			reasons = append(reasons, "PRODUCT_SCORE_ADVANTAGE")
+		}
+		if winner.Score > runner.Score {
+			reasons = append(reasons, "WEIGHTED_SCORE_ADVANTAGE")
+		}
+		if winner.Lines > runner.Lines {
+			reasons = append(reasons, "LINE_COUNT_ADVANTAGE")
+		}
+		if winner.Count > runner.Count {
+			reasons = append(reasons, "FILE_COUNT_ADVANTAGE")
+		}
+
+		top := winner.ProductScore + winner.Score
+		second := runner.ProductScore + runner.Score
+		if top+second > 0 {
+			confidence = top / (top + second)
+		}
+	}
+
+	if confidence < 0 {
+		confidence = 0
+	}
+	if confidence > 1 {
+		confidence = 1
+	}
+	confidence = math.Round(confidence*1000) / 1000
+
+	return LanguageEvidenceSummary{
+		DetectedLanguage: detectedLanguage,
+		Confidence:       confidence,
+		ReasonCodes:      reasons,
+	}
+}
+
+func collectLanguageStats(absPath string) ([]languages.LanguageStat, error) {
+	ignoreStrategy := domain.NewDefaultIgnoreStrategy(domain.DefaultIgnoredDirs)
+	policy := languages.DetectionPolicy{}
+	config := loadConfiguration(absPath, false)
+	if config != nil && config.LanguageDetection != nil {
+		policy.LanguageWeights = config.LanguageDetection.Weights
+		policy.TieBreakOrder = config.LanguageDetection.TieBreakOrder
+		policy.SegmentWeights = config.LanguageDetection.SegmentWeights
+	}
+
+	detector := languages.NewRepositoryLanguageDetectorWithPolicy(ignoreStrategy, policy)
+	detector.RegisterAdapter(languages.NewGoAdapter())
+	detector.RegisterAdapter(languages.NewPythonAdapter())
+	detector.RegisterAdapter(languages.NewJavaScriptAdapter())
+	detector.RegisterAdapter(languages.NewTypeScriptAdapter())
+
+	return detector.GetLanguageStats(absPath)
+}
+
+func loadLanguageTieBreak(absPath string) []string {
+	config := loadConfiguration(absPath, false)
+	if config != nil && config.LanguageDetection != nil && len(config.LanguageDetection.TieBreakOrder) > 0 {
+		return append([]string(nil), config.LanguageDetection.TieBreakOrder...)
+	}
+	return []string{"Python", "TypeScript", "JavaScript", "Go"}
+}
+
+func rankLanguageStats(stats []languages.LanguageStat, tieBreak []string) []languages.LanguageStat {
+	ranked := append([]languages.LanguageStat(nil), stats...)
+	priority := make(map[string]int, len(tieBreak))
+	for i, lang := range tieBreak {
+		priority[lang] = i
+	}
+
+	sort.SliceStable(ranked, func(i, j int) bool {
+		left := ranked[i]
+		right := ranked[j]
+		if left.ProductScore != right.ProductScore {
+			return left.ProductScore > right.ProductScore
+		}
+		if left.Score != right.Score {
+			return left.Score > right.Score
+		}
+		if left.Lines != right.Lines {
+			return left.Lines > right.Lines
+		}
+		if left.Count != right.Count {
+			return left.Count > right.Count
+		}
+		lp, lok := priority[left.Language]
+		rp, rok := priority[right.Language]
+		if lok && rok && lp != rp {
+			return lp < rp
+		}
+		return left.Language < right.Language
+	})
+
+	return ranked
+}

--- a/analysis_language_evidence_test.go
+++ b/analysis_language_evidence_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+
+	"RepoDoctor/internal/languages"
+)
+
+func TestRankLanguageStats_DeterministicAndReasonableOrder(t *testing.T) {
+	stats := []languages.LanguageStat{
+		{Language: "Go", ProductScore: 10, Score: 22, Lines: 100, Count: 5},
+		{Language: "Python", ProductScore: 11, Score: 21, Lines: 99, Count: 4},
+		{Language: "TypeScript", ProductScore: 8, Score: 30, Lines: 120, Count: 6},
+	}
+
+	ranked := rankLanguageStats(stats, []string{"Python", "TypeScript", "JavaScript", "Go"})
+	if len(ranked) != 3 {
+		t.Fatalf("expected 3 ranked stats, got %d", len(ranked))
+	}
+	if ranked[0].Language != "Python" {
+		t.Fatalf("expected python to win by product score, got %s", ranked[0].Language)
+	}
+}
+
+func TestCollectLanguageEvidenceSummary_UnknownPathFailsSoft(t *testing.T) {
+	summary := collectLanguageEvidenceSummary("/path/does/not/exist", "Go")
+	if summary.DetectedLanguage != "Go" {
+		t.Fatalf("expected fallback detected language Go, got %s", summary.DetectedLanguage)
+	}
+	if len(summary.ReasonCodes) == 0 {
+		t.Fatal("expected non-empty reason codes on fail-soft summary")
+	}
+}

--- a/analysis_service.go
+++ b/analysis_service.go
@@ -65,6 +65,7 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	progress.SetProgress(progress.totalSteps / 2)
 
 	report := generateRuleEngineReport(absPath, request.Format, request.Verbose, request.ColorEnabled, config, ruleSummary)
+	report.Language = collectLanguageEvidenceSummary(absPath, analysisResult.AdapterName)
 	progress.SetProgress(progress.totalSteps)
 	progress.Complete()
 

--- a/reporter.go
+++ b/reporter.go
@@ -56,8 +56,9 @@ type ReportSummary struct {
 }
 
 type LanguageEvidenceSummary struct {
-	DetectedLanguage string  `json:"detectedLanguage"`
-	Confidence       float64 `json:"confidence"`
+	DetectedLanguage string   `json:"detectedLanguage"`
+	Confidence       float64  `json:"confidence"`
+	ReasonCodes      []string `json:"reasonCodes,omitempty"`
 }
 
 // Reporter handles formatting and displaying structural analysis results
@@ -169,6 +170,7 @@ func (r *Reporter) formatJSON(report *StructuralReport) string {
 		"language": map[string]interface{}{
 			"detectedLanguage": report.Language.DetectedLanguage,
 			"confidence":       report.Language.Confidence,
+			"reasonCodes":      append([]string(nil), report.Language.ReasonCodes...),
 		},
 		"circularViolations":  sortedCircular(report.Circular),
 		"layerViolations":     sortedLayer(report.Layer),

--- a/reporter_json_test.go
+++ b/reporter_json_test.go
@@ -17,7 +17,7 @@ func TestReporter_JSONV2_ContainsSchemaAndSummary(t *testing.T) {
 			TotalScore: 95, MaxScore: 100,
 		},
 		Summary:  ReportSummary{TotalViolations: 1, Circular: 0, Layer: 0, Size: 1, GodObject: 0},
-		Language: LanguageEvidenceSummary{DetectedLanguage: "Go", Confidence: 0.99},
+		Language: LanguageEvidenceSummary{DetectedLanguage: "Go", Confidence: 0.99, ReasonCodes: []string{"SCORING_ORDER_RESOLVED"}},
 	}
 
 	jsonOut := reporter.Format(report)
@@ -29,6 +29,9 @@ func TestReporter_JSONV2_ContainsSchemaAndSummary(t *testing.T) {
 	}
 	if !strings.Contains(jsonOut, "\"language\"") {
 		t.Fatalf("expected language section in output: %s", jsonOut)
+	}
+	if !strings.Contains(jsonOut, "\"reasonCodes\"") {
+		t.Fatalf("expected reasonCodes in output: %s", jsonOut)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add language evidence summary generation with deterministic ranking and reason codes
- populate report language section with detected language confidence and reason codes
- add tests for ranking determinism and fail-soft evidence fallback

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #138