### PR TITLE
[v0.18][RD-1807] v0.18 close-out gate pack

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -41,8 +41,9 @@ jobs:
       - name: Run static checks
         run: go vet ./...
 
-      - name: Run non-Go integration confidence suites
-        run: go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
+      - name: Run v0.18 close-out gate pack
+        shell: pwsh
+        run: ./scripts/v018_closeout_gate.ps1
 
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text

--- a/scripts/v018_closeout_gate.ps1
+++ b/scripts/v018_closeout_gate.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    Write-Host "==> $Name"
+    Invoke-Expression $Command
+}
+
+$closeoutRegex = "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns|TestArchitecture_InternalDependencyBoundaries|TestArchitecture_HighRiskImportsForbiddenInModelAndDomain|TestArchitecture_PurityBoundary_NoSideEffectImportsInSensitivePackages|TestReleaseCompatibility_JSONSchemaRequiredFields|TestReporter_JSONV1_CompatibilitySwitch|TestReporter_JSONV1_GoldenParity|TestReporter_JSONV1_DeterministicAcrossInputOrdering|TestReporter_JSONV1_WithViolations_StaysValidJSON|TestReporter_JSONV2_ContainsSchemaAndSummary|TestReporter_JSONV2_GoldenStableOrderingAndSchema|TestNormalizePathWithinRoot_RejectsAbsoluteOutsidePath|TestNormalizePathWithinRoot_RejectsParentTraversalEscape|TestNormalizePathWithinRoot_AllowsPathInsideRoot|TestNormalizePathWithinRoot_RejectsSymlinkOutsideRoot|TestNormalizePathWithinRoot_SymlinkLoopFailsSoftWithoutEscape"
+
+Invoke-Step -Name "v0.18 close-out deterministic + boundary + compatibility + path-safety tests" -Command "go test ./... -run '$closeoutRegex'"
+Invoke-Step -Name "v0.18 close-out self analysis gate" -Command "go run . analyze -path ."
+
+Write-Host "v0.18 close-out gate pack passed."


### PR DESCRIPTION
## Summary
- add a single close-out gate entrypoint script for v0.18 checks
- include determinism, architecture boundary, compatibility, and path-safety test locks in one command
- wire CI to run the close-out gate pack to prevent regression drift in subsequent epics

## Validation
- go test ./...
- go vet ./...
- pwsh -File ./scripts/v018_closeout_gate.ps1
- go run . analyze -path .

Closes #198