### PR TITLE
[S08][RD-132] Add release compatibility schema audit coverage

### DIFF
--- a/release_compatibility_audit_test.go
+++ b/release_compatibility_audit_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestReleaseCompatibility_JSONSchemaRequiredFields(t *testing.T) {
+	report := &StructuralReport{
+		Version:       "0.17.0",
+		SchemaVersion: "v2",
+		Path:          "repo",
+		Score:         &StructuralScore{TotalScore: 100, MaxScore: 100},
+		Summary:       ReportSummary{TotalViolations: 0},
+		Language:      LanguageEvidenceSummary{DetectedLanguage: "Go", Confidence: 0.99, ReasonCodes: []string{"SCORING_ORDER_RESOLVED"}},
+	}
+
+	jsonText := NewReporter(FormatJSON).Format(report)
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(jsonText), &payload); err != nil {
+		t.Fatalf("failed to parse formatted JSON: %v", err)
+	}
+
+	mustHave := []string{"version", "schemaVersion", "path", "score", "summary", "language", "circularViolations", "layerViolations", "sizeViolations", "godObjectViolations"}
+	for _, key := range mustHave {
+		if _, ok := payload[key]; !ok {
+			t.Fatalf("expected required root key %q in payload", key)
+		}
+	}
+
+	language, ok := payload["language"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected language object, got %T", payload["language"])
+	}
+	if _, ok := language["detectedLanguage"]; !ok {
+		t.Fatal("expected detectedLanguage in language section")
+	}
+	if _, ok := language["confidence"]; !ok {
+		t.Fatal("expected confidence in language section")
+	}
+}


### PR DESCRIPTION
## Summary
- add JSON schema compatibility audit test for release contract keys
- validate language and violations sections remain backward-safe in v2 payloads
- lock release compatibility expectations with deterministic payload assertions

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #178