### PR TITLE
[v0.18][RD-1802] Unified deterministic ordering utilities

### DIFF
--- a/deterministic_ordering.go
+++ b/deterministic_ordering.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"RepoDoctor/internal/model"
+)
+
+func sortedStringCopy(in []string) []string {
+	result := append([]string(nil), in...)
+	sort.Strings(result)
+	return result
+}
+
+func stableSortedCopy[T any](in []T, less func(left, right T) bool) []T {
+	result := append([]T(nil), in...)
+	sort.SliceStable(result, func(i, j int) bool {
+		return less(result[i], result[j])
+	})
+	return result
+}
+
+func normalizeReportPathDeterministic(path string) string {
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	if wd, err := os.Getwd(); err == nil {
+		if rel, relErr := filepath.Rel(wd, cleaned); relErr == nil && !strings.HasPrefix(rel, "..") {
+			return filepath.ToSlash(rel)
+		}
+	}
+	return cleaned
+}
+
+func sortedCircularViolations(in []CycleViolation) []CycleViolation {
+	return stableSortedCopy(in, func(left, right CycleViolation) bool {
+		return strings.Join(left.Path, "/") < strings.Join(right.Path, "/")
+	})
+}
+
+func sortedLayerViolations(in []LayerViolation) []LayerViolation {
+	return stableSortedCopy(in, func(left, right LayerViolation) bool {
+		if left.From != right.From {
+			return left.From < right.From
+		}
+		if left.To != right.To {
+			return left.To < right.To
+		}
+		return left.Message < right.Message
+	})
+}
+
+func sortedSizeViolations(in []SizeViolation) []SizeViolation {
+	return stableSortedCopy(in, func(left, right SizeViolation) bool {
+		if left.File != right.File {
+			return left.File < right.File
+		}
+		if left.Function != right.Function {
+			return left.Function < right.Function
+		}
+		return left.Lines < right.Lines
+	})
+}
+
+func sortedGodObjectViolations(in []GodObjectViolation) []GodObjectViolation {
+	return stableSortedCopy(in, func(left, right GodObjectViolation) bool {
+		if left.File != right.File {
+			return left.File < right.File
+		}
+		return left.StructName < right.StructName
+	})
+}
+
+func sortModelViolationsDeterministic(violations []model.Violation) {
+	sort.SliceStable(violations, func(i, j int) bool {
+		if violations[i].RuleID != violations[j].RuleID {
+			return violations[i].RuleID < violations[j].RuleID
+		}
+		if violations[i].File != violations[j].File {
+			return violations[i].File < violations[j].File
+		}
+		if violations[i].Line != violations[j].Line {
+			return violations[i].Line < violations[j].Line
+		}
+		return violations[i].Message < violations[j].Message
+	})
+}

--- a/deterministic_ordering_test.go
+++ b/deterministic_ordering_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"RepoDoctor/internal/model"
+)
+
+func TestSortedStringCopy_DoesNotMutateInput(t *testing.T) {
+	input := []string{"c", "a", "b"}
+	got := sortedStringCopy(input)
+
+	if got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Fatalf("expected sorted copy [a b c], got %v", got)
+	}
+
+	if input[0] != "c" || input[1] != "a" || input[2] != "b" {
+		t.Fatalf("expected input slice to stay unchanged, got %v", input)
+	}
+}
+
+func TestSortModelViolationsDeterministic_Order(t *testing.T) {
+	violations := []model.Violation{
+		{RuleID: "rule.size", File: "b.go", Line: 12, Message: "z"},
+		{RuleID: "rule.god-object", File: "a.go", Line: 1, Message: "a"},
+		{RuleID: "rule.size", File: "a.go", Line: 2, Message: "b"},
+		{RuleID: "rule.size", File: "a.go", Line: 1, Message: "c"},
+	}
+
+	sortModelViolationsDeterministic(violations)
+
+	if violations[0].RuleID != "rule.god-object" || violations[1].Line != 1 || violations[2].Line != 2 || violations[3].File != "b.go" {
+		t.Fatalf("unexpected deterministic violation order: %+v", violations)
+	}
+}
+
+func TestNormalizeReportPathDeterministic_SlashNormalization(t *testing.T) {
+	path := filepath.Join(".", "demo", "repo")
+	got := normalizeReportPathDeterministic(path)
+	if got != "demo/repo" {
+		t.Fatalf("expected normalized slash path demo/repo, got %s", got)
+	}
+}

--- a/reporter.go
+++ b/reporter.go
@@ -3,9 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
-	"sort"
 	"strings"
 )
 
@@ -147,7 +144,7 @@ func formatCyclePath(path []string) string {
 
 // formatJSON formats the report as JSON
 func (r *Reporter) formatJSON(report *StructuralReport) string {
-	relPath := normalizeReportPath(report.Path)
+	relPath := normalizeReportPathDeterministic(report.Path)
 	payload := map[string]interface{}{
 		"version":       report.Version,
 		"schemaVersion": report.SchemaVersion,
@@ -172,10 +169,10 @@ func (r *Reporter) formatJSON(report *StructuralReport) string {
 			"confidence":       report.Language.Confidence,
 			"reasonCodes":      append([]string(nil), report.Language.ReasonCodes...),
 		},
-		"circularViolations":  sortedCircular(report.Circular),
-		"layerViolations":     sortedLayer(report.Layer),
-		"sizeViolations":      sortedSize(report.Size),
-		"godObjectViolations": sortedGodObject(report.GodObject),
+		"circularViolations":  sortedCircularViolations(report.Circular),
+		"layerViolations":     sortedLayerViolations(report.Layer),
+		"sizeViolations":      sortedSizeViolations(report.Size),
+		"godObjectViolations": sortedGodObjectViolations(report.GodObject),
 	}
 	data, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
@@ -201,65 +198,6 @@ func (r *Reporter) formatJSONV1(report *StructuralReport) string {
 	sb.WriteString("}\n")
 
 	return sb.String()
-}
-
-func normalizeReportPath(path string) string {
-	cleaned := filepath.ToSlash(filepath.Clean(path))
-	if wd, err := os.Getwd(); err == nil {
-		if rel, relErr := filepath.Rel(wd, cleaned); relErr == nil && !strings.HasPrefix(rel, "..") {
-			return filepath.ToSlash(rel)
-		}
-	}
-	return cleaned
-}
-
-func sortedCircular(in []CycleViolation) []CycleViolation {
-	result := append([]CycleViolation(nil), in...)
-	sort.SliceStable(result, func(i, j int) bool {
-		left := strings.Join(result[i].Path, "/")
-		right := strings.Join(result[j].Path, "/")
-		return left < right
-	})
-	return result
-}
-
-func sortedLayer(in []LayerViolation) []LayerViolation {
-	result := append([]LayerViolation(nil), in...)
-	sort.SliceStable(result, func(i, j int) bool {
-		if result[i].From != result[j].From {
-			return result[i].From < result[j].From
-		}
-		if result[i].To != result[j].To {
-			return result[i].To < result[j].To
-		}
-		return result[i].Message < result[j].Message
-	})
-	return result
-}
-
-func sortedSize(in []SizeViolation) []SizeViolation {
-	result := append([]SizeViolation(nil), in...)
-	sort.SliceStable(result, func(i, j int) bool {
-		if result[i].File != result[j].File {
-			return result[i].File < result[j].File
-		}
-		if result[i].Function != result[j].Function {
-			return result[i].Function < result[j].Function
-		}
-		return result[i].Lines < result[j].Lines
-	})
-	return result
-}
-
-func sortedGodObject(in []GodObjectViolation) []GodObjectViolation {
-	result := append([]GodObjectViolation(nil), in...)
-	sort.SliceStable(result, func(i, j int) bool {
-		if result[i].File != result[j].File {
-			return result[i].File < result[j].File
-		}
-		return result[i].StructName < result[j].StructName
-	})
-	return result
 }
 
 // formatScoreSection formats the score section of JSON output

--- a/runtime_context_builder.go
+++ b/runtime_context_builder.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"sort"
-
 	"RepoDoctor/internal/rules"
 )
 
@@ -27,7 +25,7 @@ func buildUnifiedRulesAnalysisContext(input runtimeAnalysisContextInput) rules.A
 
 func buildContextRepositoryFiles(graph Graph) []rules.RepositoryFile {
 	nodes := graph.GetAllNodes()
-	sort.Strings(nodes)
+	nodes = sortedStringCopy(nodes)
 
 	repositoryFiles := make([]rules.RepositoryFile, 0, len(nodes))
 	for _, node := range nodes {

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -3,7 +3,6 @@ package main
 import (
 	"os"
 	"regexp"
-	"sort"
 	"strconv"
 
 	"RepoDoctor/internal/engine"
@@ -67,7 +66,7 @@ func readRepositoryFileForContext(graph Graph, node string) rules.RepositoryFile
 
 func legacyBuildRulesAnalysisContext(absPath string, graph Graph, primaryLanguage string) rules.AnalysisContext {
 	nodes := graph.GetAllNodes()
-	sort.Strings(nodes)
+	nodes = sortedStringCopy(nodes)
 
 	repoFiles := make([]rules.RepositoryFile, 0, len(nodes))
 	for _, node := range nodes {
@@ -89,12 +88,11 @@ func legacyBuildRulesAnalysisContext(absPath string, graph Graph, primaryLanguag
 
 func toRulesDependencyGraph(graph Graph) rules.DependencyGraph {
 	nodes := graph.GetAllNodes()
-	sort.Strings(nodes)
+	nodes = sortedStringCopy(nodes)
 	edges := make(map[string][]string, len(nodes))
 
 	for _, node := range nodes {
-		deps := append([]string(nil), graph.GetDependencies(node)...)
-		sort.Strings(deps)
+		deps := sortedStringCopy(graph.GetDependencies(node))
 		edges[node] = deps
 	}
 
@@ -102,18 +100,7 @@ func toRulesDependencyGraph(graph Graph) rules.DependencyGraph {
 }
 
 func sortViolations(violations []model.Violation) {
-	sort.Slice(violations, func(i, j int) bool {
-		if violations[i].RuleID != violations[j].RuleID {
-			return violations[i].RuleID < violations[j].RuleID
-		}
-		if violations[i].File != violations[j].File {
-			return violations[i].File < violations[j].File
-		}
-		if violations[i].Line != violations[j].Line {
-			return violations[i].Line < violations[j].Line
-		}
-		return violations[i].Message < violations[j].Message
-	})
+	sortModelViolationsDeterministic(violations)
 }
 
 func buildReportFromRuleViolations(path string, version string, cfg *Config, violations []model.Violation) *StructuralReport {


### PR DESCRIPTION
## Summary
- Introduces shared deterministic ordering utilities used by runtime orchestration and reporter output formatting.
- Replaces duplicated ad-hoc sorting logic in report serialization, rule-violation ordering, and graph context assembly.
- Adds focused utility tests for sorted-copy immutability, violation ordering, and normalized report path behavior.

## Checks
- go test ./...
- go vet ./...
- go run . analyze -path . (100/100)
- go test ./... -run \"TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns\"
- go test -race ./... (attempted; blocked locally due missing gcc/cgo toolchain)

## Architecture Impact
- Utilities are centralized in root orchestration/report layer (`main` package) with no adapter/rule boundary changes.
- Language adapters and rule engine remain language-agnostic and isolated.

Closes #191