### PR TITLE
[v0.20][RD-2001] Java pilot flag/contract

### DIFF
--- a/adapter_registry.go
+++ b/adapter_registry.go
@@ -1,0 +1,18 @@
+package main
+
+import "RepoDoctor/internal/languages"
+
+func registerCoreAdapters(detector *languages.RepositoryLanguageDetector, config *Config) {
+	detector.RegisterAdapter(languages.NewGoAdapter())
+	detector.RegisterAdapter(languages.NewPythonAdapter())
+	detector.RegisterAdapter(languages.NewJavaScriptAdapter())
+	detector.RegisterAdapter(languages.NewTypeScriptAdapter())
+	_ = isJavaPilotEnabled(config)
+}
+
+func isJavaPilotEnabled(config *Config) bool {
+	if config == nil || config.LanguageDetection == nil || config.LanguageDetection.JavaPilot == nil {
+		return false
+	}
+	return *config.LanguageDetection.JavaPilot
+}

--- a/adapter_registry_test.go
+++ b/adapter_registry_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	"RepoDoctor/internal/domain"
+	"RepoDoctor/internal/languages"
+)
+
+func TestIsJavaPilotEnabled_DefaultFalse(t *testing.T) {
+	if isJavaPilotEnabled(nil) {
+		t.Fatal("nil config must not enable java pilot")
+	}
+
+	if isJavaPilotEnabled(&Config{LanguageDetection: &LanguageDetectionConfig{}}) {
+		t.Fatal("missing java pilot flag must default to false")
+	}
+}
+
+func TestIsJavaPilotEnabled_ExplicitTrue(t *testing.T) {
+	enabled := true
+	cfg := &Config{LanguageDetection: &LanguageDetectionConfig{JavaPilot: &enabled}}
+	if !isJavaPilotEnabled(cfg) {
+		t.Fatal("explicit java pilot flag must be honored")
+	}
+}
+
+func TestRegisterCoreAdapters_StableBaseContract(t *testing.T) {
+	strategy := domain.NewDefaultIgnoreStrategy(domain.DefaultIgnoredDirs)
+	detector := languages.NewRepositoryLanguageDetector(strategy)
+
+	enabled := true
+	cfg := &Config{LanguageDetection: &LanguageDetectionConfig{JavaPilot: &enabled}}
+	registerCoreAdapters(detector, cfg)
+
+	supported := detector.GetSupportedLanguages()
+	if len(supported) != 4 {
+		t.Fatalf("expected stable 4-language base contract in pilot-flag phase, got %v", supported)
+	}
+}

--- a/analysis_language_evidence.go
+++ b/analysis_language_evidence.go
@@ -73,10 +73,7 @@ func collectLanguageStats(absPath string) ([]languages.LanguageStat, error) {
 	}
 
 	detector := languages.NewRepositoryLanguageDetectorWithPolicy(ignoreStrategy, policy)
-	detector.RegisterAdapter(languages.NewGoAdapter())
-	detector.RegisterAdapter(languages.NewPythonAdapter())
-	detector.RegisterAdapter(languages.NewJavaScriptAdapter())
-	detector.RegisterAdapter(languages.NewTypeScriptAdapter())
+	registerCoreAdapters(detector, config)
 
 	return detector.GetLanguageStats(absPath)
 }

--- a/config.go
+++ b/config.go
@@ -30,6 +30,7 @@ type LanguageDetectionConfig struct {
 	Weights        map[string]float64 `yaml:"weights,omitempty"`
 	TieBreakOrder  []string           `yaml:"tie_break_order,omitempty"`
 	SegmentWeights map[string]float64 `yaml:"segment_weights,omitempty"`
+	JavaPilot      *bool              `yaml:"java_pilot_enabled,omitempty"`
 }
 
 // SizeConfig holds size rule configuration
