### PR TITLE
[S07][RD-127] Add explainability v2 remediation hints

### DIFF
--- a/circular_rule.go
+++ b/circular_rule.go
@@ -4,6 +4,7 @@ package main
 type CycleViolation struct {
 	Path     []string
 	Severity string
+	Hint     string
 }
 
 // CircularDependencyRule detects circular dependencies in a graph

--- a/god_object_rule.go
+++ b/god_object_rule.go
@@ -15,6 +15,7 @@ type GodObjectViolation struct {
 	File        string
 	FieldCount  int
 	MethodCount int
+	Hint        string
 }
 
 // GodObjectRule detects structs that violate single responsibility principle

--- a/layer_rule.go
+++ b/layer_rule.go
@@ -5,6 +5,7 @@ type LayerViolation struct {
 	From    string
 	To      string
 	Message string
+	Hint    string
 }
 
 // LayerConvention represents the allowed dependency direction

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -126,9 +126,9 @@ func buildReportFromRuleViolations(path string, version string, cfg *Config, vio
 	for _, v := range violations {
 		switch v.RuleID {
 		case "rule.circular-dependency":
-			report.Circular = append(report.Circular, CycleViolation{Path: []string{v.File}, Severity: string(v.Severity)})
+			report.Circular = append(report.Circular, CycleViolation{Path: []string{v.File}, Severity: string(v.Severity), Hint: remediationHintForViolation(v)})
 		case "rule.layer-validation":
-			report.Layer = append(report.Layer, LayerViolation{From: v.File, To: "", Message: v.Message})
+			report.Layer = append(report.Layer, LayerViolation{From: v.File, To: "", Message: v.Message, Hint: remediationHintForViolation(v)})
 		case "rule.size":
 			report.Size = append(report.Size, parseSizeViolation(v))
 		case "rule.god-object":
@@ -163,7 +163,7 @@ var (
 // parseSizeViolation extracts Lines, Threshold, and Function from a size
 // violation message instead of using hardcoded placeholder values.
 func parseSizeViolation(v model.Violation) SizeViolation {
-	sv := SizeViolation{File: v.File}
+	sv := SizeViolation{File: v.File, Hint: remediationHintForViolation(v)}
 
 	// Try function-level match first (more specific)
 	if m := sizeFuncRe.FindStringSubmatch(v.Message); len(m) == 4 {
@@ -210,7 +210,23 @@ func mergeGodObjectViolation(m map[string]*GodObjectViolation, v model.Violation
 			File:        v.File,
 			FieldCount:  fieldCount,
 			MethodCount: methodCount,
+			Hint:        remediationHintForViolation(v),
 		}
+	}
+}
+
+func remediationHintForViolation(v model.Violation) string {
+	switch v.RuleID {
+	case "rule.circular-dependency":
+		return "Break the dependency cycle by moving shared contracts to a lower-level package and injecting dependencies inward."
+	case "rule.layer-validation":
+		return "Move the dependency to an allowed lower layer or introduce an interface boundary to preserve dependency direction."
+	case "rule.size":
+		return "Split oversized files/functions into focused units with one responsibility each."
+	case "rule.god-object":
+		return "Extract cohesive responsibilities into dedicated types and keep each object focused on one concern."
+	default:
+		return ""
 	}
 }
 

--- a/runtime_engine_remediation_test.go
+++ b/runtime_engine_remediation_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"RepoDoctor/internal/model"
+)
+
+func TestBuildReportFromRuleViolations_AttachesRemediationHints(t *testing.T) {
+	violations := []model.Violation{
+		{RuleID: "rule.layer-validation", File: "repo/repo.go", Severity: model.SeverityError, Message: "x"},
+		{RuleID: "rule.size", File: "a.go", Severity: model.SeverityWarning, Message: "Function 'big' has 101 lines (threshold: 80)"},
+		{RuleID: "rule.god-object", File: "obj.go", Severity: model.SeverityWarning, Message: "Manager has 12 methods (threshold: 10)"},
+	}
+
+	report := buildReportFromRuleViolations(".", "0.5.0-dev", nil, violations)
+	if len(report.Layer) == 0 || report.Layer[0].Hint == "" {
+		t.Fatal("expected layer violation hint to be populated")
+	}
+	if len(report.Size) == 0 || report.Size[0].Hint == "" {
+		t.Fatal("expected size violation hint to be populated")
+	}
+	if len(report.GodObject) == 0 || report.GodObject[0].Hint == "" {
+		t.Fatal("expected god object hint to be populated")
+	}
+}

--- a/size_rule.go
+++ b/size_rule.go
@@ -15,6 +15,7 @@ type SizeViolation struct {
 	Function  string
 	Lines     int
 	Threshold int
+	Hint      string
 }
 
 // SizeRule checks file and function size thresholds


### PR DESCRIPTION
## Summary
- add remediation hints for core violation taxonomy in report construction
- propagate actionable hints for layer/size/god-object/circular findings
- add tests validating hint attachment in generated structural reports

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #169