### PR TITLE
[v0.20][RD-2002] Java adapter skeleton

### DIFF
--- a/adapter_registry.go
+++ b/adapter_registry.go
@@ -7,7 +7,10 @@ func registerCoreAdapters(detector *languages.RepositoryLanguageDetector, config
 	detector.RegisterAdapter(languages.NewPythonAdapter())
 	detector.RegisterAdapter(languages.NewJavaScriptAdapter())
 	detector.RegisterAdapter(languages.NewTypeScriptAdapter())
-	_ = isJavaPilotEnabled(config)
+
+	if isJavaPilotEnabled(config) {
+		detector.RegisterAdapter(languages.NewJavaAdapter())
+	}
 }
 
 func isJavaPilotEnabled(config *Config) bool {

--- a/adapter_registry_test.go
+++ b/adapter_registry_test.go
@@ -25,16 +25,21 @@ func TestIsJavaPilotEnabled_ExplicitTrue(t *testing.T) {
 	}
 }
 
-func TestRegisterCoreAdapters_StableBaseContract(t *testing.T) {
+func TestRegisterCoreAdapters_JavaPilotGate(t *testing.T) {
 	strategy := domain.NewDefaultIgnoreStrategy(domain.DefaultIgnoredDirs)
-	detector := languages.NewRepositoryLanguageDetector(strategy)
+	baseDetector := languages.NewRepositoryLanguageDetector(strategy)
+	registerCoreAdapters(baseDetector, &Config{LanguageDetection: &LanguageDetectionConfig{}})
+	if got := len(baseDetector.GetSupportedLanguages()); got != 4 {
+		t.Fatalf("expected 4 languages when java pilot disabled, got %d", got)
+	}
 
+	detector := languages.NewRepositoryLanguageDetector(strategy)
 	enabled := true
 	cfg := &Config{LanguageDetection: &LanguageDetectionConfig{JavaPilot: &enabled}}
 	registerCoreAdapters(detector, cfg)
 
 	supported := detector.GetSupportedLanguages()
-	if len(supported) != 4 {
-		t.Fatalf("expected stable 4-language base contract in pilot-flag phase, got %v", supported)
+	if len(supported) != 5 {
+		t.Fatalf("expected Java to be registered when pilot enabled, got %v", supported)
 	}
 }

--- a/internal/languages/java_adapter.go
+++ b/internal/languages/java_adapter.go
@@ -1,0 +1,188 @@
+package languages
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"RepoDoctor/internal/model"
+)
+
+const (
+	maxJavaFileBytes = 2 * 1024 * 1024
+)
+
+var (
+	javaPackagePattern = regexp.MustCompile(`^\s*package\s+([A-Za-z_][\w.]*)\s*;`)
+	javaImportPattern  = regexp.MustCompile(`^\s*import\s+(?:static\s+)?([A-Za-z_][\w.*]*)\s*;`)
+	javaMethodPattern  = regexp.MustCompile(`\b(?:public|protected|private)?\s*(?:static\s+)?(?:final\s+)?[A-Za-z_][\w<>\[\]]*\s+([A-Za-z_][\w]*)\s*\(`)
+)
+
+type JavaAdapter struct{}
+
+func NewJavaAdapter() LanguageAdapter {
+	return &JavaAdapter{}
+}
+
+func (a *JavaAdapter) Name() string {
+	return "Java"
+}
+
+func (a *JavaAdapter) FileExtensions() []string {
+	return []string{".java"}
+}
+
+func (a *JavaAdapter) DetectFiles(repoPath string) ([]string, error) {
+	javaFiles := make([]string, 0)
+	err := filepath.WalkDir(repoPath, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			name := strings.ToLower(d.Name())
+			if strings.HasPrefix(name, ".") || name == "target" || name == "build" || name == "out" || name == ".gradle" {
+				if path != repoPath {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		if strings.ToLower(filepath.Ext(path)) == ".java" {
+			javaFiles = append(javaFiles, filepath.Clean(path))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(javaFiles)
+	return javaFiles, nil
+}
+
+func (a *JavaAdapter) CollectMetrics(files []string) (*model.RepositoryMetrics, error) {
+	metrics := model.NewRepositoryMetrics()
+	for _, file := range files {
+		fm, err := a.collectFileMetrics(file)
+		if err != nil {
+			continue
+		}
+		metrics.AddFileMetrics(*fm)
+	}
+	return metrics, nil
+}
+
+func (a *JavaAdapter) collectFileMetrics(path string) (*model.FileMetrics, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(content) > maxJavaFileBytes {
+		return nil, fmt.Errorf("java file too large for safe parsing: %s", path)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	functions := 0
+	imports := 0
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "*") {
+			continue
+		}
+		if javaImportPattern.MatchString(trimmed) {
+			imports++
+		}
+		if javaMethodPattern.MatchString(trimmed) {
+			functions++
+		}
+	}
+
+	return &model.FileMetrics{
+		Path:      path,
+		Lines:     len(lines),
+		Functions: functions,
+		Imports:   imports,
+	}, nil
+}
+
+func (a *JavaAdapter) BuildDependencyGraph(files []string) (*model.DependencyGraph, error) {
+	graph := model.NewDependencyGraph()
+	for _, file := range files {
+		pkgName, imports, err := a.extractFilePackageAndImports(file)
+		if err != nil {
+			continue
+		}
+		node := graph.AddNode(file, file, pkgName)
+		for _, imp := range imports {
+			normalized := a.NormalizeImport(imp)
+			if normalized == "" {
+				continue
+			}
+			node.Imports = append(node.Imports, normalized)
+			if node.Metadata == nil {
+				node.Metadata = make(map[string]string)
+			}
+			node.Metadata["import_class:"+normalized] = "internal"
+			graph.AddEdge(file, normalized)
+		}
+	}
+	return graph, nil
+}
+
+func (a *JavaAdapter) extractFilePackageAndImports(path string) (string, []string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", nil, err
+	}
+	defer file.Close()
+
+	pkg := ""
+	imports := make([]string, 0, 8)
+	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.ContainsRune(line, '\x00') {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if pkg == "" {
+			if m := javaPackagePattern.FindStringSubmatch(trimmed); len(m) == 2 {
+				pkg = m[1]
+			}
+		}
+		if m := javaImportPattern.FindStringSubmatch(trimmed); len(m) == 2 {
+			imports = append(imports, m[1])
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", nil, err
+	}
+	sort.Strings(imports)
+	return pkg, imports, nil
+}
+
+func (a *JavaAdapter) IsStdlibPackage(importPath string) bool {
+	normalized := strings.TrimSpace(importPath)
+	return strings.HasPrefix(normalized, "java.") || strings.HasPrefix(normalized, "javax.") || strings.HasPrefix(normalized, "jdk.") || strings.HasPrefix(normalized, "sun.")
+}
+
+func (a *JavaAdapter) Capabilities() AdapterCapabilities {
+	return AdapterCapabilities{
+		SupportsDependencyGraph: true,
+		SupportsMetrics:         true,
+		UsesASTParsing:          false,
+	}
+}
+
+func (a *JavaAdapter) NormalizeImport(importPath string) string {
+	normalized := strings.TrimSpace(importPath)
+	normalized = strings.TrimSuffix(normalized, ";")
+	normalized = strings.TrimPrefix(normalized, "static ")
+	normalized = strings.TrimSuffix(normalized, ".*")
+	return normalized
+}

--- a/internal/languages/java_adapter_test.go
+++ b/internal/languages/java_adapter_test.go
@@ -1,0 +1,88 @@
+package languages
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestJavaAdapter_CapabilitiesAndNormalizeImport(t *testing.T) {
+	adapter := NewJavaAdapter()
+	caps := adapter.Capabilities()
+	if !caps.SupportsDependencyGraph || !caps.SupportsMetrics {
+		t.Fatal("expected Java adapter to support graph and metrics")
+	}
+
+	if got := adapter.NormalizeImport(" static java.util.Collections.*;"); got != "java.util.Collections" {
+		t.Fatalf("unexpected normalized Java import: %q", got)
+	}
+}
+
+func TestJavaAdapter_DetectFilesAndSkipBuildDirs(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "src", "main", "java"), 0o755); err != nil {
+		t.Fatalf("failed to create src dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "target"), 0o755); err != nil {
+		t.Fatalf("failed to create target dir: %v", err)
+	}
+
+	prod := filepath.Join(repo, "src", "main", "java", "App.java")
+	ignored := filepath.Join(repo, "target", "Generated.java")
+	if err := os.WriteFile(prod, []byte("package app;\nclass App {}\n"), 0o644); err != nil {
+		t.Fatalf("failed writing prod fixture: %v", err)
+	}
+	if err := os.WriteFile(ignored, []byte("class Generated {}\n"), 0o644); err != nil {
+		t.Fatalf("failed writing ignored fixture: %v", err)
+	}
+
+	files, err := adapterDetectFilesForTest(NewJavaAdapter(), repo)
+	if err != nil {
+		t.Fatalf("DetectFiles failed: %v", err)
+	}
+	if len(files) != 1 || filepath.Clean(files[0]) != filepath.Clean(prod) {
+		t.Fatalf("expected only production java file, got %v", files)
+	}
+}
+
+func TestJavaAdapter_BuildDependencyGraph_Deterministic(t *testing.T) {
+	repo := t.TempDir()
+	file := filepath.Join(repo, "App.java")
+	content := strings.Join([]string{
+		"package app.core;",
+		"import java.util.List;",
+		"import com.acme.shared.Util;",
+		"public class App {",
+		"  public void run() {}",
+		"}",
+	}, "\n")
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed writing java fixture: %v", err)
+	}
+
+	adapter := NewJavaAdapter()
+	first, err := adapter.BuildDependencyGraph([]string{file})
+	if err != nil {
+		t.Fatalf("BuildDependencyGraph failed: %v", err)
+	}
+	baseline := strings.Join(first.GetNode(file).Imports, "|")
+
+	for i := 0; i < 10; i++ {
+		next, nextErr := adapter.BuildDependencyGraph([]string{file})
+		if nextErr != nil {
+			t.Fatalf("BuildDependencyGraph failed on iteration %d: %v", i, nextErr)
+		}
+		node := next.GetNode(file)
+		if node == nil {
+			t.Fatalf("expected graph node for %s", file)
+		}
+		if current := strings.Join(node.Imports, "|"); current != baseline {
+			t.Fatalf("java graph imports must be deterministic, baseline=%q current=%q", baseline, current)
+		}
+	}
+}
+
+func adapterDetectFilesForTest(adapter LanguageAdapter, repo string) ([]string, error) {
+	return adapter.DetectFiles(repo)
+}


### PR DESCRIPTION
## Summary
- add a deterministic Java adapter skeleton with .java discovery and bounded parsing behavior
- implement baseline Java metrics and dependency graph extraction suitable for pilot hardening
- wire Java adapter registration behind java pilot feature flag and add focused adapter tests

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .

Closes #209