### PR TITLE
[S07][RD-125] Improve Python dynamic import precision with unsupported markers

### DIFF
--- a/internal/languages/python_adapter.go
+++ b/internal/languages/python_adapter.go
@@ -314,6 +314,11 @@ func (a *PythonAdapter) CollectEvidence(repoPath string, files []string) ([]Evid
 
 		moduleRoot := detectPythonModuleRoot(root, normalizedPath)
 		for _, item := range evidence {
+			if item.unsupportedReason != "" {
+				warnings = append(warnings, fmt.Sprintf("python dynamic import unsupported: %s (%s)", item.unsupportedReason, normalizedPath))
+				continue
+			}
+
 			weight := 0.40
 			signalType := "python_import_absolute"
 			if item.relative {

--- a/internal/languages/python_adapter_test.go
+++ b/internal/languages/python_adapter_test.go
@@ -435,7 +435,35 @@ func TestParsePythonImportEvidence_IgnoresUnsafeDynamicRelative(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsePythonImportEvidence failed: %v", err)
 	}
-	if len(evidence) != 0 {
-		t.Fatalf("expected unsafe dynamic relative import to be ignored, got %v", evidence)
+	if len(evidence) != 1 {
+		t.Fatalf("expected one unsupported marker evidence, got %v", evidence)
+	}
+	if evidence[0].modulePath != "" {
+		t.Fatalf("expected unsupported dynamic import to not resolve module path, got %q", evidence[0].modulePath)
+	}
+	if evidence[0].unsupportedReason != "RELATIVE_DYNAMIC_IMPORT_UNSUPPORTED" {
+		t.Fatalf("expected unsupported reason marker, got %q", evidence[0].unsupportedReason)
+	}
+}
+
+func TestPythonAdapter_CollectEvidence_ReportsUnsupportedDynamicImportMarker(t *testing.T) {
+	repo := t.TempDir()
+	file := filepath.Join(repo, "dynamic.py")
+	content := "mod = importlib.import_module('.private')\n"
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	adapter := NewPythonAdapter()
+	signals, warnings, err := adapter.CollectEvidence(repo, []string{file})
+	if err != nil {
+		t.Fatalf("CollectEvidence failed: %v", err)
+	}
+	if len(signals) != 0 {
+		t.Fatalf("expected no evidence signals for unsupported dynamic import, got %v", signals)
+	}
+	joined := strings.Join(warnings, "|")
+	if !strings.Contains(joined, "RELATIVE_DYNAMIC_IMPORT_UNSUPPORTED") {
+		t.Fatalf("expected warning marker for unsupported dynamic import, got %v", warnings)
 	}
 }

--- a/internal/languages/python_evidence.go
+++ b/internal/languages/python_evidence.go
@@ -8,9 +8,10 @@ import (
 )
 
 type importEvidence struct {
-	modulePath string
-	relative   bool
-	level      int
+	modulePath        string
+	relative          bool
+	level             int
+	unsupportedReason string
 }
 
 func parsePythonImportEvidence(path string) ([]importEvidence, error) {
@@ -40,8 +41,8 @@ func parsePythonImportLine(raw string) []importEvidence {
 		return nil
 	}
 
-	if dynamic := parsePythonDynamicImport(line); dynamic != "" {
-		return []importEvidence{{modulePath: dynamic}}
+	if dynamic, reason := parsePythonDynamicImport(line); dynamic != "" || reason != "" {
+		return []importEvidence{{modulePath: dynamic, unsupportedReason: reason}}
 	}
 
 	if strings.HasPrefix(line, "import ") {
@@ -129,9 +130,9 @@ func parsePythonImportTargets(importPart string) []string {
 	return targets
 }
 
-func parsePythonDynamicImport(line string) string {
+func parsePythonDynamicImport(line string) (string, string) {
 	if !strings.Contains(line, "import_module(") && !strings.Contains(line, "__import__(") {
-		return ""
+		return "", ""
 	}
 
 	for _, prefix := range []string{"importlib.import_module", "__import__"} {
@@ -151,13 +152,19 @@ func parsePythonDynamicImport(line string) string {
 			}
 			candidate := strings.TrimSpace(args[start+1 : start+1+end])
 			if candidate == "" || strings.HasPrefix(candidate, ".") {
-				return ""
+				return "", "RELATIVE_DYNAMIC_IMPORT_UNSUPPORTED"
 			}
-			return candidate
+			return candidate, ""
 		}
+
+		if strings.Contains(args, "+") || strings.Contains(args, "%") || strings.Contains(args, "format(") {
+			return "", "DYNAMIC_IMPORT_EXPRESSION_UNSUPPORTED"
+		}
+
+		return "", "DYNAMIC_IMPORT_UNPARSEABLE"
 	}
 
-	return ""
+	return "", "DYNAMIC_IMPORT_UNPARSEABLE"
 }
 
 func detectPythonModuleRoot(repoRoot, filePath string) string {


### PR DESCRIPTION
## Summary
- add explicit unsupported markers for dynamic import patterns that cannot be resolved safely
- preserve fail-soft behavior while avoiding silent mis-inference
- surface unsupported dynamic import reason codes through evidence warnings

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #167