### PR TITLE
[v0.20][RD-2005] Java capability wiring

### DIFF
--- a/analysis_language_evidence.go
+++ b/analysis_language_evidence.go
@@ -83,7 +83,7 @@ func loadLanguageTieBreak(absPath string) []string {
 	if config != nil && config.LanguageDetection != nil && len(config.LanguageDetection.TieBreakOrder) > 0 {
 		return append([]string(nil), config.LanguageDetection.TieBreakOrder...)
 	}
-	return []string{"Python", "TypeScript", "JavaScript", "Go"}
+	return []string{"Python", "TypeScript", "JavaScript", "Go", "Java"}
 }
 
 func rankLanguageStats(stats []languages.LanguageStat, tieBreak []string) []languages.LanguageStat {

--- a/analysis_language_evidence_test.go
+++ b/analysis_language_evidence_test.go
@@ -13,7 +13,7 @@ func TestRankLanguageStats_DeterministicAndReasonableOrder(t *testing.T) {
 		{Language: "TypeScript", ProductScore: 8, Score: 30, Lines: 120, Count: 6},
 	}
 
-	ranked := rankLanguageStats(stats, []string{"Python", "TypeScript", "JavaScript", "Go"})
+	ranked := rankLanguageStats(stats, []string{"Python", "TypeScript", "JavaScript", "Go", "Java"})
 	if len(ranked) != 3 {
 		t.Fatalf("expected 3 ranked stats, got %d", len(ranked))
 	}

--- a/config.go
+++ b/config.go
@@ -236,7 +236,7 @@ func (l *ConfigLoader) getDefaultConfig() *Config {
 				"TypeScript": 1.0,
 				"Java":       0.8,
 			},
-			TieBreakOrder: []string{"Python", "TypeScript", "JavaScript", "Go"},
+			TieBreakOrder: []string{"Python", "TypeScript", "JavaScript", "Go", "Java"},
 			SegmentWeights: map[string]float64{
 				"src":     1.0,
 				"app":     1.0,

--- a/internal/languages/language_detector.go
+++ b/internal/languages/language_detector.go
@@ -151,8 +151,8 @@ func NewRepositoryLanguageDetectorWithPolicy(ignoreStrategy domain.IgnoreStrateg
 
 func defaultDetectionPolicy() DetectionPolicy {
 	return DetectionPolicy{
-		LanguageWeights: map[string]float64{"Go": 1, "Python": 1, "JavaScript": 1, "TypeScript": 1},
-		TieBreakOrder:   []string{"Python", "TypeScript", "JavaScript", "Go"},
+		LanguageWeights: map[string]float64{"Go": 1, "Python": 1, "JavaScript": 1, "TypeScript": 1, "Java": 0.8},
+		TieBreakOrder:   []string{"Python", "TypeScript", "JavaScript", "Go", "Java"},
 		SegmentWeights:  map[string]float64{"src": 1.0, "app": 1.0, "pkg": 1.0, "tools": 0.2, "scripts": 0.2},
 	}
 }

--- a/main_java_pilot_integration_test.go
+++ b/main_java_pilot_integration_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunAdapterPipeline_JavaPilotEnabled_SelectsJavaAdapter(t *testing.T) {
+	repo := t.TempDir()
+	javaFile := filepath.Join(repo, "src", "main", "java", "App.java")
+	if err := os.MkdirAll(filepath.Dir(javaFile), 0o755); err != nil {
+		t.Fatalf("failed creating java fixture dir: %v", err)
+	}
+	if err := os.WriteFile(javaFile, []byte("package demo;\nimport java.util.List;\npublic class App {}\n"), 0o644); err != nil {
+		t.Fatalf("failed writing java fixture: %v", err)
+	}
+
+	configPath := filepath.Join(repo, ".repodoctor", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("failed creating config dir: %v", err)
+	}
+	config := []byte("language_detection:\n  java_pilot_enabled: true\n  weights:\n    Java: 5\n    Go: 1\n    Python: 1\n    JavaScript: 1\n    TypeScript: 1\n")
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("failed writing config: %v", err)
+	}
+
+	result, err := runAdapterPipeline(repo)
+	if err != nil {
+		t.Fatalf("runAdapterPipeline failed: %v", err)
+	}
+	if result.AdapterName != "Java" {
+		t.Fatalf("expected Java adapter when pilot is enabled, got %s", result.AdapterName)
+	}
+}

--- a/runtime_context_builder.go
+++ b/runtime_context_builder.go
@@ -39,5 +39,5 @@ func resolveContextLanguages(primaryLanguage string) []string {
 	if primaryLanguage != "" {
 		return []string{primaryLanguage}
 	}
-	return []string{"Go", "Python", "JavaScript", "TypeScript"}
+	return []string{"Go", "Python", "JavaScript", "TypeScript", "Java"}
 }

--- a/runtime_context_builder_test.go
+++ b/runtime_context_builder_test.go
@@ -55,3 +55,13 @@ func TestBuildUnifiedRulesAnalysisContext_ConfigurationContractKeys(t *testing.T
 		t.Fatalf("configuration key %q drifted: got %v want %v", "architectureProfile", architectureProfile, "layered")
 	}
 }
+
+func TestResolveContextLanguages_DefaultIncludesJavaPilotLanguage(t *testing.T) {
+	languages := resolveContextLanguages("")
+	if len(languages) != 5 {
+		t.Fatalf("expected 5 default languages including Java, got %v", languages)
+	}
+	if languages[4] != "Java" {
+		t.Fatalf("expected Java in default language set tail, got %v", languages)
+	}
+}

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -73,7 +73,7 @@ func legacyBuildRulesAnalysisContext(absPath string, graph Graph, primaryLanguag
 		repoFiles = append(repoFiles, readRepositoryFileForContext(graph, node))
 	}
 
-	languages := []string{"Go", "Python", "JavaScript", "TypeScript"}
+	languages := []string{"Go", "Python", "JavaScript", "TypeScript", "Java"}
 	if primaryLanguage != "" {
 		languages = []string{primaryLanguage}
 	}


### PR DESCRIPTION
## Summary
- wire Java into default language policy and runtime fallback language contexts
- ensure java_pilot_enabled repositories can resolve Java through the main adapter pipeline
- add integration and deterministic coverage for Java pilot language selection behavior

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .

Closes #212