### PR TITLE
[S08][RD-131] Add cross-OS release determinism CI matrix

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   repodoctor:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     
     steps:
       - name: Checkout code
@@ -36,16 +40,16 @@ jobs:
         run: go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
 
       - name: Run RepoDoctor analysis
-        run: ./RepoDoctor analyze -path . -format text
+        run: go run . analyze -path . -format text
 
       - name: Run RepoDoctor analysis (JSON output)
-        run: ./RepoDoctor analyze -path . -format json -verbose || true
+        run: go run . analyze -path . -format json -verbose || true
         if: always()
 
       - name: Upload analysis results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: repodoctor-report
+          name: repodoctor-report-${{ matrix.os }}
           path: repodoctor-report.json
           retention-days: 30


### PR DESCRIPTION
## Summary
- expand repodoctor workflow to run on ubuntu and windows runners
- execute analysis via go run for shell/path portability
- publish per-OS report artifacts for determinism traceability

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #177