### PR TITLE
[v0.19][RD-1901] Incremental boundary interface extraction

### DIFF
--- a/internal/analysis/incremental_boundary.go
+++ b/internal/analysis/incremental_boundary.go
@@ -1,0 +1,91 @@
+package analysis
+
+import "fmt"
+
+// IncrementalSnapshotStore isolates incremental cache persistence from orchestration.
+// Concrete storage implementations remain internal to the analysis layer.
+type IncrementalSnapshotStore interface {
+	Load(cacheKey string) (IncrementalCacheSnapshot, bool, error)
+	Save(snapshot IncrementalCacheSnapshot) error
+}
+
+// IncrementalFingerprintProvider isolates fingerprint collection/diff logic.
+type IncrementalFingerprintProvider interface {
+	Build(repoPath string) (map[string]string, error)
+	Diff(previous, current map[string]string) (changed []string, removed []string)
+}
+
+type GoIncrementalFingerprintProvider struct{}
+
+func (p GoIncrementalFingerprintProvider) Build(repoPath string) (map[string]string, error) {
+	return BuildGoFingerprintMap(repoPath)
+}
+
+func (p GoIncrementalFingerprintProvider) Diff(previous, current map[string]string) ([]string, []string) {
+	return DiffFingerprintStates(previous, current)
+}
+
+type IncrementalDelta struct {
+	Snapshot    IncrementalCacheSnapshot
+	Changed     []string
+	Removed     []string
+	CacheHit    bool
+	PreviousKey string
+}
+
+// IncrementalBoundaryService computes incremental deltas without leaking
+// storage implementation details outside internal/analysis.
+type IncrementalBoundaryService struct {
+	store    IncrementalSnapshotStore
+	provider IncrementalFingerprintProvider
+}
+
+func NewIncrementalBoundaryService(store IncrementalSnapshotStore, provider IncrementalFingerprintProvider) (*IncrementalBoundaryService, error) {
+	if store == nil {
+		return nil, fmt.Errorf("incremental snapshot store is required")
+	}
+	if provider == nil {
+		return nil, fmt.Errorf("incremental fingerprint provider is required")
+	}
+	return &IncrementalBoundaryService{store: store, provider: provider}, nil
+}
+
+func (s *IncrementalBoundaryService) Compute(repoPath, cacheKey string) (IncrementalDelta, error) {
+	if s == nil {
+		return IncrementalDelta{}, fmt.Errorf("incremental boundary service is required")
+	}
+	if cacheKey == "" {
+		return IncrementalDelta{}, fmt.Errorf("cache key is required")
+	}
+
+	fingerprints, err := s.provider.Build(repoPath)
+	if err != nil {
+		return IncrementalDelta{}, fmt.Errorf("build fingerprints: %w", err)
+	}
+	currentSnapshot := NewIncrementalCacheSnapshot(cacheKey, fingerprints)
+
+	previous, found, err := s.store.Load(cacheKey)
+	if err != nil {
+		return IncrementalDelta{}, fmt.Errorf("load incremental snapshot: %w", err)
+	}
+
+	changed := make([]string, 0)
+	removed := make([]string, 0)
+	previousKey := ""
+	if found {
+		changed, removed = s.provider.Diff(previous.Fingerprints, currentSnapshot.Fingerprints)
+		previousKey = previous.CacheKey
+	}
+
+	if err := s.store.Save(currentSnapshot); err != nil {
+		return IncrementalDelta{}, fmt.Errorf("save incremental snapshot: %w", err)
+	}
+
+	return IncrementalDelta{
+		Snapshot:    currentSnapshot,
+		Changed:     append([]string(nil), changed...),
+		Removed:     append([]string(nil), removed...),
+		CacheHit:    found,
+		PreviousKey: previousKey,
+	}, nil
+}

--- a/internal/analysis/incremental_boundary_test.go
+++ b/internal/analysis/incremental_boundary_test.go
@@ -1,0 +1,123 @@
+package analysis
+
+import (
+	"errors"
+	"testing"
+)
+
+type stubFingerprintProvider struct {
+	state map[string]string
+	err   error
+}
+
+func (s stubFingerprintProvider) Build(repoPath string) (map[string]string, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	result := make(map[string]string, len(s.state))
+	for path, hash := range s.state {
+		result[path] = hash
+	}
+	return result, nil
+}
+
+func (s stubFingerprintProvider) Diff(previous, current map[string]string) ([]string, []string) {
+	return DiffFingerprintStates(previous, current)
+}
+
+func TestIncrementalBoundaryService_RequiresDependencies(t *testing.T) {
+	_, err := NewIncrementalBoundaryService(nil, GoIncrementalFingerprintProvider{})
+	if err == nil {
+		t.Fatal("expected error for nil store")
+	}
+
+	store := NewInMemoryIncrementalSnapshotStore()
+	_, err = NewIncrementalBoundaryService(store, nil)
+	if err == nil {
+		t.Fatal("expected error for nil provider")
+	}
+}
+
+func TestIncrementalBoundaryService_FirstRunCacheMissThenHitWithDiff(t *testing.T) {
+	store := NewInMemoryIncrementalSnapshotStore()
+	service, err := NewIncrementalBoundaryService(store, stubFingerprintProvider{
+		state: map[string]string{"a.go": "h1", "b.go": "h2"},
+	})
+	if err != nil {
+		t.Fatalf("failed to create boundary service: %v", err)
+	}
+
+	first, err := service.Compute("/repo", "cache-key")
+	if err != nil {
+		t.Fatalf("first compute failed: %v", err)
+	}
+	if first.CacheHit {
+		t.Fatal("first compute should be cache miss")
+	}
+	if len(first.Changed) != 0 || len(first.Removed) != 0 {
+		t.Fatalf("first compute must not return stale diffs, changed=%v removed=%v", first.Changed, first.Removed)
+	}
+
+	service.provider = stubFingerprintProvider{state: map[string]string{"a.go": "h1-changed", "c.go": "h3"}}
+	second, err := service.Compute("/repo", "cache-key")
+	if err != nil {
+		t.Fatalf("second compute failed: %v", err)
+	}
+	if !second.CacheHit {
+		t.Fatal("second compute should be cache hit")
+	}
+
+	if len(second.Changed) != 2 {
+		t.Fatalf("expected two changed entries (a.go + c.go), got %v", second.Changed)
+	}
+	if second.Changed[0] != "a.go" || second.Changed[1] != "c.go" {
+		t.Fatalf("unexpected changed list ordering/content: %v", second.Changed)
+	}
+	if len(second.Removed) != 1 || second.Removed[0] != "b.go" {
+		t.Fatalf("unexpected removed list: %v", second.Removed)
+	}
+}
+
+func TestIncrementalBoundaryService_PropagatesBuildErrors(t *testing.T) {
+	store := NewInMemoryIncrementalSnapshotStore()
+	service, err := NewIncrementalBoundaryService(store, stubFingerprintProvider{err: errors.New("boom")})
+	if err != nil {
+		t.Fatalf("failed to create boundary service: %v", err)
+	}
+
+	if _, err := service.Compute("/repo", "cache-key"); err == nil {
+		t.Fatal("expected build error to be returned")
+	}
+}
+
+func TestInMemoryIncrementalSnapshotStore_ClonesOnSaveAndLoad(t *testing.T) {
+	store := NewInMemoryIncrementalSnapshotStore()
+	original := NewIncrementalCacheSnapshot("cache-key", map[string]string{"a.go": "h1"})
+	if err := store.Save(original); err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	original.Fingerprints["a.go"] = "tampered"
+	loaded, found, err := store.Load("cache-key")
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected stored snapshot to be found")
+	}
+	if loaded.Fingerprints["a.go"] != "h1" {
+		t.Fatalf("store must clone on save, got %s", loaded.Fingerprints["a.go"])
+	}
+
+	loaded.Fingerprints["a.go"] = "modified-after-load"
+	reloaded, found, err := store.Load("cache-key")
+	if err != nil {
+		t.Fatalf("reload failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected snapshot on reload")
+	}
+	if reloaded.Fingerprints["a.go"] != "h1" {
+		t.Fatalf("store must clone on load, got %s", reloaded.Fingerprints["a.go"])
+	}
+}

--- a/internal/analysis/incremental_store_memory.go
+++ b/internal/analysis/incremental_store_memory.go
@@ -1,0 +1,53 @@
+package analysis
+
+import "fmt"
+
+// InMemoryIncrementalSnapshotStore is a deterministic test-friendly store
+// implementation kept within analysis boundaries.
+type InMemoryIncrementalSnapshotStore struct {
+	snapshots map[string]IncrementalCacheSnapshot
+}
+
+func NewInMemoryIncrementalSnapshotStore() *InMemoryIncrementalSnapshotStore {
+	return &InMemoryIncrementalSnapshotStore{
+		snapshots: make(map[string]IncrementalCacheSnapshot),
+	}
+}
+
+func (s *InMemoryIncrementalSnapshotStore) Load(cacheKey string) (IncrementalCacheSnapshot, bool, error) {
+	if s == nil {
+		return IncrementalCacheSnapshot{}, false, fmt.Errorf("snapshot store is required")
+	}
+	if cacheKey == "" {
+		return IncrementalCacheSnapshot{}, false, fmt.Errorf("cache key is required")
+	}
+
+	snapshot, ok := s.snapshots[cacheKey]
+	if !ok {
+		return IncrementalCacheSnapshot{}, false, nil
+	}
+	return cloneSnapshot(snapshot), true, nil
+}
+
+func (s *InMemoryIncrementalSnapshotStore) Save(snapshot IncrementalCacheSnapshot) error {
+	if s == nil {
+		return fmt.Errorf("snapshot store is required")
+	}
+	if err := snapshot.Validate(); err != nil {
+		return err
+	}
+	s.snapshots[snapshot.CacheKey] = cloneSnapshot(snapshot)
+	return nil
+}
+
+func cloneSnapshot(snapshot IncrementalCacheSnapshot) IncrementalCacheSnapshot {
+	cloned := make(map[string]string, len(snapshot.Fingerprints))
+	for path, hash := range snapshot.Fingerprints {
+		cloned[path] = hash
+	}
+	return IncrementalCacheSnapshot{
+		SchemaVersion: snapshot.SchemaVersion,
+		CacheKey:      snapshot.CacheKey,
+		Fingerprints:  cloned,
+	}
+}


### PR DESCRIPTION
## Summary
- extract analysis-layer interfaces for incremental snapshot persistence and fingerprint provider boundaries
- add an in-memory snapshot store implementation that clones on save/load to prevent state leakage
- add boundary-service tests for cache hit/miss behavior, deterministic diffing, dependency validation, and error propagation

## Validation
- go test ./...
- go vet ./...
- go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
- go run . analyze -path .

Closes #200