### PR TITLE
[S07][RD-126] Harden JS/TS path-mapping and scoped import precision

### DIFF
--- a/internal/languages/js_ts_adapter.go
+++ b/internal/languages/js_ts_adapter.go
@@ -218,6 +218,15 @@ func (a *jsTsAdapter) NormalizeImport(importPath string) string {
 		return ""
 	}
 	trimmed = strings.TrimPrefix(trimmed, "node:")
+	if strings.HasPrefix(trimmed, "@/") {
+		return "@/"
+	}
+	if strings.HasPrefix(trimmed, "~/") {
+		return "~/"
+	}
+	if strings.HasPrefix(trimmed, "#/") {
+		return "#/"
+	}
 	if strings.HasPrefix(trimmed, "./") || strings.HasPrefix(trimmed, "../") {
 		return strings.TrimSpace(trimmed)
 	}

--- a/internal/languages/js_ts_adapter_test.go
+++ b/internal/languages/js_ts_adapter_test.go
@@ -246,3 +246,23 @@ func TestJSTSAdapter_BuildDependencyGraph_ExportFromAndSafeRequireSubset(t *test
 		t.Fatalf("expected dynamic require subset to be ignored, got %v", node.Imports)
 	}
 }
+
+func TestJSTSAdapter_NormalizeImport_PathMappedAndScopedPrecision(t *testing.T) {
+	adapter := NewTypeScriptAdapter()
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{input: "@/components/button", expected: "@/"},
+		{input: "~/utils/date", expected: "~/"},
+		{input: "#/domain/user", expected: "#/"},
+		{input: "@scope/pkg/utils", expected: "@scope/pkg"},
+		{input: "node:fs", expected: "fs"},
+	}
+
+	for _, tt := range tests {
+		if got := adapter.NormalizeImport(tt.input); got != tt.expected {
+			t.Fatalf("NormalizeImport(%q) expected %q, got %q", tt.input, tt.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add explicit normalization for ts-path mapping prefixes (@/, ~/, #/)
- preserve scoped package precision for @scope/pkg imports
- add normalization tests for mapped/scoped and node: imports

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #168