### PR TITLE
[v0.19][RD-1906] Cache integrity + poisoning resistance

### DIFF
--- a/internal/analysis/incremental_boundary_test.go
+++ b/internal/analysis/incremental_boundary_test.go
@@ -41,7 +41,10 @@ func TestIncrementalBoundaryService_RequiresDependencies(t *testing.T) {
 func TestIncrementalBoundaryService_FirstRunCacheMissThenHitWithDiff(t *testing.T) {
 	store := NewInMemoryIncrementalSnapshotStore()
 	service, err := NewIncrementalBoundaryService(store, stubFingerprintProvider{
-		state: map[string]string{"a.go": "h1", "b.go": "h2"},
+		state: map[string]string{
+			"a.go": "1111111111111111111111111111111111111111111111111111111111111111",
+			"b.go": "2222222222222222222222222222222222222222222222222222222222222222",
+		},
 	})
 	if err != nil {
 		t.Fatalf("failed to create boundary service: %v", err)
@@ -58,7 +61,10 @@ func TestIncrementalBoundaryService_FirstRunCacheMissThenHitWithDiff(t *testing.
 		t.Fatalf("first compute must not return stale diffs, changed=%v removed=%v", first.Changed, first.Removed)
 	}
 
-	service.provider = stubFingerprintProvider{state: map[string]string{"a.go": "h1-changed", "c.go": "h3"}}
+	service.provider = stubFingerprintProvider{state: map[string]string{
+		"a.go": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"c.go": "3333333333333333333333333333333333333333333333333333333333333333",
+	}}
 	second, err := service.Compute("/repo", "cache-key")
 	if err != nil {
 		t.Fatalf("second compute failed: %v", err)
@@ -96,12 +102,12 @@ func TestIncrementalBoundaryService_PropagatesBuildErrors(t *testing.T) {
 
 func TestInMemoryIncrementalSnapshotStore_ClonesOnSaveAndLoad(t *testing.T) {
 	store := NewInMemoryIncrementalSnapshotStore()
-	original := NewIncrementalCacheSnapshot("cache-key", map[string]string{"a.go": "h1"})
+	original := NewIncrementalCacheSnapshot("cache-key", map[string]string{"a.go": "1111111111111111111111111111111111111111111111111111111111111111"})
 	if err := store.Save(original); err != nil {
 		t.Fatalf("save failed: %v", err)
 	}
 
-	original.Fingerprints["a.go"] = "tampered"
+	original.Fingerprints["a.go"] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	loaded, found, err := store.Load("cache-key")
 	if err != nil {
 		t.Fatalf("load failed: %v", err)
@@ -109,11 +115,11 @@ func TestInMemoryIncrementalSnapshotStore_ClonesOnSaveAndLoad(t *testing.T) {
 	if !found {
 		t.Fatal("expected stored snapshot to be found")
 	}
-	if loaded.Fingerprints["a.go"] != "h1" {
+	if loaded.Fingerprints["a.go"] != "1111111111111111111111111111111111111111111111111111111111111111" {
 		t.Fatalf("store must clone on save, got %s", loaded.Fingerprints["a.go"])
 	}
 
-	loaded.Fingerprints["a.go"] = "modified-after-load"
+	loaded.Fingerprints["a.go"] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	reloaded, found, err := store.Load("cache-key")
 	if err != nil {
 		t.Fatalf("reload failed: %v", err)
@@ -121,7 +127,7 @@ func TestInMemoryIncrementalSnapshotStore_ClonesOnSaveAndLoad(t *testing.T) {
 	if !found {
 		t.Fatal("expected snapshot on reload")
 	}
-	if reloaded.Fingerprints["a.go"] != "h1" {
+	if reloaded.Fingerprints["a.go"] != "1111111111111111111111111111111111111111111111111111111111111111" {
 		t.Fatalf("store must clone on load, got %s", reloaded.Fingerprints["a.go"])
 	}
 }

--- a/internal/analysis/incremental_cache_key.go
+++ b/internal/analysis/incremental_cache_key.go
@@ -11,8 +11,10 @@ import (
 
 type IncrementalCacheKeyInput struct {
 	AnalyzerVersion   string
+	CacheSchema       string
 	RepositoryPath    string
 	ConfigFingerprint string
+	RuleFingerprint   string
 }
 
 func BuildIncrementalCacheKey(input IncrementalCacheKeyInput) (string, error) {
@@ -31,7 +33,17 @@ func BuildIncrementalCacheKey(input IncrementalCacheKeyInput) (string, error) {
 		configHash = HashConfigBytes(nil)
 	}
 
-	payload := strings.Join([]string{version, normalizedPath, configHash}, "|")
+	ruleHash := strings.TrimSpace(input.RuleFingerprint)
+	if ruleHash == "" {
+		ruleHash = HashConfigBytes(nil)
+	}
+
+	cacheSchema := strings.TrimSpace(input.CacheSchema)
+	if cacheSchema == "" {
+		cacheSchema = IncrementalCacheSchemaVersion
+	}
+
+	payload := strings.Join([]string{version, cacheSchema, normalizedPath, configHash, ruleHash}, "|")
 	sum := sha256.Sum256([]byte(payload))
 	return hex.EncodeToString(sum[:]), nil
 }

--- a/internal/analysis/incremental_cache_key_test.go
+++ b/internal/analysis/incremental_cache_key_test.go
@@ -5,8 +5,10 @@ import "testing"
 func TestBuildIncrementalCacheKey_Deterministic(t *testing.T) {
 	input := IncrementalCacheKeyInput{
 		AnalyzerVersion:   "0.14.0-dev",
+		CacheSchema:       IncrementalCacheSchemaVersion,
 		RepositoryPath:    ".",
 		ConfigFingerprint: HashConfigBytes([]byte("a: 1")),
+		RuleFingerprint:   HashConfigBytes([]byte("rules: default")),
 	}
 
 	first, err := BuildIncrementalCacheKey(input)
@@ -25,7 +27,7 @@ func TestBuildIncrementalCacheKey_Deterministic(t *testing.T) {
 }
 
 func TestBuildIncrementalCacheKey_ChangesWithVersionOrConfig(t *testing.T) {
-	base := IncrementalCacheKeyInput{AnalyzerVersion: "0.14.0-dev", RepositoryPath: ".", ConfigFingerprint: HashConfigBytes([]byte("a:1"))}
+	base := IncrementalCacheKeyInput{AnalyzerVersion: "0.14.0-dev", CacheSchema: IncrementalCacheSchemaVersion, RepositoryPath: ".", ConfigFingerprint: HashConfigBytes([]byte("a:1")), RuleFingerprint: HashConfigBytes([]byte("rules:a"))}
 	keyA, err := BuildIncrementalCacheKey(base)
 	if err != nil {
 		t.Fatalf("BuildIncrementalCacheKey failed: %v", err)
@@ -49,5 +51,25 @@ func TestBuildIncrementalCacheKey_ChangesWithVersionOrConfig(t *testing.T) {
 	}
 	if keyA == keyC {
 		t.Fatal("expected key to change when config hash changes")
+	}
+
+	variantSchema := base
+	variantSchema.CacheSchema = "v2"
+	keyD, err := BuildIncrementalCacheKey(variantSchema)
+	if err != nil {
+		t.Fatalf("BuildIncrementalCacheKey failed: %v", err)
+	}
+	if keyA == keyD {
+		t.Fatal("expected key to change when schema changes")
+	}
+
+	variantRules := base
+	variantRules.RuleFingerprint = HashConfigBytes([]byte("rules:b"))
+	keyE, err := BuildIncrementalCacheKey(variantRules)
+	if err != nil {
+		t.Fatalf("BuildIncrementalCacheKey failed: %v", err)
+	}
+	if keyA == keyE {
+		t.Fatal("expected key to change when rule hash changes")
 	}
 }

--- a/internal/analysis/incremental_cache_store.go
+++ b/internal/analysis/incremental_cache_store.go
@@ -3,6 +3,8 @@ package analysis
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
+	"strings"
 )
 
 const IncrementalCacheSchemaVersion = "v1"
@@ -35,6 +37,17 @@ func (s IncrementalCacheSnapshot) Validate() error {
 	if s.Fingerprints == nil {
 		return fmt.Errorf("incremental cache snapshot fingerprints cannot be nil")
 	}
+	for path, hash := range s.Fingerprints {
+		if strings.TrimSpace(path) == "" {
+			return fmt.Errorf("incremental cache snapshot contains empty fingerprint path")
+		}
+		if filepath.Clean(path) != path {
+			return fmt.Errorf("incremental cache snapshot path must be clean: %s", path)
+		}
+		if len(hash) != 64 || !isLowerHex(hash) {
+			return fmt.Errorf("incremental cache snapshot hash must be 64-char lowercase hex")
+		}
+	}
 	return nil
 }
 
@@ -54,4 +67,23 @@ func UnmarshalIncrementalCacheSnapshot(data []byte) (IncrementalCacheSnapshot, e
 		return IncrementalCacheSnapshot{}, err
 	}
 	return snapshot, nil
+}
+
+// UnmarshalIncrementalCacheSnapshotSafe never panics and returns ok=false
+// for malformed, unsupported, or suspicious cache payloads.
+func UnmarshalIncrementalCacheSnapshotSafe(data []byte) (snapshot IncrementalCacheSnapshot, ok bool) {
+	snapshot, err := UnmarshalIncrementalCacheSnapshot(data)
+	if err != nil {
+		return IncrementalCacheSnapshot{}, false
+	}
+	return snapshot, true
+}
+
+func isLowerHex(value string) bool {
+	for _, ch := range value {
+		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/analysis/incremental_cache_store_test.go
+++ b/internal/analysis/incremental_cache_store_test.go
@@ -3,7 +3,7 @@ package analysis
 import "testing"
 
 func TestIncrementalCacheSnapshot_MarshalRoundTrip(t *testing.T) {
-	s := NewIncrementalCacheSnapshot("cache-key", map[string]string{"a.go": "hash-a"})
+	s := NewIncrementalCacheSnapshot("cache-key", map[string]string{"a.go": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
 	data, err := MarshalIncrementalCacheSnapshot(s)
 	if err != nil {
 		t.Fatalf("MarshalIncrementalCacheSnapshot failed: %v", err)
@@ -22,8 +22,25 @@ func TestIncrementalCacheSnapshot_MarshalRoundTrip(t *testing.T) {
 }
 
 func TestIncrementalCacheSnapshot_RejectsUnsupportedVersion(t *testing.T) {
-	data := []byte(`{"schemaVersion":"v0","cacheKey":"k","fingerprints":{"a.go":"h"}}`)
+	data := []byte(`{"schemaVersion":"v0","cacheKey":"k","fingerprints":{"a.go":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}`)
 	if _, err := UnmarshalIncrementalCacheSnapshot(data); err == nil {
 		t.Fatal("expected unsupported version to fail")
+	}
+}
+
+func TestIncrementalCacheSnapshot_RejectsNonHexHash(t *testing.T) {
+	data := []byte(`{"schemaVersion":"v1","cacheKey":"k","fingerprints":{"a.go":"not-hex"}}`)
+	if _, err := UnmarshalIncrementalCacheSnapshot(data); err == nil {
+		t.Fatal("expected non-hex hash to fail")
+	}
+}
+
+func TestUnmarshalIncrementalCacheSnapshotSafe_FailsClosedOnCorruptPayload(t *testing.T) {
+	if _, ok := UnmarshalIncrementalCacheSnapshotSafe([]byte(`{"schemaVersion":"v1",`)); ok {
+		t.Fatal("expected corrupt payload to fail closed")
+	}
+
+	if _, ok := UnmarshalIncrementalCacheSnapshotSafe([]byte(`{"schemaVersion":"v0","cacheKey":"k","fingerprints":{"a.go":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}`)); ok {
+		t.Fatal("expected unsupported schema payload to fail closed")
 	}
 }

--- a/internal/analysis/incremental_correctness_test.go
+++ b/internal/analysis/incremental_correctness_test.go
@@ -16,8 +16,10 @@ func TestIncrementalCorrectness_ColdAndIncrementalFingerprintStateParity(t *test
 
 	key, err := BuildIncrementalCacheKey(IncrementalCacheKeyInput{
 		AnalyzerVersion:   "0.14.0-dev",
+		CacheSchema:       IncrementalCacheSchemaVersion,
 		RepositoryPath:    repo,
 		ConfigFingerprint: HashConfigBytes([]byte("rules:default")),
+		RuleFingerprint:   HashConfigBytes([]byte("rule-pack:v1")),
 	})
 	if err != nil {
 		t.Fatalf("BuildIncrementalCacheKey failed: %v", err)


### PR DESCRIPTION
## Summary
- include cache schema and rule fingerprint in incremental cache key material to prevent cross-context collisions
- harden snapshot validation with clean-path and strict lowercase hex hash requirements
- add fail-closed safe unmarshal path for corrupted or incompatible payloads plus focused integrity tests

## Validation
- go test ./...
- go vet ./...
- pwsh -File ./scripts/v018_closeout_gate.ps1
- pwsh -File ./scripts/v019_benchmark_gate.ps1
- go run . analyze -path .

Closes #205