### PR TITLE
[v0.18][RD-1804] Rule-context contract hardening

### DIFF
--- a/docs/report.md
+++ b/docs/report.md
@@ -1,0 +1,12 @@
+# RepoDoctor Version Report Tracker
+
+Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutulur.
+
+| Version | Milestone | Status | Notes |
+|---|---|---|---|
+| v0.17 | S8-v0.17 Near-Max Practical Maturity | Completed | Maturity report published (`docs/v0.17-maturity-report.md`). |
+| v0.18 | M0: v0.18 Contract Hardening | In Progress | RD-1801..RD-1803 merged, RD-1804+ backlog prepared. |
+| v0.19 | M1: v0.19 Incremental & Performance | Planned | Issues RD-1901..RD-1908 created. |
+| v0.20 | M2: v0.20 Java Pilot (Gated) | Planned | Issues RD-2001..RD-2007 created (default-off pilot). |
+| v1.0 | M3: v1.0 UX & Polish | Planned | Issues RD-10001..RD-10005 created. |
+| v1.1+ | M4: v1.1+ Scale (Use-case gated) | Planned | Issues RD-11001..RD-11003 created. |

--- a/internal/rules/analysis_context_contract_test.go
+++ b/internal/rules/analysis_context_contract_test.go
@@ -1,0 +1,41 @@
+package rules
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAnalysisContextContract_VersionLocked(t *testing.T) {
+	if AnalysisContextContractVersion != "v1" {
+		t.Fatalf("analysis context contract version drifted: got %q want %q", AnalysisContextContractVersion, "v1")
+	}
+}
+
+func TestAnalysisContextContract_ShapeLocked(t *testing.T) {
+	ctxType := reflect.TypeOf(AnalysisContext{})
+
+	expectedFields := []struct {
+		name string
+		typ  reflect.Type
+	}{
+		{name: "RepositoryFiles", typ: reflect.TypeOf([]RepositoryFile{})},
+		{name: "RepositoryMetrics", typ: reflect.TypeOf(RepositoryMetrics{})},
+		{name: "DependencyGraph", typ: reflect.TypeOf(DependencyGraph{})},
+		{name: "Configuration", typ: reflect.TypeOf(Configuration{})},
+		{name: "Languages", typ: reflect.TypeOf([]string{})},
+	}
+
+	if ctxType.NumField() != len(expectedFields) {
+		t.Fatalf("analysis context shape drifted: got %d fields want %d", ctxType.NumField(), len(expectedFields))
+	}
+
+	for index, expected := range expectedFields {
+		field := ctxType.Field(index)
+		if field.Name != expected.name {
+			t.Fatalf("analysis context field[%d] name drifted: got %q want %q", index, field.Name, expected.name)
+		}
+		if field.Type != expected.typ {
+			t.Fatalf("analysis context field[%d] type drifted: got %s want %s", index, field.Type, expected.typ)
+		}
+	}
+}

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -2,6 +2,10 @@ package rules
 
 import "RepoDoctor/internal/model"
 
+// AnalysisContextContractVersion identifies the stable shape contract for
+// AnalysisContext. Bump only when the public context layout changes.
+const AnalysisContextContractVersion = "v1"
+
 // AnalysisContext provides read-only access to repository data for rules.
 // It encapsulates all information needed for rule evaluation without
 // allowing mutation of the repository code.

--- a/runtime_context_builder_test.go
+++ b/runtime_context_builder_test.go
@@ -27,3 +27,31 @@ func TestBuildUnifiedRulesAnalysisContext_DeterministicNodesAndLanguages(t *test
 		t.Fatalf("expected primary language selection [Python], got %v", ctx.Languages)
 	}
 }
+
+func TestBuildUnifiedRulesAnalysisContext_ConfigurationContractKeys(t *testing.T) {
+	graph := NewDependencyGraph()
+	graph.AddNode("a.go")
+
+	ctx := buildUnifiedRulesAnalysisContext(runtimeAnalysisContextInput{
+		RepositoryPath:      filepath.Clean("."),
+		Graph:               graph,
+		PrimaryLanguage:     "Go",
+		ArchitectureProfile: "layered",
+	})
+
+	repositoryPath, ok := ctx.Configuration["repositoryPath"]
+	if !ok {
+		t.Fatalf("configuration key %q missing", "repositoryPath")
+	}
+	if repositoryPath != filepath.Clean(".") {
+		t.Fatalf("configuration key %q drifted: got %v want %v", "repositoryPath", repositoryPath, filepath.Clean("."))
+	}
+
+	architectureProfile, ok := ctx.Configuration["architectureProfile"]
+	if !ok {
+		t.Fatalf("configuration key %q missing", "architectureProfile")
+	}
+	if architectureProfile != "layered" {
+		t.Fatalf("configuration key %q drifted: got %v want %v", "architectureProfile", architectureProfile, "layered")
+	}
+}


### PR DESCRIPTION
## Summary
- lock `internal/rules.AnalysisContext` with explicit contract version constant and reflection-based shape test to fail fast on incompatible context changes
- add runtime context configuration key contract test (`repositoryPath`, `architectureProfile`) to prevent orchestration drift
- add `docs/report.md` as a version-tracking report index aligned with current roadmap state

## Architecture Impact
- no layer boundary change; hardening is test-first contract lock over existing rules/orchestration seam

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .
- TZ=UTC LC_ALL=C GOMAXPROCS=1 go test ./... -count=5 -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"

Closes #195