### PR TITLE
[v0.18][RD-1805] Output compatibility lock

### DIFF
--- a/reporter.go
+++ b/reporter.go
@@ -224,13 +224,14 @@ func formatViolationsSection(sb *strings.Builder, report *StructuralReport) {
 
 // formatCircularViolations formats circular dependency violations
 func (r *Reporter) formatCircularViolations(sb *strings.Builder, report *StructuralReport) {
+	circular := sortedCircularViolations(report.Circular)
 	sb.WriteString("  \"circularViolations\": [\n")
-	for i, v := range report.Circular {
+	for i, v := range circular {
 		sb.WriteString("    {\n")
 		sb.WriteString(fmt.Sprintf("      \"path\": %s,\n", formatStringArray(v.Path)))
 		sb.WriteString(fmt.Sprintf("      \"severity\": \"%s\"\n", v.Severity))
 		sb.WriteString("    }")
-		if i < len(report.Circular)-1 {
+		if i < len(circular)-1 {
 			sb.WriteString(",")
 		}
 		sb.WriteString("\n")
@@ -240,14 +241,15 @@ func (r *Reporter) formatCircularViolations(sb *strings.Builder, report *Structu
 
 // formatLayerViolations formats layer violations
 func (r *Reporter) formatLayerViolations(sb *strings.Builder, report *StructuralReport) {
+	layer := sortedLayerViolations(report.Layer)
 	sb.WriteString("  \"layerViolations\": [\n")
-	for i, v := range report.Layer {
+	for i, v := range layer {
 		sb.WriteString("    {\n")
 		sb.WriteString(fmt.Sprintf("      \"from\": \"%s\",\n", v.From))
 		sb.WriteString(fmt.Sprintf("      \"to\": \"%s\",\n", v.To))
 		sb.WriteString(fmt.Sprintf("      \"message\": \"%s\"\n", v.Message))
 		sb.WriteString("    }")
-		if i < len(report.Layer)-1 {
+		if i < len(layer)-1 {
 			sb.WriteString(",")
 		}
 		sb.WriteString("\n")
@@ -257,15 +259,16 @@ func (r *Reporter) formatLayerViolations(sb *strings.Builder, report *Structural
 
 // formatSizeViolations formats size violations
 func (r *Reporter) formatSizeViolations(sb *strings.Builder, report *StructuralReport) {
+	size := sortedSizeViolations(report.Size)
 	sb.WriteString("  \"sizeViolations\": [\n")
-	for i, v := range report.Size {
+	for i, v := range size {
 		sb.WriteString("    {\n")
 		sb.WriteString(fmt.Sprintf("      \"file\": \"%s\",\n", v.File))
 		sb.WriteString(fmt.Sprintf("      \"function\": \"%s\",\n", v.Function))
 		sb.WriteString(fmt.Sprintf("      \"lines\": %d,\n", v.Lines))
 		sb.WriteString(fmt.Sprintf("      \"threshold\": %d\n", v.Threshold))
 		sb.WriteString("    }")
-		if i < len(report.Size)-1 {
+		if i < len(size)-1 {
 			sb.WriteString(",")
 		}
 		sb.WriteString("\n")
@@ -275,15 +278,16 @@ func (r *Reporter) formatSizeViolations(sb *strings.Builder, report *StructuralR
 
 // formatGodObjectViolations formats god object violations
 func (r *Reporter) formatGodObjectViolations(sb *strings.Builder, report *StructuralReport) {
+	objects := sortedGodObjectViolations(report.GodObject)
 	sb.WriteString("  \"godObjectViolations\": [\n")
-	for i, v := range report.GodObject {
+	for i, v := range objects {
 		sb.WriteString("    {\n")
 		sb.WriteString(fmt.Sprintf("      \"struct\": \"%s\",\n", v.StructName))
 		sb.WriteString(fmt.Sprintf("      \"file\": \"%s\",\n", v.File))
 		sb.WriteString(fmt.Sprintf("      \"fields\": %d,\n", v.FieldCount))
-		sb.WriteString(fmt.Sprintf("      \"methods\": %d,\n", v.MethodCount))
+		sb.WriteString(fmt.Sprintf("      \"methods\": %d\n", v.MethodCount))
 		sb.WriteString("    }")
-		if i < len(report.GodObject)-1 {
+		if i < len(objects)-1 {
 			sb.WriteString(",")
 		}
 		sb.WriteString("\n")

--- a/reporter_json_test.go
+++ b/reporter_json_test.go
@@ -187,3 +187,85 @@ func TestReporter_JSON_EscapesUntrustedFields(t *testing.T) {
 		t.Fatalf("escaped output must still be valid json: %v", err)
 	}
 }
+
+func TestReporter_JSONV1_DeterministicAcrossInputOrdering(t *testing.T) {
+	reporter := NewReporter(FormatJSONV1)
+	build := func(circular []CycleViolation, layer []LayerViolation, size []SizeViolation, god []GodObjectViolation) *StructuralReport {
+		return &StructuralReport{
+			Version: "0.5.0-dev",
+			Path:    "repo",
+			Score: &StructuralScore{
+				TotalScore:       80,
+				MaxScore:         100,
+				CircularPenalty:  10,
+				LayerPenalty:     5,
+				SizePenalty:      3,
+				GodObjectPenalty: 2,
+				CircularCount:    len(circular),
+				LayerCount:       len(layer),
+				SizeCount:        len(size),
+				GodObjectCount:   len(god),
+			},
+			Circular:  circular,
+			Layer:     layer,
+			Size:      size,
+			GodObject: god,
+		}
+	}
+
+	first := build(
+		[]CycleViolation{{Path: []string{"pkg/z", "pkg/a"}, Severity: "critical"}, {Path: []string{"pkg/a", "pkg/b"}, Severity: "critical"}},
+		[]LayerViolation{{From: "infrastructure", To: "domain", Message: "x"}, {From: "application", To: "domain", Message: "a"}},
+		[]SizeViolation{{File: "z.go", Function: "b", Lines: 90, Threshold: 80}, {File: "a.go", Function: "a", Lines: 95, Threshold: 80}},
+		[]GodObjectViolation{{File: "z.go", StructName: "Z", FieldCount: 20, MethodCount: 11}, {File: "a.go", StructName: "A", FieldCount: 18, MethodCount: 12}},
+	)
+
+	second := build(
+		[]CycleViolation{{Path: []string{"pkg/a", "pkg/b"}, Severity: "critical"}, {Path: []string{"pkg/z", "pkg/a"}, Severity: "critical"}},
+		[]LayerViolation{{From: "application", To: "domain", Message: "a"}, {From: "infrastructure", To: "domain", Message: "x"}},
+		[]SizeViolation{{File: "a.go", Function: "a", Lines: 95, Threshold: 80}, {File: "z.go", Function: "b", Lines: 90, Threshold: 80}},
+		[]GodObjectViolation{{File: "a.go", StructName: "A", FieldCount: 18, MethodCount: 12}, {File: "z.go", StructName: "Z", FieldCount: 20, MethodCount: 11}},
+	)
+
+	outA := reporter.Format(first)
+	outB := reporter.Format(second)
+	if outA != outB {
+		t.Fatalf("json-v1 output must be deterministic regardless of input ordering\nA:\n%s\nB:\n%s", outA, outB)
+	}
+
+	if strings.Contains(outA, "schemaVersion") || strings.Contains(outA, "\"summary\"") || strings.Contains(outA, "\"language\"") {
+		t.Fatalf("json-v1 compatibility contract broken, unexpected v2 fields in output: %s", outA)
+	}
+}
+
+func TestReporter_JSONV1_WithViolations_StaysValidJSON(t *testing.T) {
+	reporter := NewReporter(FormatJSONV1)
+	report := &StructuralReport{
+		Version: "0.5.0-dev",
+		Path:    "repo",
+		Score: &StructuralScore{
+			TotalScore:       92,
+			MaxScore:         100,
+			CircularPenalty:  0,
+			LayerPenalty:     0,
+			SizePenalty:      3,
+			GodObjectPenalty: 5,
+			CircularCount:    0,
+			LayerCount:       0,
+			SizeCount:        1,
+			GodObjectCount:   1,
+		},
+		Size:      []SizeViolation{{File: "a.go", Function: "f", Lines: 90, Threshold: 80}},
+		GodObject: []GodObjectViolation{{File: "a.go", StructName: "Svc", FieldCount: 20, MethodCount: 11}},
+	}
+
+	out := reporter.Format(report)
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("json-v1 output must remain valid JSON: %v\noutput:\n%s", err, out)
+	}
+
+	if _, hasSchema := payload["schemaVersion"]; hasSchema {
+		t.Fatalf("json-v1 output must not include schemaVersion: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce deterministic ordering for JSON v1 violation arrays to prevent output drift from input traversal order
- add compatibility tests asserting JSON v1 remains schema-stable and valid with non-empty violations
- preserve legacy JSON v1 contract (no schemaVersion/summary/language fields)

## Validation
- go test ./...
- go vet ./...
- go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
- go run . analyze -path .

Closes #196