@@ -233,6 +234,7 @@ func (l *ConfigLoader) getDefaultConfig() *Config {
 				"Python":     1.0,
 				"JavaScript": 1.0,
 				"TypeScript": 1.0,
+				"Java":       0.8,
 			},
 			TieBreakOrder: []string{"Python", "TypeScript", "JavaScript", "Go"},
 			SegmentWeights: map[string]float64{
@@ -242,9 +244,14 @@ func (l *ConfigLoader) getDefaultConfig() *Config {
 				"tools":   0.2,
 				"scripts": 0.2,
 			},
+			JavaPilot: boolPtr(false),
 		},
 		Architecture: &ArchitectureConfig{Profile: "layered"},
 	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }
 
 // mergeWithDefaults merges provided config with defaults
@@ -351,6 +358,9 @@ func mergeLanguageDetectionConfig(cfg, defaults *Config) {
 	if cfg.LanguageDetection.SegmentWeights == nil {
 		cfg.LanguageDetection.SegmentWeights = defaults.LanguageDetection.SegmentWeights
 	}
+	if cfg.LanguageDetection.JavaPilot == nil {
+		cfg.LanguageDetection.JavaPilot = defaults.LanguageDetection.JavaPilot
+	}
 }
 
 func mergeArchitectureConfig(cfg, defaults *Config) {
@@ -394,7 +404,7 @@ func rejectUnknownConfigKeys(data []byte) error {
 		encoded, _ := json.Marshal(ldRaw)
 		var ld map[string]interface{}
 		_ = json.Unmarshal(encoded, &ld)
-		allowedLD := map[string]bool{"weights": true, "tie_break_order": true, "segment_weights": true}
+		allowedLD := map[string]bool{"weights": true, "tie_break_order": true, "segment_weights": true, "java_pilot_enabled": true}
 		for key := range ld {
 			if !allowedLD[key] {
 				return fmt.Errorf("config validation error: unknown language_detection key '%s'", key)

--- a/config_test.go
+++ b/config_test.go
@@ -297,6 +297,38 @@ language_detection:
 	}
 }
 
+func TestConfigLoader_JavaPilotFlagDefaultsToDisabled(t *testing.T) {
+	loader := NewConfigLoader(filepath.Join(t.TempDir(), "missing.yaml"))
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("unexpected load error: %v", err)
+	}
+	if cfg.LanguageDetection == nil || cfg.LanguageDetection.JavaPilot == nil {
+		t.Fatal("expected java pilot flag to be defaulted")
+	}
+	if *cfg.LanguageDetection.JavaPilot {
+		t.Fatal("expected java pilot to be disabled by default")
+	}
+}
+
+func TestConfigLoader_JavaPilotFlagCanBeEnabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	configContent := "language_detection:\n  java_pilot_enabled: true\n"
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed writing config: %v", err)
+	}
+
+	loader := NewConfigLoader(configPath)
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("expected java pilot config to load, got: %v", err)
+	}
+	if cfg.LanguageDetection == nil || cfg.LanguageDetection.JavaPilot == nil || !*cfg.LanguageDetection.JavaPilot {
+		t.Fatalf("expected java pilot flag enabled, got %+v", cfg.LanguageDetection)
+	}
+}
+
 func TestConfigLoader_MergeWithDefaults_TableDrivenInvariants(t *testing.T) {
 	loader := NewConfigLoader("")
 	enabled := false

--- a/main.go
+++ b/main.go
@@ -404,10 +404,7 @@ func runAdapterPipeline(absPath string) (*analysis.Result, error) {
 		policy.SegmentWeights = config.LanguageDetection.SegmentWeights
 	}
 	detector := languages.NewRepositoryLanguageDetectorWithPolicy(ignoreStrategy, policy)
-	detector.RegisterAdapter(languages.NewGoAdapter())
-	detector.RegisterAdapter(languages.NewPythonAdapter())
-	detector.RegisterAdapter(languages.NewJavaScriptAdapter())
-	detector.RegisterAdapter(languages.NewTypeScriptAdapter())
+	registerCoreAdapters(detector, config)
 
 	orchestrator := analysis.NewOrchestrator(detector)
 	return orchestrator.Analyze(absPath)


### PR DESCRIPTION
## Summary
- add language_detection.java_pilot_enabled config contract with deterministic default-off behavior
- centralize adapter registration through a shared registry helper to support future gated Java onboarding
- add config and registry tests for java pilot flag semantics and stable base-language contract

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .

Closes #208