### PR TITLE
[v0.19][RD-1907] Release readiness stabilization

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -53,6 +53,14 @@ jobs:
           GOMAXPROCS: 1
         run: ./scripts/v019_benchmark_gate.ps1
 
+      - name: Run v0.19 release stabilization gate
+        shell: pwsh
+        env:
+          TZ: UTC
+          LC_ALL: C
+          GOMAXPROCS: 1
+        run: ./scripts/v019_release_stabilization_gate.ps1
+
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -5,8 +5,8 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | Version | Milestone | Status | Notes |
 |---|---|---|---|
 | v0.17 | S8-v0.17 Near-Max Practical Maturity | Completed | Maturity report published (`docs/v0.17-maturity-report.md`). |
-| v0.18 | M0: v0.18 Contract Hardening | In Progress | RD-1801..RD-1803 merged, RD-1804+ backlog prepared. |
-| v0.19 | M1: v0.19 Incremental & Performance | Planned | Issues RD-1901..RD-1908 created. |
+| v0.18 | M0: v0.18 Contract Hardening | Completed | RD-1801..RD-1808 merged into `dev`; close-out, path-safety, and CI supply-chain gates active. |
+| v0.19 | M1: v0.19 Incremental & Performance | In Progress | RD-1901..RD-1906 and RD-1908 merged into `dev`; stabilization gate pack active, release close pending RD-1907. |
 | v0.20 | M2: v0.20 Java Pilot (Gated) | Planned | Issues RD-2001..RD-2007 created (default-off pilot). |
 | v1.0 | M3: v1.0 UX & Polish | Planned | Issues RD-10001..RD-10005 created. |
 | v1.1+ | M4: v1.1+ Scale (Use-case gated) | Planned | Issues RD-11001..RD-11003 created. |

--- a/scripts/v019_release_stabilization_gate.ps1
+++ b/scripts/v019_release_stabilization_gate.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    Write-Host "==> $Name"
+    Invoke-Expression $Command
+}
+
+Invoke-Step -Name "core test suite" -Command "go test ./..."
+Invoke-Step -Name "static analysis" -Command "go vet ./..."
+Invoke-Step -Name "v0.18 close-out pack" -Command "pwsh -File ./scripts/v018_closeout_gate.ps1"
+Invoke-Step -Name "v0.19 benchmark + memory pack" -Command "pwsh -File ./scripts/v019_benchmark_gate.ps1"
+Invoke-Step -Name "self-analysis 100/100 gate" -Command "go run . analyze -path ."
+
+Write-Host "v0.19 release stabilization gate passed."


### PR DESCRIPTION
## Summary
- add a v0.19 release stabilization gate entrypoint that runs tests, vet, v0.18 close-out, v0.19 benchmark, and self-analysis checks in sequence
- wire CI to run stabilization gate under normalized benchmark environment settings
- update report tracking to reflect v0.18 completion and current v0.19 progress

## Validation
- pwsh -File ./scripts/v019_release_stabilization_gate.ps1
- go test ./...
- go vet ./...
- go run . analyze -path .

Closes #206