### PR TITLE
[v0.20][RD-2004] Java abuse-resistance bounds

### DIFF
--- a/internal/languages/java_adapter.go
+++ b/internal/languages/java_adapter.go
@@ -13,7 +13,9 @@ import (
 )
 
 const (
-	maxJavaFileBytes = 2 * 1024 * 1024
+	maxJavaFileBytes  = 2 * 1024 * 1024
+	maxJavaFilesScan  = 10000
+	maxJavaImportRows = 50000
 )
 
 var (
@@ -39,6 +41,7 @@ func (a *JavaAdapter) FileExtensions() []string {
 
 func (a *JavaAdapter) DetectFiles(repoPath string) ([]string, error) {
 	javaFiles := make([]string, 0)
+	seen := 0
 	err := filepath.WalkDir(repoPath, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -53,6 +56,10 @@ func (a *JavaAdapter) DetectFiles(repoPath string) ([]string, error) {
 			return nil
 		}
 		if strings.ToLower(filepath.Ext(path)) == ".java" {
+			seen++
+			if seen > maxJavaFilesScan {
+				return nil
+			}
 			javaFiles = append(javaFiles, filepath.Clean(path))
 		}
 		return nil
@@ -176,7 +183,6 @@ func (a *JavaAdapter) BuildDependencyGraph(files []string) (*model.DependencyGra
 			if normalized == "" {
 				continue
 			}
-			node.Imports = append(node.Imports, normalized)
 			if node.Metadata == nil {
 				node.Metadata = make(map[string]string)
 			}
@@ -199,7 +205,12 @@ func (a *JavaAdapter) extractFilePackageAndImports(path string) (string, []strin
 	scanner := bufio.NewScanner(file)
 	buf := make([]byte, 0, 64*1024)
 	scanner.Buffer(buf, 1024*1024)
+	rows := 0
 	for scanner.Scan() {
+		rows++
+		if rows > maxJavaImportRows {
+			break
+		}
 		line := scanner.Text()
 		if strings.ContainsRune(line, '\x00') {
 			continue

--- a/internal/languages/java_adapter_test.go
+++ b/internal/languages/java_adapter_test.go
@@ -3,6 +3,7 @@ package languages
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -110,4 +111,64 @@ func TestJavaAdapter_CollectMetrics_ExtractsTypesAndMethods(t *testing.T) {
 
 func adapterDetectFilesForTest(adapter LanguageAdapter, repo string) ([]string, error) {
 	return adapter.DetectFiles(repo)
+}
+
+func TestJavaAdapter_CollectMetrics_FailSoftOnOversizedFile(t *testing.T) {
+	repo := t.TempDir()
+	file := filepath.Join(repo, "Huge.java")
+	big := strings.Repeat("a", maxJavaFileBytes+1)
+	if err := os.WriteFile(file, []byte(big), 0o644); err != nil {
+		t.Fatalf("failed writing oversized fixture: %v", err)
+	}
+
+	adapter := NewJavaAdapter()
+	metrics, err := adapter.CollectMetrics([]string{file})
+	if err != nil {
+		t.Fatalf("CollectMetrics should fail-soft and return no error, got: %v", err)
+	}
+	if metrics.TotalFiles != 0 {
+		t.Fatalf("oversized file should be skipped, got files=%d", metrics.TotalFiles)
+	}
+}
+
+func TestJavaAdapter_DetectFiles_BoundedByMaxScanLimit(t *testing.T) {
+	repo := t.TempDir()
+	for i := 0; i < maxJavaFilesScan+100; i++ {
+		path := filepath.Join(repo, "src", "F"+strconv.Itoa(i)+".java")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("failed creating fixture dir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("class F{}\n"), 0o644); err != nil {
+			t.Fatalf("failed writing fixture file: %v", err)
+		}
+	}
+
+	files, err := NewJavaAdapter().DetectFiles(repo)
+	if err != nil {
+		t.Fatalf("DetectFiles failed: %v", err)
+	}
+	if len(files) != maxJavaFilesScan {
+		t.Fatalf("expected bounded java scan size %d, got %d", maxJavaFilesScan, len(files))
+	}
+}
+
+func TestJavaAdapter_BuildDependencyGraph_SkipsNULImportLines(t *testing.T) {
+	repo := t.TempDir()
+	file := filepath.Join(repo, "App.java")
+	content := "package a;\nimport com.acme.Ok;\nimport bad\x00line;\n"
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed writing fixture: %v", err)
+	}
+
+	graph, err := NewJavaAdapter().BuildDependencyGraph([]string{file})
+	if err != nil {
+		t.Fatalf("BuildDependencyGraph failed: %v", err)
+	}
+	node := graph.GetNode(file)
+	if node == nil {
+		t.Fatalf("expected node for %s", file)
+	}
+	if len(node.Imports) != 1 || node.Imports[0] != "com.acme.Ok" {
+		t.Fatalf("expected only safe import to survive NUL filtering, got %v", node.Imports)
+	}
 }


### PR DESCRIPTION
## Summary
- enforce bounded Java discovery/import scanning to avoid untrusted repository abuse patterns
- keep Java extraction fail-soft for oversized and malformed lines without panics
- add targeted tests for size limits, scan limits, and NUL-byte line handling

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .

Closes #211