### PR TITLE
[S04][RD-113] Unify multi-language context assembly path

### DIFF
--- a/runtime_context_builder.go
+++ b/runtime_context_builder.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"sort"
+
+	"RepoDoctor/internal/rules"
+)
+
+type runtimeAnalysisContextInput struct {
+	RepositoryPath  string
+	Graph           Graph
+	PrimaryLanguage string
+}
+
+func buildUnifiedRulesAnalysisContext(input runtimeAnalysisContextInput) rules.AnalysisContext {
+	repositoryFiles := buildContextRepositoryFiles(input.Graph)
+	languages := resolveContextLanguages(input.PrimaryLanguage)
+
+	return rules.AnalysisContext{
+		RepositoryFiles: repositoryFiles,
+		DependencyGraph: toRulesDependencyGraph(input.Graph),
+		Configuration:   rules.Configuration{"repositoryPath": input.RepositoryPath},
+		Languages:       languages,
+	}
+}
+
+func buildContextRepositoryFiles(graph Graph) []rules.RepositoryFile {
+	nodes := graph.GetAllNodes()
+	sort.Strings(nodes)
+
+	repositoryFiles := make([]rules.RepositoryFile, 0, len(nodes))
+	for _, node := range nodes {
+		repositoryFiles = append(repositoryFiles, readRepositoryFileForContext(graph, node))
+	}
+
+	return repositoryFiles
+}
+
+func resolveContextLanguages(primaryLanguage string) []string {
+	if primaryLanguage != "" {
+		return []string{primaryLanguage}
+	}
+	return []string{"Go", "Python", "JavaScript", "TypeScript"}
+}

--- a/runtime_context_builder_test.go
+++ b/runtime_context_builder_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildUnifiedRulesAnalysisContext_DeterministicNodesAndLanguages(t *testing.T) {
+	graph := NewDependencyGraph()
+	graph.AddNode("b.go")
+	graph.AddNode("a.go")
+	graph.AddEdge("a.go", "b.go")
+
+	ctx := buildUnifiedRulesAnalysisContext(runtimeAnalysisContextInput{
+		RepositoryPath:  filepath.Clean("."),
+		Graph:           graph,
+		PrimaryLanguage: "Python",
+	})
+
+	if len(ctx.RepositoryFiles) != 2 {
+		t.Fatalf("expected 2 repository files, got %d", len(ctx.RepositoryFiles))
+	}
+	if ctx.RepositoryFiles[0].Path != "a.go" || ctx.RepositoryFiles[1].Path != "b.go" {
+		t.Fatalf("expected deterministic sorted repository files, got %v, %v", ctx.RepositoryFiles[0].Path, ctx.RepositoryFiles[1].Path)
+	}
+	if len(ctx.Languages) != 1 || ctx.Languages[0] != "Python" {
+		t.Fatalf("expected primary language selection [Python], got %v", ctx.Languages)
+	}
+}

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -24,7 +24,11 @@ func runInternalRulePipeline(absPath string, graph Graph, primaryLanguage string
 	registry.MustRegister(rules.NewCircularDependencyRule(toRulesDependencyGraph(graph)))
 
 	executor := engine.NewRuleExecutor(registry)
-	context := buildRulesAnalysisContext(absPath, graph, primaryLanguage)
+	context := buildUnifiedRulesAnalysisContext(runtimeAnalysisContextInput{
+		RepositoryPath:  absPath,
+		Graph:           graph,
+		PrimaryLanguage: primaryLanguage,
+	})
 	result := executor.Execute(context)
 	sortViolations(result.Violations)
 
@@ -35,21 +39,34 @@ func runInternalRulePipeline(absPath string, graph Graph, primaryLanguage string
 }
 
 func buildRulesAnalysisContext(absPath string, graph Graph, primaryLanguage string) rules.AnalysisContext {
+	// Backward-compatible delegate retained for tests/legacy callers.
+	return buildUnifiedRulesAnalysisContext(runtimeAnalysisContextInput{
+		RepositoryPath:  absPath,
+		Graph:           graph,
+		PrimaryLanguage: primaryLanguage,
+	})
+}
+
+func readRepositoryFileForContext(graph Graph, node string) rules.RepositoryFile {
+	content := ""
+	if data, err := os.ReadFile(node); err == nil {
+		content = string(data)
+	}
+
+	return rules.RepositoryFile{
+		Path:    node,
+		Content: content,
+		Imports: graph.GetDependencies(node),
+	}
+}
+
+func legacyBuildRulesAnalysisContext(absPath string, graph Graph, primaryLanguage string) rules.AnalysisContext {
 	nodes := graph.GetAllNodes()
 	sort.Strings(nodes)
 
 	repoFiles := make([]rules.RepositoryFile, 0, len(nodes))
 	for _, node := range nodes {
-		content := ""
-		if data, err := os.ReadFile(node); err == nil {
-			content = string(data)
-		}
-
-		repoFiles = append(repoFiles, rules.RepositoryFile{
-			Path:    node,
-			Content: content,
-			Imports: graph.GetDependencies(node),
-		})
+		repoFiles = append(repoFiles, readRepositoryFileForContext(graph, node))
 	}
 
 	languages := []string{"Go", "Python", "JavaScript", "TypeScript"}


### PR DESCRIPTION
## Summary
- introduce unified runtime context builder for deterministic multi-language analysis context
- centralize repository file assembly and language selection
- keep backward-compatible delegate path while reducing orchestration duplication

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #144