### PR TITLE
[S07][RD-124] Harden Go precision for module/package import patterns

### DIFF
--- a/internal/languages/go_adapter.go
+++ b/internal/languages/go_adapter.go
@@ -1,6 +1,7 @@
 package languages
 
 import (
+	"bufio"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -165,9 +166,10 @@ func goExtractStructMetrics(fset *token.FileSet, typeSpec *ast.TypeSpec, structT
 // BuildDependencyGraph constructs a dependency graph from Go imports
 func (a *GoAdapter) BuildDependencyGraph(files []string) (*model.DependencyGraph, error) {
 	graph := model.NewDependencyGraph()
+	modulePath := resolveGoModulePath(files)
 
 	for _, file := range files {
-		node, err := goParseFileAndAddToGraph(a.fset, file, graph)
+		node, err := goParseFileAndAddToGraph(a.fset, file, modulePath, graph)
 		if err != nil {
 			continue
 		}
@@ -185,7 +187,7 @@ func (a *GoAdapter) BuildDependencyGraph(files []string) (*model.DependencyGraph
 
 // goParseFileAndAddToGraph parses a Go file and adds it to the dependency graph.
 // Package-level helper to keep GoAdapter method count within SRP bounds.
-func goParseFileAndAddToGraph(fset *token.FileSet, path string, graph *model.DependencyGraph) (*model.Node, error) {
+func goParseFileAndAddToGraph(fset *token.FileSet, path, modulePath string, graph *model.DependencyGraph) (*model.Node, error) {
 	node, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
 	if err != nil {
 		return nil, err
@@ -208,10 +210,46 @@ func goParseFileAndAddToGraph(fset *token.FileSet, path string, graph *model.Dep
 		if graphNode.Metadata == nil {
 			graphNode.Metadata = make(map[string]string)
 		}
-		graphNode.Metadata["import_class:"+importPath] = string(classifyGoImport(importPath))
+		graphNode.Metadata["import_class:"+importPath] = string(classifyGoImportWithModule(importPath, modulePath))
 	}
 
 	return graphNode, nil
+}
+
+func resolveGoModulePath(files []string) string {
+	if len(files) == 0 {
+		return ""
+	}
+	start := filepath.Dir(files[0])
+	for {
+		goModPath := filepath.Join(start, "go.mod")
+		if module := readGoModuleName(goModPath); module != "" {
+			return module
+		}
+		parent := filepath.Dir(start)
+		if parent == start {
+			break
+		}
+		start = parent
+	}
+	return ""
+}
+
+func readGoModuleName(goModPath string) string {
+	file, err := os.Open(goModPath)
+	if err != nil {
+		return ""
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module "))
+		}
+	}
+	return ""
 }
 
 // IsStdlibPackage checks if a package is part of Go standard library

--- a/internal/languages/go_classification.go
+++ b/internal/languages/go_classification.go
@@ -12,6 +12,10 @@ const (
 )
 
 func classifyGoImport(importPath string) GoImportClass {
+	return classifyGoImportWithModule(importPath, "")
+}
+
+func classifyGoImportWithModule(importPath, modulePath string) GoImportClass {
 	normalized := strings.TrimSpace(importPath)
 	if normalized == "" {
 		return GoImportExternal
@@ -23,6 +27,13 @@ func classifyGoImport(importPath string) GoImportClass {
 
 	if strings.Contains(normalized, "/internal/") || strings.HasSuffix(normalized, "/internal") {
 		return GoImportInternal
+	}
+
+	modulePath = strings.TrimSpace(modulePath)
+	if modulePath != "" {
+		if normalized == modulePath || strings.HasPrefix(normalized, modulePath+"/") {
+			return GoImportInternal
+		}
 	}
 
 	return GoImportExternal

--- a/internal/languages/go_classification_test.go
+++ b/internal/languages/go_classification_test.go
@@ -27,13 +27,27 @@ func TestClassifyGoImport(t *testing.T) {
 	}
 }
 
+func TestClassifyGoImportWithModulePath(t *testing.T) {
+	if got := classifyGoImportWithModule("github.com/myorg/repo/pkg/domain", "github.com/myorg/repo"); got != GoImportInternal {
+		t.Fatalf("expected module-scoped import to be internal, got %s", got)
+	}
+	if got := classifyGoImportWithModule("github.com/other/repo/pkg", "github.com/myorg/repo"); got != GoImportExternal {
+		t.Fatalf("expected external import outside module, got %s", got)
+	}
+}
+
 func TestGoAdapter_BuildDependencyGraph_StoresImportClassificationMetadata(t *testing.T) {
 	repo := t.TempDir()
+	goMod := filepath.Join(repo, "go.mod")
+	if err := os.WriteFile(goMod, []byte("module github.com/myorg/repo\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("failed writing go.mod: %v", err)
+	}
 	path := filepath.Join(repo, "main.go")
 	content := `package main
 import (
   "fmt"
   "github.com/pkg/errors"
+  "github.com/myorg/repo/pkg/domain"
   "github.com/myorg/repo/internal/service"
 )
 func main() { _, _, _ = fmt.Println, errors.New, service.Run }
@@ -61,5 +75,8 @@ func main() { _, _, _ = fmt.Println, errors.New, service.Run }
 	}
 	if got := node.Metadata["import_class:github.com/myorg/repo/internal/service"]; got != string(GoImportInternal) {
 		t.Fatalf("expected internal classification for internal import, got %q", got)
+	}
+	if got := node.Metadata["import_class:github.com/myorg/repo/pkg/domain"]; got != string(GoImportInternal) {
+		t.Fatalf("expected module-path import to be internal, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- add module-aware Go import classification for improved precision
- classify module-local imports as internal when matching go.mod module path
- keep deterministic metadata classification and expand tests for module-scoped imports

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #166