### PR TITLE
[S05][RD-116] Add incremental cache key schema

### DIFF
--- a/internal/analysis/incremental_cache_key.go
+++ b/internal/analysis/incremental_cache_key.go
@@ -1,0 +1,57 @@
+package analysis
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type IncrementalCacheKeyInput struct {
+	AnalyzerVersion   string
+	RepositoryPath    string
+	ConfigFingerprint string
+}
+
+func BuildIncrementalCacheKey(input IncrementalCacheKeyInput) (string, error) {
+	version := strings.TrimSpace(input.AnalyzerVersion)
+	if version == "" {
+		return "", fmt.Errorf("analyzer version is required")
+	}
+
+	normalizedPath, err := normalizeCachePath(input.RepositoryPath)
+	if err != nil {
+		return "", err
+	}
+
+	configHash := strings.TrimSpace(input.ConfigFingerprint)
+	if configHash == "" {
+		configHash = HashConfigBytes(nil)
+	}
+
+	payload := strings.Join([]string{version, normalizedPath, configHash}, "|")
+	sum := sha256.Sum256([]byte(payload))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func HashConfigBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func normalizeCachePath(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("repository path is required")
+	}
+	absPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", fmt.Errorf("failed to normalize repository path: %w", err)
+	}
+	normalized := filepath.ToSlash(filepath.Clean(absPath))
+	if runtime.GOOS == "windows" {
+		normalized = strings.ToLower(normalized)
+	}
+	return normalized, nil
+}

--- a/internal/analysis/incremental_cache_key_test.go
+++ b/internal/analysis/incremental_cache_key_test.go
@@ -1,0 +1,53 @@
+package analysis
+
+import "testing"
+
+func TestBuildIncrementalCacheKey_Deterministic(t *testing.T) {
+	input := IncrementalCacheKeyInput{
+		AnalyzerVersion:   "0.14.0-dev",
+		RepositoryPath:    ".",
+		ConfigFingerprint: HashConfigBytes([]byte("a: 1")),
+	}
+
+	first, err := BuildIncrementalCacheKey(input)
+	if err != nil {
+		t.Fatalf("BuildIncrementalCacheKey failed: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		next, nextErr := BuildIncrementalCacheKey(input)
+		if nextErr != nil {
+			t.Fatalf("BuildIncrementalCacheKey failed on iteration %d: %v", i, nextErr)
+		}
+		if next != first {
+			t.Fatalf("cache key must be deterministic, got %s vs %s", first, next)
+		}
+	}
+}
+
+func TestBuildIncrementalCacheKey_ChangesWithVersionOrConfig(t *testing.T) {
+	base := IncrementalCacheKeyInput{AnalyzerVersion: "0.14.0-dev", RepositoryPath: ".", ConfigFingerprint: HashConfigBytes([]byte("a:1"))}
+	keyA, err := BuildIncrementalCacheKey(base)
+	if err != nil {
+		t.Fatalf("BuildIncrementalCacheKey failed: %v", err)
+	}
+
+	variantVersion := base
+	variantVersion.AnalyzerVersion = "0.14.1-dev"
+	keyB, err := BuildIncrementalCacheKey(variantVersion)
+	if err != nil {
+		t.Fatalf("BuildIncrementalCacheKey failed: %v", err)
+	}
+	if keyA == keyB {
+		t.Fatal("expected key to change when version changes")
+	}
+
+	variantConfig := base
+	variantConfig.ConfigFingerprint = HashConfigBytes([]byte("a:2"))
+	keyC, err := BuildIncrementalCacheKey(variantConfig)
+	if err != nil {
+		t.Fatalf("BuildIncrementalCacheKey failed: %v", err)
+	}
+	if keyA == keyC {
+		t.Fatal("expected key to change when config hash changes")
+	}
+}


### PR DESCRIPTION
## Summary
- introduce deterministic incremental cache key schema based on version + normalized path + config hash
- add config hash utility and cross-platform path normalization behavior
- add deterministic and variance tests for cache-key changes

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #150