### PR TITLE
[v0.19][RD-1903] Hot-path optimization + parallel parsing

### DIFF
--- a/internal/analysis/incremental_fingerprint.go
+++ b/internal/analysis/incremental_fingerprint.go
@@ -7,8 +7,10 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
 )
 
 type FileFingerprint struct {
@@ -33,7 +35,59 @@ type IncrementalDiffSummary struct {
 }
 
 func BuildGoFingerprintMap(repoPath string) (map[string]string, error) {
-	state := make(map[string]string)
+	goFiles, err := collectGoFiles(repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	state := make(map[string]string, len(goFiles))
+	if len(goFiles) == 0 {
+		return state, nil
+	}
+
+	workers := runtime.NumCPU()
+	if workers < 1 {
+		workers = 1
+	}
+	if workers > len(goFiles) {
+		workers = len(goFiles)
+	}
+
+	paths := make(chan string, len(goFiles))
+	results := make(chan FileFingerprint, len(goFiles))
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for path := range paths {
+				data, readErr := os.ReadFile(path)
+				if readErr != nil {
+					continue
+				}
+				hash := sha256.Sum256(data)
+				results <- FileFingerprint{Path: path, Hash: hex.EncodeToString(hash[:])}
+			}
+		}()
+	}
+
+	for _, path := range goFiles {
+		paths <- path
+	}
+	close(paths)
+	wg.Wait()
+	close(results)
+
+	for fp := range results {
+		state[fp.Path] = fp.Hash
+	}
+
+	return state, nil
+}
+
+func collectGoFiles(repoPath string) ([]string, error) {
+	goFiles := make([]string, 0, 256)
 	err := filepath.WalkDir(repoPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
@@ -47,18 +101,14 @@ func BuildGoFingerprintMap(repoPath string) (map[string]string, error) {
 		if strings.ToLower(filepath.Ext(path)) != ".go" {
 			return nil
 		}
-		data, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return nil
-		}
-		hash := sha256.Sum256(data)
-		state[filepath.Clean(path)] = hex.EncodeToString(hash[:])
+		goFiles = append(goFiles, filepath.Clean(path))
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return state, nil
+	sort.Strings(goFiles)
+	return goFiles, nil
 }
 
 func DiffFingerprintStates(previous, current map[string]string) (changed, removed []string) {

--- a/internal/analysis/incremental_fingerprint_test.go
+++ b/internal/analysis/incremental_fingerprint_test.go
@@ -3,6 +3,8 @@ package analysis
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -51,5 +53,34 @@ func TestValidateFingerprintState(t *testing.T) {
 	}
 	if err := ValidateFingerprintState(IncrementalFingerprintState{Files: map[string]string{"a.go": "h"}}); err != nil {
 		t.Fatalf("expected valid state, got %v", err)
+	}
+}
+
+func TestBuildGoFingerprintMap_DeterministicAcrossRuns(t *testing.T) {
+	repo := t.TempDir()
+	for i := 0; i < 40; i++ {
+		path := filepath.Join(repo, "pkg", "f"+strconv.Itoa(i)+".go")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("failed creating dir: %v", err)
+		}
+		content := []byte("package main\nfunc f" + strconv.Itoa(i) + "() int { return " + strconv.Itoa(i) + " }\n")
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			t.Fatalf("failed writing go file: %v", err)
+		}
+	}
+
+	baseline, err := BuildGoFingerprintMap(repo)
+	if err != nil {
+		t.Fatalf("BuildGoFingerprintMap baseline failed: %v", err)
+	}
+
+	for i := 0; i < 20; i++ {
+		next, nextErr := BuildGoFingerprintMap(repo)
+		if nextErr != nil {
+			t.Fatalf("BuildGoFingerprintMap failed at run %d: %v", i, nextErr)
+		}
+		if !reflect.DeepEqual(baseline, next) {
+			t.Fatalf("fingerprint map must remain deterministic; baseline=%v next=%v", baseline, next)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- optimize BuildGoFingerprintMap hot path by splitting discovery from hashing and processing file hashes with a bounded worker pool
- keep deterministic behavior by sorting collected file paths before parallel hashing
- add deterministic-repeat test coverage for incremental fingerprint map generation

## Validation
- go test ./...
- go vet ./...
- go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
- go run . analyze -path .

Closes #202