### PR TITLE
[S05][RD-117] Add Go fingerprint invalidation map foundation

### DIFF
--- a/internal/analysis/incremental_fingerprint.go
+++ b/internal/analysis/incremental_fingerprint.go
@@ -1,0 +1,105 @@
+package analysis
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type FileFingerprint struct {
+	Path string
+	Hash string
+}
+
+type IncrementalFingerprintState struct {
+	Files map[string]string
+}
+
+func BuildGoFingerprintMap(repoPath string) (map[string]string, error) {
+	state := make(map[string]string)
+	err := filepath.WalkDir(repoPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.ToLower(filepath.Ext(path)) != ".go" {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		hash := sha256.Sum256(data)
+		state[filepath.Clean(path)] = hex.EncodeToString(hash[:])
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func DiffFingerprintStates(previous, current map[string]string) (changed, removed []string) {
+	changedSet := make(map[string]struct{})
+	removedSet := make(map[string]struct{})
+
+	for path, oldHash := range previous {
+		newHash, ok := current[path]
+		if !ok {
+			removedSet[path] = struct{}{}
+			continue
+		}
+		if newHash != oldHash {
+			changedSet[path] = struct{}{}
+		}
+	}
+
+	for path := range current {
+		if _, existed := previous[path]; !existed {
+			changedSet[path] = struct{}{}
+		}
+	}
+
+	changed = setToSortedSlice(changedSet)
+	removed = setToSortedSlice(removedSet)
+	return changed, removed
+}
+
+func setToSortedSlice(input map[string]struct{}) []string {
+	out := make([]string, 0, len(input))
+	for key := range input {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func MarshalFingerprintState(state map[string]string) IncrementalFingerprintState {
+	cloned := make(map[string]string, len(state))
+	for path, hash := range state {
+		cloned[path] = hash
+	}
+	return IncrementalFingerprintState{Files: cloned}
+}
+
+func ValidateFingerprintState(state IncrementalFingerprintState) error {
+	if state.Files == nil {
+		return fmt.Errorf("fingerprint state files map cannot be nil")
+	}
+	for path, hash := range state.Files {
+		if strings.TrimSpace(path) == "" || strings.TrimSpace(hash) == "" {
+			return fmt.Errorf("fingerprint state contains empty path/hash entry")
+		}
+	}
+	return nil
+}

--- a/internal/analysis/incremental_fingerprint_test.go
+++ b/internal/analysis/incremental_fingerprint_test.go
@@ -1,0 +1,55 @@
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildGoFingerprintMap_OnlyGoFiles(t *testing.T) {
+	repo := t.TempDir()
+	goPath := filepath.Join(repo, "a.go")
+	pyPath := filepath.Join(repo, "b.py")
+	if err := os.WriteFile(goPath, []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("failed writing go file: %v", err)
+	}
+	if err := os.WriteFile(pyPath, []byte("print('x')\n"), 0o644); err != nil {
+		t.Fatalf("failed writing py file: %v", err)
+	}
+
+	state, err := BuildGoFingerprintMap(repo)
+	if err != nil {
+		t.Fatalf("BuildGoFingerprintMap failed: %v", err)
+	}
+	if len(state) != 1 {
+		t.Fatalf("expected one go fingerprint entry, got %d", len(state))
+	}
+	if _, ok := state[filepath.Clean(goPath)]; !ok {
+		t.Fatalf("expected fingerprint for go file path %s", goPath)
+	}
+}
+
+func TestDiffFingerprintStates_DetectsChangedAddedRemoved(t *testing.T) {
+	prev := map[string]string{"a.go": "h1", "b.go": "h2"}
+	next := map[string]string{"a.go": "h1-new", "c.go": "h3"}
+
+	changed, removed := DiffFingerprintStates(prev, next)
+	if len(changed) != 2 {
+		t.Fatalf("expected changed set size 2, got %d (%v)", len(changed), changed)
+	}
+	if len(removed) != 1 || removed[0] != "b.go" {
+		t.Fatalf("expected removed [b.go], got %v", removed)
+	}
+}
+
+func TestValidateFingerprintState(t *testing.T) {
+	if err := ValidateFingerprintState(IncrementalFingerprintState{Files: nil}); err == nil {
+		t.Fatal("expected nil files map validation failure")
+	}
+	if err := ValidateFingerprintState(IncrementalFingerprintState{Files: map[string]string{"": "h"}}); err == nil {
+		t.Fatal("expected empty path validation failure")
+	}
+	if err := ValidateFingerprintState(IncrementalFingerprintState{Files: map[string]string{"a.go": "h"}}); err != nil {
+		t.Fatalf("expected valid state, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add Go file fingerprint map builder for incremental invalidation foundation
- add deterministic diff logic for changed/removed file sets
- add state validation and coverage tests

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #151