### PR TITLE
[S08][RD-134] Publish v0.17 maturity report

### DIFF
--- a/RELEASE_MATURITY_v0.17.md
+++ b/RELEASE_MATURITY_v0.17.md
@@ -1,0 +1,49 @@
+# RepoDoctor v0.17 Maturity Report
+
+## Release Summary
+
+v0.17 finalizes the roadmap sequence from Sprint-1 to Sprint-8 with cross-language reliability, determinism, and compatibility safeguards.
+
+## Scorecard
+
+- Structural self-analysis: **100.0 / 100.0**
+- Local gates:
+  - `go test ./...` pass
+  - `go vet ./...` pass
+  - `go run . analyze -path .` pass
+- CI gates:
+  - Linux + Windows matrix pass (`repodoctor` workflow)
+
+## Precision Improvements
+
+- Go module-aware import classification (stdlib/internal/third-party precision uplift)
+- Python dynamic import unsupported markers to prevent silent mis-inference
+- JS/TS path-map/scoped import normalization hardening
+
+## Reliability / Performance Foundations
+
+- Incremental cache key schema and snapshot contract versioning
+- Go fingerprint/invalidation map baseline
+- Incremental-vs-cold correctness parity suite
+- Large fixture benchmark pack for trend tracking
+
+## Explainability Improvements
+
+- Language evidence reason codes and confidence values in JSON report language section
+- Profile-aware rule markers (`[profile:<name>]`) for architecture policy context
+- Remediation hints attached for core violation families
+
+## Compatibility and Determinism
+
+- Release JSON schema compatibility audit tests
+- Cross-OS determinism matrix in CI (ubuntu-latest, windows-latest)
+- Deterministic ordering maintained in rule and adapter pipelines
+
+## Known Boundaries (Intentional)
+
+- Dynamic import analysis is fail-soft for unsupported expression forms.
+- Incremental infrastructure is stabilized at the contract layer; full GA runtime orchestration can iterate without schema break.
+
+## Final Verdict
+
+RepoDoctor v0.17 is release-ready for roadmap scope, with deterministic outputs, explicit compatibility checks, and architecture health held at 100/100.


### PR DESCRIPTION
## Summary
- add v0.17 maturity report documenting precision, reliability, determinism and compatibility outcomes
- include release scorecard and known boundary notes
- align report contents with implemented behavior and current gate results

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .  # 100/100

## Issue
- Closes #180