### PR TITLE
[S08][RD-128] Stabilize incremental cache schema boundary

### DIFF
--- a/internal/analysis/incremental_cache_store.go
+++ b/internal/analysis/incremental_cache_store.go
@@ -1,0 +1,57 @@
+package analysis
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const IncrementalCacheSchemaVersion = "v1"
+
+type IncrementalCacheSnapshot struct {
+	SchemaVersion string            `json:"schemaVersion"`
+	CacheKey      string            `json:"cacheKey"`
+	Fingerprints  map[string]string `json:"fingerprints"`
+}
+
+func NewIncrementalCacheSnapshot(cacheKey string, fingerprints map[string]string) IncrementalCacheSnapshot {
+	cloned := make(map[string]string, len(fingerprints))
+	for path, hash := range fingerprints {
+		cloned[path] = hash
+	}
+	return IncrementalCacheSnapshot{
+		SchemaVersion: IncrementalCacheSchemaVersion,
+		CacheKey:      cacheKey,
+		Fingerprints:  cloned,
+	}
+}
+
+func (s IncrementalCacheSnapshot) Validate() error {
+	if s.SchemaVersion != IncrementalCacheSchemaVersion {
+		return fmt.Errorf("unsupported incremental cache schema version: %s", s.SchemaVersion)
+	}
+	if s.CacheKey == "" {
+		return fmt.Errorf("incremental cache snapshot cacheKey cannot be empty")
+	}
+	if s.Fingerprints == nil {
+		return fmt.Errorf("incremental cache snapshot fingerprints cannot be nil")
+	}
+	return nil
+}
+
+func MarshalIncrementalCacheSnapshot(snapshot IncrementalCacheSnapshot) ([]byte, error) {
+	if err := snapshot.Validate(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(snapshot)
+}
+
+func UnmarshalIncrementalCacheSnapshot(data []byte) (IncrementalCacheSnapshot, error) {
+	var snapshot IncrementalCacheSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return IncrementalCacheSnapshot{}, err
+	}
+	if err := snapshot.Validate(); err != nil {
+		return IncrementalCacheSnapshot{}, err
+	}
+	return snapshot, nil
+}

--- a/internal/analysis/incremental_cache_store_test.go
+++ b/internal/analysis/incremental_cache_store_test.go
@@ -1,0 +1,29 @@
+package analysis
+
+import "testing"
+
+func TestIncrementalCacheSnapshot_MarshalRoundTrip(t *testing.T) {
+	s := NewIncrementalCacheSnapshot("cache-key", map[string]string{"a.go": "hash-a"})
+	data, err := MarshalIncrementalCacheSnapshot(s)
+	if err != nil {
+		t.Fatalf("MarshalIncrementalCacheSnapshot failed: %v", err)
+	}
+
+	roundTrip, err := UnmarshalIncrementalCacheSnapshot(data)
+	if err != nil {
+		t.Fatalf("UnmarshalIncrementalCacheSnapshot failed: %v", err)
+	}
+	if roundTrip.SchemaVersion != IncrementalCacheSchemaVersion {
+		t.Fatalf("expected schema version %s, got %s", IncrementalCacheSchemaVersion, roundTrip.SchemaVersion)
+	}
+	if roundTrip.CacheKey != "cache-key" {
+		t.Fatalf("expected cache key cache-key, got %s", roundTrip.CacheKey)
+	}
+}
+
+func TestIncrementalCacheSnapshot_RejectsUnsupportedVersion(t *testing.T) {
+	data := []byte(`{"schemaVersion":"v0","cacheKey":"k","fingerprints":{"a.go":"h"}}`)
+	if _, err := UnmarshalIncrementalCacheSnapshot(data); err == nil {
+		t.Fatal("expected unsupported version to fail")
+	}
+}


### PR DESCRIPTION
## Summary
- add versioned incremental cache snapshot schema for GA boundary stability
- add marshal/unmarshal validation path for cache snapshot persistence
- enforce schema-version compatibility and fail-fast invalid payload handling

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #174