### PR TITLE
[S06][RD-122] Align Python profile enforcement to shared schema

### DIFF
--- a/internal/rules/layer_validation_rule_profile_test.go
+++ b/internal/rules/layer_validation_rule_profile_test.go
@@ -39,3 +39,23 @@ func TestLayerValidationRule_ProfileLayeredIncludesReasonMarker(t *testing.T) {
 		t.Fatalf("expected profile marker in violation message, got %q", got)
 	}
 }
+
+func TestLayerValidationRule_PythonProfileAlignment(t *testing.T) {
+	rule := NewLayerValidationRule()
+	ctx := AnalysisContext{
+		Configuration: Configuration{"architectureProfile": "clean"},
+		RepositoryFiles: []RepositoryFile{{
+			Path:    "repo/repo/user_repo.py",
+			Imports: []string{"handler/user_handler.py"},
+		}},
+		Languages: []string{"Python"},
+	}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) == 0 {
+		t.Fatal("expected layer violation for clean profile in python context")
+	}
+	if !strings.Contains(violations[0].Message, "[profile:clean]") {
+		t.Fatalf("expected clean profile marker in violation message, got %q", violations[0].Message)
+	}
+}


### PR DESCRIPTION
## Summary
- add Python-context profile enforcement test coverage for shared architecture profile contract
- verify clean profile marker is emitted deterministically in layer violations
- ensure language-context alignment without rule branching

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #160