### PR TITLE
[v0.20][RD-2007] Pilot go/no-go decision

### DIFF
--- a/JAVA_PILOT_DECISION_v0.20.md
+++ b/JAVA_PILOT_DECISION_v0.20.md
@@ -1,0 +1,38 @@
+# RepoDoctor v0.20 Java Pilot Decision Memo
+
+## Scope
+
+This memo records the go/no-go decision for the gated Java pilot after completing RD-2001 through RD-2006.
+
+## Evidence Summary
+
+- Java pilot contract is default-off (`language_detection.java_pilot_enabled`), preserving backward compatibility.
+- Java adapter skeleton and extraction MVP are implemented with deterministic file discovery and import graph generation.
+- Abuse-resistance bounds are in place:
+  - max file bytes,
+  - bounded scan/import rows,
+  - NUL-safe line handling,
+  - fail-soft behavior on malformed/oversized files.
+- Java pilot fixture corpus and benchmark smoke are available under `internal/languages/testdata/java_pilot_fixture`.
+- Core quality gates remain green:
+  - `go test ./...`
+  - `go vet ./...`
+  - `go run . analyze -path .` (100/100)
+
+## Decision
+
+**GO (GATED)**
+
+Proceed with Java support only behind the explicit pilot flag.
+
+## Guardrails
+
+1. Java stays disabled by default for all users.
+2. Any performance or determinism regression blocks default enablement.
+3. Rule engine remains language-agnostic (no Java-specific rule forks).
+4. CI gates and stabilization packs must stay green on Linux and Windows.
+
+## Follow-up
+
+- Keep pilot telemetry/evidence collection active in upcoming iterations.
+- Re-evaluate default enablement only after sustained stability across multiple releases.

--- a/docs/report.md
+++ b/docs/report.md
@@ -6,7 +6,7 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 |---|---|---|---|
 | v0.17 | S8-v0.17 Near-Max Practical Maturity | Completed | Maturity report published (`docs/v0.17-maturity-report.md`). |
 | v0.18 | M0: v0.18 Contract Hardening | Completed | RD-1801..RD-1808 merged into `dev`; close-out, path-safety, and CI supply-chain gates active. |
-| v0.19 | M1: v0.19 Incremental & Performance | In Progress | RD-1901..RD-1906 and RD-1908 merged into `dev`; stabilization gate pack active, release close pending RD-1907. |
-| v0.20 | M2: v0.20 Java Pilot (Gated) | Planned | Issues RD-2001..RD-2007 created (default-off pilot). |
+| v0.19 | M1: v0.19 Incremental & Performance | Completed | RD-1901..RD-1908 merged; release stabilization gate and benchmark+memory CI budgets active. |
+| v0.20 | M2: v0.20 Java Pilot (Gated) | Completed (Gated GO) | RD-2001..RD-2007 completed; decision memo published (`JAVA_PILOT_DECISION_v0.20.md`), pilot remains default-off. |
 | v1.0 | M3: v1.0 UX & Polish | Planned | Issues RD-10001..RD-10005 created. |
 | v1.1+ | M4: v1.1+ Scale (Use-case gated) | Planned | Issues RD-11001..RD-11003 created. |


### PR DESCRIPTION
## Summary
- publish v0.20 Java pilot go/no-go decision memo with explicit guardrails and follow-up criteria
- update version report tracker to mark v0.19 as completed and v0.20 as completed (gated GO)
- keep Java rollout constrained to default-off pilot mode pending sustained stability evidence

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .

Closes #214