### PR TITLE
[S08][RD-133] Burn down critical output-index formatting defects

### DIFF
--- a/circular_rule.go
+++ b/circular_rule.go
@@ -1,5 +1,7 @@
 package main
 
+import "strconv"
+
 // CycleViolation represents a circular dependency violation
 type CycleViolation struct {
 	Path     []string
@@ -82,5 +84,5 @@ func formatCycle(index int, path []string) string {
 		cyclePath += " → " + path[0]
 	}
 
-	return "[" + string(rune(index)) + "] " + cyclePath + "\n"
+	return "[" + strconv.Itoa(index) + "] " + cyclePath + "\n"
 }

--- a/circular_rule_test.go
+++ b/circular_rule_test.go
@@ -1,0 +1,10 @@
+package main
+
+import "testing"
+
+func TestFormatCycle_UsesDecimalIndex(t *testing.T) {
+	formatted := formatCycle(12, []string{"a", "b"})
+	if formatted[:4] != "[12]" {
+		t.Fatalf("expected decimal index prefix [12], got %q", formatted)
+	}
+}

--- a/layer_rule.go
+++ b/layer_rule.go
@@ -1,5 +1,7 @@
 package main
 
+import "strconv"
+
 // LayerViolation represents a layer constraint violation
 type LayerViolation struct {
 	From    string
@@ -88,7 +90,7 @@ func (r *LayerValidationRule) Message() string {
 
 	msg := "Layer violations found:\n"
 	for i, v := range r.violations {
-		msg += "[" + string(rune(i+48)) + "] " + v.Message + "\n"
+		msg += "[" + strconv.Itoa(i+1) + "] " + v.Message + "\n"
 	}
 
 	return msg

--- a/layer_rule_test.go
+++ b/layer_rule_test.go
@@ -1,0 +1,22 @@
+package main
+
+import "testing"
+
+func TestLayerValidationRule_Message_UsesDecimalIndices(t *testing.T) {
+	rule := &LayerValidationRule{
+		violations: []LayerViolation{{Message: "v1"}, {Message: "v2"}, {Message: "v3"}},
+	}
+	msg := rule.Message()
+	if !(contains(msg, "[1]") && contains(msg, "[2]") && contains(msg, "[3]")) {
+		t.Fatalf("expected decimal violation indices in message, got %q", msg)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- fix cycle formatting to use decimal index conversion instead of rune conversion
- fix layer violation summary indexing to use deterministic numeric labels
- add tests to lock index formatting behavior

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #179