### PR TITLE
[S08][RD-129] Harden Python reliability/performance evidence path

### DIFF
--- a/internal/languages/python_adapter_test.go
+++ b/internal/languages/python_adapter_test.go
@@ -467,3 +467,27 @@ func TestPythonAdapter_CollectEvidence_ReportsUnsupportedDynamicImportMarker(t *
 		t.Fatalf("expected warning marker for unsupported dynamic import, got %v", warnings)
 	}
 }
+
+func TestParsePythonImportEvidence_HardeningSkipsNulAndCapsLines(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "large.py")
+	var sb strings.Builder
+	for i := 0; i < maxPythonEvidenceLines+50; i++ {
+		sb.WriteString("import os\n")
+	}
+	sb.WriteString("\x00from bad import x\n")
+	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
+		t.Fatalf("failed writing fixture: %v", err)
+	}
+
+	evidence, err := parsePythonImportEvidence(path)
+	if err != nil {
+		t.Fatalf("parsePythonImportEvidence failed: %v", err)
+	}
+	if len(evidence) == 0 {
+		t.Fatal("expected evidence entries from capped import lines")
+	}
+	if len(evidence) > maxPythonEvidenceLines {
+		t.Fatalf("expected evidence to be capped, got %d", len(evidence))
+	}
+}

--- a/internal/languages/python_evidence.go
+++ b/internal/languages/python_evidence.go
@@ -7,6 +7,11 @@ import (
 	"strings"
 )
 
+const (
+	maxPythonEvidenceLines      = 10000
+	maxPythonEvidenceLineBuffer = 256 * 1024
+)
+
 type importEvidence struct {
 	modulePath        string
 	relative          bool
@@ -23,8 +28,15 @@ func parsePythonImportEvidence(path string) ([]importEvidence, error) {
 
 	result := make([]importEvidence, 0)
 	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, maxPythonEvidenceLineBuffer)
+	linesRead := 0
 
 	for scanner.Scan() {
+		linesRead++
+		if linesRead > maxPythonEvidenceLines {
+			break
+		}
 		result = append(result, parsePythonImportLine(scanner.Text())...)
 	}
 
@@ -38,6 +50,9 @@ func parsePythonImportEvidence(path string) ([]importEvidence, error) {
 func parsePythonImportLine(raw string) []importEvidence {
 	line := strings.TrimSpace(raw)
 	if line == "" || strings.HasPrefix(line, "#") {
+		return nil
+	}
+	if strings.ContainsRune(line, '\x00') {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- add bounded scanner limits for Python import evidence parsing
- cap maximum lines processed for predictable cost on oversized sources
- ignore NUL-containing lines to avoid malformed/binary parsing noise

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #175