### PR TITLE
[S06][RD-120] Introduce shared architecture profile domain schema

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"RepoDoctor/internal/domain"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -182,8 +184,8 @@ func (l *ConfigLoader) validate(cfg *Config) error {
 	if cfg.Architecture != nil {
 		if strings.TrimSpace(cfg.Architecture.Profile) != "" {
 			profile := strings.TrimSpace(cfg.Architecture.Profile)
-			if !isValidArchitectureProfile(profile) {
-				return fmt.Errorf("architecture.profile must be one of: clean, layered, modular-monolith")
+			if _, err := domain.ParseArchitectureProfile(profile); err != nil {
+				return err
 			}
 		}
 	}
@@ -401,16 +403,6 @@ func rejectUnknownConfigKeys(data []byte) error {
 	}
 
 	return nil
-}
-
-func isValidArchitectureProfile(profile string) bool {
-	allowed := map[string]struct{}{
-		"clean":            {},
-		"layered":          {},
-		"modular-monolith": {},
-	}
-	_, ok := allowed[profile]
-	return ok
 }
 
 // GetConfigPath returns the default config path for a given directory

--- a/internal/domain/architecture_profile.go
+++ b/internal/domain/architecture_profile.go
@@ -1,0 +1,35 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ArchitectureProfile string
+
+const (
+	ArchitectureProfileClean           ArchitectureProfile = "clean"
+	ArchitectureProfileLayered         ArchitectureProfile = "layered"
+	ArchitectureProfileModularMonolith ArchitectureProfile = "modular-monolith"
+)
+
+func ParseArchitectureProfile(raw string) (ArchitectureProfile, error) {
+	normalized := strings.TrimSpace(strings.ToLower(raw))
+	if normalized == "" {
+		return ArchitectureProfileLayered, nil
+	}
+	profile := ArchitectureProfile(normalized)
+	if !profile.Valid() {
+		return "", fmt.Errorf("architecture.profile must be one of: clean, layered, modular-monolith")
+	}
+	return profile, nil
+}
+
+func (p ArchitectureProfile) Valid() bool {
+	switch p {
+	case ArchitectureProfileClean, ArchitectureProfileLayered, ArchitectureProfileModularMonolith:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/domain/architecture_profile_test.go
+++ b/internal/domain/architecture_profile_test.go
@@ -1,0 +1,36 @@
+package domain
+
+import "testing"
+
+func TestParseArchitectureProfile(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expected  ArchitectureProfile
+		wantError bool
+	}{
+		{name: "default empty -> layered", input: "", expected: ArchitectureProfileLayered},
+		{name: "clean", input: "clean", expected: ArchitectureProfileClean},
+		{name: "layered", input: "layered", expected: ArchitectureProfileLayered},
+		{name: "modular monolith", input: "modular-monolith", expected: ArchitectureProfileModularMonolith},
+		{name: "invalid", input: "hexagonal", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseArchitectureProfile(tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.expected {
+				t.Fatalf("expected %s, got %s", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add shared architecture profile domain model and parser (clean/layered/modular-monolith)
- route config validation through domain parser to centralize profile contract
- add domain-level tests for deterministic profile parsing behavior

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #158