### PR TITLE
[S08][RD-130] Harden JS/TS reliability and scan bounds

### DIFF
--- a/internal/languages/js_ts_adapter.go
+++ b/internal/languages/js_ts_adapter.go
@@ -15,6 +15,7 @@ import (
 
 const maxMetadataBytes = 2 * 1024 * 1024
 const maxMetadataDepth = 8
+const maxJSTSImportEvidenceLines = 20000
 
 type metadataCacheEntry struct {
 	packageJSON bool
@@ -119,7 +120,10 @@ func (a *jsTsAdapter) BuildDependencyGraph(files []string) (*model.DependencyGra
 			continue
 		}
 		lines := strings.Split(string(content), "\n")
-		for _, line := range lines {
+		for i, line := range lines {
+			if i >= maxJSTSImportEvidenceLines {
+				break
+			}
 			collectJSImportLine(a, file, strings.TrimSpace(line), node, graph, requireRe, dynamicImportRe)
 		}
 	}
@@ -128,6 +132,9 @@ func (a *jsTsAdapter) BuildDependencyGraph(files []string) (*model.DependencyGra
 
 func collectJSImportLine(a *jsTsAdapter, file, trimmed string, node *model.Node, graph *model.DependencyGraph, requireRe, dynamicImportRe *regexp.Regexp) {
 	if strings.HasPrefix(trimmed, "//") {
+		return
+	}
+	if strings.ContainsRune(trimmed, '\x00') {
 		return
 	}
 

--- a/internal/languages/js_ts_adapter_test.go
+++ b/internal/languages/js_ts_adapter_test.go
@@ -266,3 +266,35 @@ func TestJSTSAdapter_NormalizeImport_PathMappedAndScopedPrecision(t *testing.T) 
 		}
 	}
 }
+
+func TestJSTSAdapter_BuildDependencyGraph_HardeningSkipsNulAndCapsLines(t *testing.T) {
+	repo := t.TempDir()
+	file := filepath.Join(repo, "large.ts")
+	var sb strings.Builder
+	for i := 0; i < maxJSTSImportEvidenceLines+100; i++ {
+		sb.WriteString("import x from 'react'\n")
+	}
+	sb.WriteString("\x00import y from 'broken'\n")
+
+	if err := os.WriteFile(file, []byte(sb.String()), 0o644); err != nil {
+		t.Fatalf("failed writing fixture: %v", err)
+	}
+
+	adapter := NewTypeScriptAdapter()
+	graph, err := adapter.BuildDependencyGraph([]string{file})
+	if err != nil {
+		t.Fatalf("BuildDependencyGraph failed: %v", err)
+	}
+	node := graph.GetNode(file)
+	if node == nil {
+		t.Fatalf("expected graph node for %s", file)
+	}
+	if len(node.Imports) > maxJSTSImportEvidenceLines+1 {
+		t.Fatalf("expected imports to be capped, got %d", len(node.Imports))
+	}
+	for _, imp := range node.Imports {
+		if strings.Contains(imp, "broken") {
+			t.Fatalf("expected nul-tainted import to be skipped, got %v", node.Imports)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- cap JS/TS import scanning line budget for predictable large-file behavior
- skip NUL-tainted lines to avoid malformed/binary parsing noise
- add hardening tests for capped scans and malformed-line filtering

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #176