### PR TITLE
release(v0.20): gated Java pilot completion

### DIFF
--- a/JAVA_PILOT_DECISION_v0.20.md
+++ b/JAVA_PILOT_DECISION_v0.20.md
@@ -1,0 +1,38 @@
+# RepoDoctor v0.20 Java Pilot Decision Memo
+
+## Scope
+
+This memo records the go/no-go decision for the gated Java pilot after completing RD-2001 through RD-2006.
+
+## Evidence Summary
+
+- Java pilot contract is default-off (`language_detection.java_pilot_enabled`), preserving backward compatibility.
+- Java adapter skeleton and extraction MVP are implemented with deterministic file discovery and import graph generation.
+- Abuse-resistance bounds are in place:
+  - max file bytes,
+  - bounded scan/import rows,
+  - NUL-safe line handling,
+  - fail-soft behavior on malformed/oversized files.
+- Java pilot fixture corpus and benchmark smoke are available under `internal/languages/testdata/java_pilot_fixture`.
+- Core quality gates remain green:
+  - `go test ./...`
+  - `go vet ./...`
+  - `go run . analyze -path .` (100/100)
+
+## Decision
+
+**GO (GATED)**
+
+Proceed with Java support only behind the explicit pilot flag.
+
+## Guardrails
+
+1. Java stays disabled by default for all users.
+2. Any performance or determinism regression blocks default enablement.
+3. Rule engine remains language-agnostic (no Java-specific rule forks).
+4. CI gates and stabilization packs must stay green on Linux and Windows.
+
+## Follow-up
+
+- Keep pilot telemetry/evidence collection active in upcoming iterations.
+- Re-evaluate default enablement only after sustained stability across multiple releases.

--- a/adapter_registry.go
+++ b/adapter_registry.go
@@ -7,7 +7,10 @@ func registerCoreAdapters(detector *languages.RepositoryLanguageDetector, config
 	detector.RegisterAdapter(languages.NewPythonAdapter())
 	detector.RegisterAdapter(languages.NewJavaScriptAdapter())
 	detector.RegisterAdapter(languages.NewTypeScriptAdapter())
-	_ = isJavaPilotEnabled(config)
+
+	if isJavaPilotEnabled(config) {
+		detector.RegisterAdapter(languages.NewJavaAdapter())
+	}
 }
 
 func isJavaPilotEnabled(config *Config) bool {

--- a/adapter_registry.go
+++ b/adapter_registry.go
@@ -1,0 +1,18 @@
+package main
+
+import "RepoDoctor/internal/languages"
+
+func registerCoreAdapters(detector *languages.RepositoryLanguageDetector, config *Config) {
+	detector.RegisterAdapter(languages.NewGoAdapter())
+	detector.RegisterAdapter(languages.NewPythonAdapter())
+	detector.RegisterAdapter(languages.NewJavaScriptAdapter())
+	detector.RegisterAdapter(languages.NewTypeScriptAdapter())
+	_ = isJavaPilotEnabled(config)
+}
+
+func isJavaPilotEnabled(config *Config) bool {
+	if config == nil || config.LanguageDetection == nil || config.LanguageDetection.JavaPilot == nil {
+		return false
+	}
+	return *config.LanguageDetection.JavaPilot
+}

--- a/adapter_registry_test.go
+++ b/adapter_registry_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	"RepoDoctor/internal/domain"
+	"RepoDoctor/internal/languages"
+)
+
+func TestIsJavaPilotEnabled_DefaultFalse(t *testing.T) {
+	if isJavaPilotEnabled(nil) {
+		t.Fatal("nil config must not enable java pilot")
+	}
+
+	if isJavaPilotEnabled(&Config{LanguageDetection: &LanguageDetectionConfig{}}) {
+		t.Fatal("missing java pilot flag must default to false")
+	}
+}
+
+func TestIsJavaPilotEnabled_ExplicitTrue(t *testing.T) {
+	enabled := true
+	cfg := &Config{LanguageDetection: &LanguageDetectionConfig{JavaPilot: &enabled}}
+	if !isJavaPilotEnabled(cfg) {
+		t.Fatal("explicit java pilot flag must be honored")
+	}
+}
+
+func TestRegisterCoreAdapters_StableBaseContract(t *testing.T) {
+	strategy := domain.NewDefaultIgnoreStrategy(domain.DefaultIgnoredDirs)
+	detector := languages.NewRepositoryLanguageDetector(strategy)
+
+	enabled := true
+	cfg := &Config{LanguageDetection: &LanguageDetectionConfig{JavaPilot: &enabled}}
+	registerCoreAdapters(detector, cfg)
+
+	supported := detector.GetSupportedLanguages()
+	if len(supported) != 4 {
+		t.Fatalf("expected stable 4-language base contract in pilot-flag phase, got %v", supported)
+	}
+}

--- a/adapter_registry_test.go
+++ b/adapter_registry_test.go
@@ -25,16 +25,21 @@ func TestIsJavaPilotEnabled_ExplicitTrue(t *testing.T) {
 	}
 }
 
-func TestRegisterCoreAdapters_StableBaseContract(t *testing.T) {
+func TestRegisterCoreAdapters_JavaPilotGate(t *testing.T) {
 	strategy := domain.NewDefaultIgnoreStrategy(domain.DefaultIgnoredDirs)
-	detector := languages.NewRepositoryLanguageDetector(strategy)
+	baseDetector := languages.NewRepositoryLanguageDetector(strategy)
+	registerCoreAdapters(baseDetector, &Config{LanguageDetection: &LanguageDetectionConfig{}})
+	if got := len(baseDetector.GetSupportedLanguages()); got != 4 {
+		t.Fatalf("expected 4 languages when java pilot disabled, got %d", got)
+	}
 
+	detector := languages.NewRepositoryLanguageDetector(strategy)
 	enabled := true
 	cfg := &Config{LanguageDetection: &LanguageDetectionConfig{JavaPilot: &enabled}}
 	registerCoreAdapters(detector, cfg)
 
 	supported := detector.GetSupportedLanguages()
-	if len(supported) != 4 {
-		t.Fatalf("expected stable 4-language base contract in pilot-flag phase, got %v", supported)
+	if len(supported) != 5 {
+		t.Fatalf("expected Java to be registered when pilot enabled, got %v", supported)
 	}
 }

--- a/analysis_language_evidence.go
+++ b/analysis_language_evidence.go
@@ -83,7 +83,7 @@ func loadLanguageTieBreak(absPath string) []string {
 	if config != nil && config.LanguageDetection != nil && len(config.LanguageDetection.TieBreakOrder) > 0 {
 		return append([]string(nil), config.LanguageDetection.TieBreakOrder...)
 	}
-	return []string{"Python", "TypeScript", "JavaScript", "Go"}
+	return []string{"Python", "TypeScript", "JavaScript", "Go", "Java"}
 }
 
 func rankLanguageStats(stats []languages.LanguageStat, tieBreak []string) []languages.LanguageStat {

--- a/analysis_language_evidence.go
+++ b/analysis_language_evidence.go
@@ -73,10 +73,7 @@ func collectLanguageStats(absPath string) ([]languages.LanguageStat, error) {
 	}
 
 	detector := languages.NewRepositoryLanguageDetectorWithPolicy(ignoreStrategy, policy)
-	detector.RegisterAdapter(languages.NewGoAdapter())
-	detector.RegisterAdapter(languages.NewPythonAdapter())
-	detector.RegisterAdapter(languages.NewJavaScriptAdapter())
-	detector.RegisterAdapter(languages.NewTypeScriptAdapter())
+	registerCoreAdapters(detector, config)
 
 	return detector.GetLanguageStats(absPath)
 }

--- a/analysis_language_evidence_test.go
+++ b/analysis_language_evidence_test.go
@@ -13,7 +13,7 @@ func TestRankLanguageStats_DeterministicAndReasonableOrder(t *testing.T) {
 		{Language: "TypeScript", ProductScore: 8, Score: 30, Lines: 120, Count: 6},
 	}
 
-	ranked := rankLanguageStats(stats, []string{"Python", "TypeScript", "JavaScript", "Go"})
+	ranked := rankLanguageStats(stats, []string{"Python", "TypeScript", "JavaScript", "Go", "Java"})
 	if len(ranked) != 3 {
 		t.Fatalf("expected 3 ranked stats, got %d", len(ranked))
 	}

--- a/config.go
+++ b/config.go
@@ -30,6 +30,7 @@ type LanguageDetectionConfig struct {
 	Weights        map[string]float64 `yaml:"weights,omitempty"`
 	TieBreakOrder  []string           `yaml:"tie_break_order,omitempty"`
 	SegmentWeights map[string]float64 `yaml:"segment_weights,omitempty"`
+	JavaPilot      *bool              `yaml:"java_pilot_enabled,omitempty"`
 }
 
 // SizeConfig holds size rule configuration
@@ -233,6 +234,7 @@ func (l *ConfigLoader) getDefaultConfig() *Config {
 				"Python":     1.0,
 				"JavaScript": 1.0,
 				"TypeScript": 1.0,
+				"Java":       0.8,
 			},
 			TieBreakOrder: []string{"Python", "TypeScript", "JavaScript", "Go"},
 			SegmentWeights: map[string]float64{
@@ -242,9 +244,14 @@ func (l *ConfigLoader) getDefaultConfig() *Config {
 				"tools":   0.2,
 				"scripts": 0.2,
 			},
+			JavaPilot: boolPtr(false),
 		},
 		Architecture: &ArchitectureConfig{Profile: "layered"},
 	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }
 
 // mergeWithDefaults merges provided config with defaults
@@ -351,6 +358,9 @@ func mergeLanguageDetectionConfig(cfg, defaults *Config) {
 	if cfg.LanguageDetection.SegmentWeights == nil {
 		cfg.LanguageDetection.SegmentWeights = defaults.LanguageDetection.SegmentWeights
 	}
+	if cfg.LanguageDetection.JavaPilot == nil {
+		cfg.LanguageDetection.JavaPilot = defaults.LanguageDetection.JavaPilot
+	}
 }
 
 func mergeArchitectureConfig(cfg, defaults *Config) {
@@ -394,7 +404,7 @@ func rejectUnknownConfigKeys(data []byte) error {
 		encoded, _ := json.Marshal(ldRaw)
 		var ld map[string]interface{}
 		_ = json.Unmarshal(encoded, &ld)
-		allowedLD := map[string]bool{"weights": true, "tie_break_order": true, "segment_weights": true}
+		allowedLD := map[string]bool{"weights": true, "tie_break_order": true, "segment_weights": true, "java_pilot_enabled": true}
 		for key := range ld {
 			if !allowedLD[key] {
 				return fmt.Errorf("config validation error: unknown language_detection key '%s'", key)

--- a/config.go
+++ b/config.go
@@ -236,7 +236,7 @@ func (l *ConfigLoader) getDefaultConfig() *Config {
 				"TypeScript": 1.0,
 				"Java":       0.8,
 			},
-			TieBreakOrder: []string{"Python", "TypeScript", "JavaScript", "Go"},
+			TieBreakOrder: []string{"Python", "TypeScript", "JavaScript", "Go", "Java"},
 			SegmentWeights: map[string]float64{
 				"src":     1.0,
 				"app":     1.0,

--- a/config_test.go
+++ b/config_test.go
@@ -297,6 +297,38 @@ language_detection:
 	}
 }
 
+func TestConfigLoader_JavaPilotFlagDefaultsToDisabled(t *testing.T) {
+	loader := NewConfigLoader(filepath.Join(t.TempDir(), "missing.yaml"))
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("unexpected load error: %v", err)
+	}
+	if cfg.LanguageDetection == nil || cfg.LanguageDetection.JavaPilot == nil {
+		t.Fatal("expected java pilot flag to be defaulted")
+	}
+	if *cfg.LanguageDetection.JavaPilot {
+		t.Fatal("expected java pilot to be disabled by default")
+	}
+}
+
+func TestConfigLoader_JavaPilotFlagCanBeEnabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	configContent := "language_detection:\n  java_pilot_enabled: true\n"
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed writing config: %v", err)
+	}
+
+	loader := NewConfigLoader(configPath)
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("expected java pilot config to load, got: %v", err)
+	}
+	if cfg.LanguageDetection == nil || cfg.LanguageDetection.JavaPilot == nil || !*cfg.LanguageDetection.JavaPilot {
+		t.Fatalf("expected java pilot flag enabled, got %+v", cfg.LanguageDetection)
+	}
+}
+
 func TestConfigLoader_MergeWithDefaults_TableDrivenInvariants(t *testing.T) {
 	loader := NewConfigLoader("")
 	enabled := false

--- a/docs/report.md
+++ b/docs/report.md
@@ -6,7 +6,7 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 |---|---|---|---|
 | v0.17 | S8-v0.17 Near-Max Practical Maturity | Completed | Maturity report published (`docs/v0.17-maturity-report.md`). |
 | v0.18 | M0: v0.18 Contract Hardening | Completed | RD-1801..RD-1808 merged into `dev`; close-out, path-safety, and CI supply-chain gates active. |
-| v0.19 | M1: v0.19 Incremental & Performance | In Progress | RD-1901..RD-1906 and RD-1908 merged into `dev`; stabilization gate pack active, release close pending RD-1907. |
-| v0.20 | M2: v0.20 Java Pilot (Gated) | Planned | Issues RD-2001..RD-2007 created (default-off pilot). |
+| v0.19 | M1: v0.19 Incremental & Performance | Completed | RD-1901..RD-1908 merged; release stabilization gate and benchmark+memory CI budgets active. |
+| v0.20 | M2: v0.20 Java Pilot (Gated) | Completed (Gated GO) | RD-2001..RD-2007 completed; decision memo published (`JAVA_PILOT_DECISION_v0.20.md`), pilot remains default-off. |
 | v1.0 | M3: v1.0 UX & Polish | Planned | Issues RD-10001..RD-10005 created. |
 | v1.1+ | M4: v1.1+ Scale (Use-case gated) | Planned | Issues RD-11001..RD-11003 created. |

--- a/internal/languages/java_adapter.go
+++ b/internal/languages/java_adapter.go
@@ -19,6 +19,7 @@ const (
 var (
 	javaPackagePattern = regexp.MustCompile(`^\s*package\s+([A-Za-z_][\w.]*)\s*;`)
 	javaImportPattern  = regexp.MustCompile(`^\s*import\s+(?:static\s+)?([A-Za-z_][\w.*]*)\s*;`)
+	javaTypePattern    = regexp.MustCompile(`\b(class|interface|enum|record)\s+([A-Za-z_][\w]*)`)
 	javaMethodPattern  = regexp.MustCompile(`\b(?:public|protected|private)?\s*(?:static\s+)?(?:final\s+)?[A-Za-z_][\w<>\[\]]*\s+([A-Za-z_][\w]*)\s*\(`)
 )
 
@@ -66,25 +67,43 @@ func (a *JavaAdapter) DetectFiles(repoPath string) ([]string, error) {
 func (a *JavaAdapter) CollectMetrics(files []string) (*model.RepositoryMetrics, error) {
 	metrics := model.NewRepositoryMetrics()
 	for _, file := range files {
-		fm, err := a.collectFileMetrics(file)
+		fm, functions, structs, err := a.collectFileMetrics(file)
 		if err != nil {
 			continue
 		}
 		metrics.AddFileMetrics(*fm)
+		for _, fn := range functions {
+			metrics.AddFunctionMetrics(fn)
+		}
+		for _, st := range structs {
+			metrics.AddStructMetrics(st)
+		}
 	}
 	return metrics, nil
 }
 
-func (a *JavaAdapter) collectFileMetrics(path string) (*model.FileMetrics, error) {
+func (a *JavaAdapter) collectFileMetrics(path string) (*model.FileMetrics, []model.FunctionMetrics, []model.StructMetrics, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
 	if len(content) > maxJavaFileBytes {
-		return nil, fmt.Errorf("java file too large for safe parsing: %s", path)
+		return nil, nil, nil, fmt.Errorf("java file too large for safe parsing: %s", path)
 	}
 
 	lines := strings.Split(string(content), "\n")
+	functions, imports := countJavaFunctionsAndImports(lines)
+	functionMetrics, structMetrics := extractJavaSymbolMetrics(path, lines)
+
+	return &model.FileMetrics{
+		Path:      path,
+		Lines:     len(lines),
+		Functions: functions,
+		Imports:   imports,
+	}, functionMetrics, structMetrics, nil
+}
+
+func countJavaFunctionsAndImports(lines []string) (int, int) {
 	functions := 0
 	imports := 0
 	for _, line := range lines {
@@ -99,13 +118,49 @@ func (a *JavaAdapter) collectFileMetrics(path string) (*model.FileMetrics, error
 			functions++
 		}
 	}
+	return functions, imports
+}
 
-	return &model.FileMetrics{
-		Path:      path,
-		Lines:     len(lines),
-		Functions: functions,
-		Imports:   imports,
-	}, nil
+func extractJavaSymbolMetrics(path string, lines []string) ([]model.FunctionMetrics, []model.StructMetrics) {
+	functionMetrics := make([]model.FunctionMetrics, 0)
+	structMetrics := make([]model.StructMetrics, 0)
+	structMethods := make(map[string]int)
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "*") {
+			continue
+		}
+		if m := javaTypePattern.FindStringSubmatch(trimmed); len(m) == 3 {
+			structMetrics = append(structMetrics, model.StructMetrics{Name: m[2], File: path, Line: i + 1, Exported: true})
+			continue
+		}
+		if m := javaMethodPattern.FindStringSubmatch(trimmed); len(m) == 2 {
+			functionMetrics = append(functionMetrics, model.FunctionMetrics{Name: m[1], File: path, Line: i + 1, Parameters: javaMethodParameterCount(trimmed)})
+			if len(structMetrics) > 0 {
+				owner := structMetrics[len(structMetrics)-1].Name
+				structMethods[owner]++
+			}
+		}
+	}
+
+	for i := range structMetrics {
+		structMetrics[i].Methods = structMethods[structMetrics[i].Name]
+	}
+	return functionMetrics, structMetrics
+}
+
+func javaMethodParameterCount(signature string) int {
+	open := strings.Index(signature, "(")
+	close := strings.Index(signature, ")")
+	if open < 0 || close <= open {
+		return 0
+	}
+	params := strings.TrimSpace(signature[open+1 : close])
+	if params == "" {
+		return 0
+	}
+	return strings.Count(params, ",") + 1
 }
 
 func (a *JavaAdapter) BuildDependencyGraph(files []string) (*model.DependencyGraph, error) {

--- a/internal/languages/java_adapter.go
+++ b/internal/languages/java_adapter.go
@@ -1,0 +1,188 @@
+package languages
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"RepoDoctor/internal/model"
+)
+
+const (
+	maxJavaFileBytes = 2 * 1024 * 1024
+)
+
+var (
+	javaPackagePattern = regexp.MustCompile(`^\s*package\s+([A-Za-z_][\w.]*)\s*;`)
+	javaImportPattern  = regexp.MustCompile(`^\s*import\s+(?:static\s+)?([A-Za-z_][\w.*]*)\s*;`)
+	javaMethodPattern  = regexp.MustCompile(`\b(?:public|protected|private)?\s*(?:static\s+)?(?:final\s+)?[A-Za-z_][\w<>\[\]]*\s+([A-Za-z_][\w]*)\s*\(`)
+)
+
+type JavaAdapter struct{}
+
+func NewJavaAdapter() LanguageAdapter {
+	return &JavaAdapter{}
+}
+
+func (a *JavaAdapter) Name() string {
+	return "Java"
+}
+
+func (a *JavaAdapter) FileExtensions() []string {
+	return []string{".java"}
+}
+
+func (a *JavaAdapter) DetectFiles(repoPath string) ([]string, error) {
+	javaFiles := make([]string, 0)
+	err := filepath.WalkDir(repoPath, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			name := strings.ToLower(d.Name())
+			if strings.HasPrefix(name, ".") || name == "target" || name == "build" || name == "out" || name == ".gradle" {
+				if path != repoPath {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		if strings.ToLower(filepath.Ext(path)) == ".java" {
+			javaFiles = append(javaFiles, filepath.Clean(path))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(javaFiles)
+	return javaFiles, nil
+}
+
+func (a *JavaAdapter) CollectMetrics(files []string) (*model.RepositoryMetrics, error) {
+	metrics := model.NewRepositoryMetrics()
+	for _, file := range files {
+		fm, err := a.collectFileMetrics(file)
+		if err != nil {
+			continue
+		}
+		metrics.AddFileMetrics(*fm)
+	}
+	return metrics, nil
+}
+
+func (a *JavaAdapter) collectFileMetrics(path string) (*model.FileMetrics, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(content) > maxJavaFileBytes {
+		return nil, fmt.Errorf("java file too large for safe parsing: %s", path)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	functions := 0
+	imports := 0
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "*") {
+			continue
+		}
+		if javaImportPattern.MatchString(trimmed) {
+			imports++
+		}
+		if javaMethodPattern.MatchString(trimmed) {
+			functions++
+		}
+	}
+
+	return &model.FileMetrics{
+		Path:      path,
+		Lines:     len(lines),
+		Functions: functions,
+		Imports:   imports,
+	}, nil
+}
+
+func (a *JavaAdapter) BuildDependencyGraph(files []string) (*model.DependencyGraph, error) {
+	graph := model.NewDependencyGraph()
+	for _, file := range files {
+		pkgName, imports, err := a.extractFilePackageAndImports(file)
+		if err != nil {
+			continue
+		}
+		node := graph.AddNode(file, file, pkgName)
+		for _, imp := range imports {
+			normalized := a.NormalizeImport(imp)
+			if normalized == "" {
+				continue
+			}
+			node.Imports = append(node.Imports, normalized)
+			if node.Metadata == nil {
+				node.Metadata = make(map[string]string)
+			}
+			node.Metadata["import_class:"+normalized] = "internal"
+			graph.AddEdge(file, normalized)
+		}
+	}
+	return graph, nil
+}
+
+func (a *JavaAdapter) extractFilePackageAndImports(path string) (string, []string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", nil, err
+	}
+	defer file.Close()
+
+	pkg := ""
+	imports := make([]string, 0, 8)
+	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.ContainsRune(line, '\x00') {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if pkg == "" {
+			if m := javaPackagePattern.FindStringSubmatch(trimmed); len(m) == 2 {
+				pkg = m[1]
+			}
+		}
+		if m := javaImportPattern.FindStringSubmatch(trimmed); len(m) == 2 {
+			imports = append(imports, m[1])
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", nil, err
+	}
+	sort.Strings(imports)
+	return pkg, imports, nil
+}
+
+func (a *JavaAdapter) IsStdlibPackage(importPath string) bool {
+	normalized := strings.TrimSpace(importPath)
+	return strings.HasPrefix(normalized, "java.") || strings.HasPrefix(normalized, "javax.") || strings.HasPrefix(normalized, "jdk.") || strings.HasPrefix(normalized, "sun.")
+}
+
+func (a *JavaAdapter) Capabilities() AdapterCapabilities {
+	return AdapterCapabilities{
+		SupportsDependencyGraph: true,
+		SupportsMetrics:         true,
+		UsesASTParsing:          false,
+	}
+}
+
+func (a *JavaAdapter) NormalizeImport(importPath string) string {
+	normalized := strings.TrimSpace(importPath)
+	normalized = strings.TrimSuffix(normalized, ";")
+	normalized = strings.TrimPrefix(normalized, "static ")
+	normalized = strings.TrimSuffix(normalized, ".*")
+	return normalized
+}

--- a/internal/languages/java_adapter.go
+++ b/internal/languages/java_adapter.go
@@ -13,7 +13,9 @@ import (
 )
 
 const (
-	maxJavaFileBytes = 2 * 1024 * 1024
+	maxJavaFileBytes  = 2 * 1024 * 1024
+	maxJavaFilesScan  = 10000
+	maxJavaImportRows = 50000
 )
 
 var (
@@ -39,6 +41,7 @@ func (a *JavaAdapter) FileExtensions() []string {
 
 func (a *JavaAdapter) DetectFiles(repoPath string) ([]string, error) {
 	javaFiles := make([]string, 0)
+	seen := 0
 	err := filepath.WalkDir(repoPath, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -53,6 +56,10 @@ func (a *JavaAdapter) DetectFiles(repoPath string) ([]string, error) {
 			return nil
 		}
 		if strings.ToLower(filepath.Ext(path)) == ".java" {
+			seen++
+			if seen > maxJavaFilesScan {
+				return nil
+			}
 			javaFiles = append(javaFiles, filepath.Clean(path))
 		}
 		return nil
@@ -176,7 +183,6 @@ func (a *JavaAdapter) BuildDependencyGraph(files []string) (*model.DependencyGra
 			if normalized == "" {
 				continue
 			}
-			node.Imports = append(node.Imports, normalized)
 			if node.Metadata == nil {
 				node.Metadata = make(map[string]string)
 			}
@@ -199,7 +205,12 @@ func (a *JavaAdapter) extractFilePackageAndImports(path string) (string, []strin
 	scanner := bufio.NewScanner(file)
 	buf := make([]byte, 0, 64*1024)
 	scanner.Buffer(buf, 1024*1024)
+	rows := 0
 	for scanner.Scan() {
+		rows++
+		if rows > maxJavaImportRows {
+			break
+		}
 		line := scanner.Text()
 		if strings.ContainsRune(line, '\x00') {
 			continue

--- a/internal/languages/java_adapter_benchmark_test.go
+++ b/internal/languages/java_adapter_benchmark_test.go
@@ -1,0 +1,47 @@
+package languages
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func BenchmarkJavaAdapter_DetectCollectGraph(b *testing.B) {
+	repo := b.TempDir()
+	seedJavaBenchmarkFixture(b, repo, 400)
+	adapter := NewJavaAdapter()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		files, err := adapter.DetectFiles(repo)
+		if err != nil {
+			b.Fatalf("DetectFiles failed: %v", err)
+		}
+		if _, err := adapter.CollectMetrics(files); err != nil {
+			b.Fatalf("CollectMetrics failed: %v", err)
+		}
+		if _, err := adapter.BuildDependencyGraph(files); err != nil {
+			b.Fatalf("BuildDependencyGraph failed: %v", err)
+		}
+	}
+}
+
+func seedJavaBenchmarkFixture(b *testing.B, repo string, files int) {
+	b.Helper()
+	for i := 0; i < files; i++ {
+		dir := filepath.Join(repo, "src", "main", "java", "pkg", strconv.Itoa(i%20))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			b.Fatalf("failed creating fixture dir: %v", err)
+		}
+		path := filepath.Join(dir, "Class"+strconv.Itoa(i)+".java")
+		content := "package pkg." + strconv.Itoa(i%20) + ";\n" +
+			"import java.util.List;\n" +
+			"public class Class" + strconv.Itoa(i) + " {\n" +
+			"  public int value(" + "int a, int b" + ") { return a + b + " + strconv.Itoa(i) + "; }\n" +
+			"}\n"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			b.Fatalf("failed writing fixture file: %v", err)
+		}
+	}
+}

--- a/internal/languages/java_adapter_test.go
+++ b/internal/languages/java_adapter_test.go
@@ -83,6 +83,31 @@ func TestJavaAdapter_BuildDependencyGraph_Deterministic(t *testing.T) {
 	}
 }
 
+func TestJavaAdapter_CollectMetrics_ExtractsTypesAndMethods(t *testing.T) {
+	repo := t.TempDir()
+	file := filepath.Join(repo, "Service.java")
+	content := strings.Join([]string{
+		"package app.core;",
+		"import java.util.List;",
+		"public class Service {",
+		"  public Service() {}",
+		"  public int run(String a, int b) { return b; }",
+		"}",
+	}, "\n")
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed writing java fixture: %v", err)
+	}
+
+	adapter := NewJavaAdapter()
+	metrics, err := adapter.CollectMetrics([]string{file})
+	if err != nil {
+		t.Fatalf("CollectMetrics failed: %v", err)
+	}
+	if metrics.TotalFiles != 1 || metrics.TotalFunctions == 0 || metrics.TotalStructs == 0 {
+		t.Fatalf("expected java metrics extraction, got files=%d funcs=%d structs=%d", metrics.TotalFiles, metrics.TotalFunctions, metrics.TotalStructs)
+	}
+}
+
 func adapterDetectFilesForTest(adapter LanguageAdapter, repo string) ([]string, error) {
 	return adapter.DetectFiles(repo)
 }

--- a/internal/languages/java_adapter_test.go
+++ b/internal/languages/java_adapter_test.go
@@ -1,0 +1,88 @@
+package languages
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestJavaAdapter_CapabilitiesAndNormalizeImport(t *testing.T) {
+	adapter := NewJavaAdapter()
+	caps := adapter.Capabilities()
+	if !caps.SupportsDependencyGraph || !caps.SupportsMetrics {
+		t.Fatal("expected Java adapter to support graph and metrics")
+	}
+
+	if got := adapter.NormalizeImport(" static java.util.Collections.*;"); got != "java.util.Collections" {
+		t.Fatalf("unexpected normalized Java import: %q", got)
+	}
+}
+
+func TestJavaAdapter_DetectFilesAndSkipBuildDirs(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "src", "main", "java"), 0o755); err != nil {
+		t.Fatalf("failed to create src dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "target"), 0o755); err != nil {
+		t.Fatalf("failed to create target dir: %v", err)
+	}
+
+	prod := filepath.Join(repo, "src", "main", "java", "App.java")
+	ignored := filepath.Join(repo, "target", "Generated.java")
+	if err := os.WriteFile(prod, []byte("package app;\nclass App {}\n"), 0o644); err != nil {
+		t.Fatalf("failed writing prod fixture: %v", err)
+	}
+	if err := os.WriteFile(ignored, []byte("class Generated {}\n"), 0o644); err != nil {
+		t.Fatalf("failed writing ignored fixture: %v", err)
+	}
+
+	files, err := adapterDetectFilesForTest(NewJavaAdapter(), repo)
+	if err != nil {
+		t.Fatalf("DetectFiles failed: %v", err)
+	}
+	if len(files) != 1 || filepath.Clean(files[0]) != filepath.Clean(prod) {
+		t.Fatalf("expected only production java file, got %v", files)
+	}
+}
+
+func TestJavaAdapter_BuildDependencyGraph_Deterministic(t *testing.T) {
+	repo := t.TempDir()
+	file := filepath.Join(repo, "App.java")
+	content := strings.Join([]string{
+		"package app.core;",
+		"import java.util.List;",
+		"import com.acme.shared.Util;",
+		"public class App {",
+		"  public void run() {}",
+		"}",
+	}, "\n")
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed writing java fixture: %v", err)
+	}
+
+	adapter := NewJavaAdapter()
+	first, err := adapter.BuildDependencyGraph([]string{file})
+	if err != nil {
+		t.Fatalf("BuildDependencyGraph failed: %v", err)
+	}
+	baseline := strings.Join(first.GetNode(file).Imports, "|")
+
+	for i := 0; i < 10; i++ {
+		next, nextErr := adapter.BuildDependencyGraph([]string{file})
+		if nextErr != nil {
+			t.Fatalf("BuildDependencyGraph failed on iteration %d: %v", i, nextErr)
+		}
+		node := next.GetNode(file)
+		if node == nil {
+			t.Fatalf("expected graph node for %s", file)
+		}
+		if current := strings.Join(node.Imports, "|"); current != baseline {
+			t.Fatalf("java graph imports must be deterministic, baseline=%q current=%q", baseline, current)
+		}
+	}
+}
+
+func adapterDetectFilesForTest(adapter LanguageAdapter, repo string) ([]string, error) {
+	return adapter.DetectFiles(repo)
+}

--- a/internal/languages/java_adapter_test.go
+++ b/internal/languages/java_adapter_test.go
@@ -3,6 +3,7 @@ package languages
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -110,4 +111,64 @@ func TestJavaAdapter_CollectMetrics_ExtractsTypesAndMethods(t *testing.T) {
 
 func adapterDetectFilesForTest(adapter LanguageAdapter, repo string) ([]string, error) {
 	return adapter.DetectFiles(repo)
+}
+
+func TestJavaAdapter_CollectMetrics_FailSoftOnOversizedFile(t *testing.T) {
+	repo := t.TempDir()
+	file := filepath.Join(repo, "Huge.java")
+	big := strings.Repeat("a", maxJavaFileBytes+1)
+	if err := os.WriteFile(file, []byte(big), 0o644); err != nil {
+		t.Fatalf("failed writing oversized fixture: %v", err)
+	}
+
+	adapter := NewJavaAdapter()
+	metrics, err := adapter.CollectMetrics([]string{file})
+	if err != nil {
+		t.Fatalf("CollectMetrics should fail-soft and return no error, got: %v", err)
+	}
+	if metrics.TotalFiles != 0 {
+		t.Fatalf("oversized file should be skipped, got files=%d", metrics.TotalFiles)
+	}
+}
+
+func TestJavaAdapter_DetectFiles_BoundedByMaxScanLimit(t *testing.T) {
+	repo := t.TempDir()
+	for i := 0; i < maxJavaFilesScan+100; i++ {
+		path := filepath.Join(repo, "src", "F"+strconv.Itoa(i)+".java")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("failed creating fixture dir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("class F{}\n"), 0o644); err != nil {
+			t.Fatalf("failed writing fixture file: %v", err)
+		}
+	}
+
+	files, err := NewJavaAdapter().DetectFiles(repo)
+	if err != nil {
+		t.Fatalf("DetectFiles failed: %v", err)
+	}
+	if len(files) != maxJavaFilesScan {
+		t.Fatalf("expected bounded java scan size %d, got %d", maxJavaFilesScan, len(files))
+	}
+}
+
+func TestJavaAdapter_BuildDependencyGraph_SkipsNULImportLines(t *testing.T) {
+	repo := t.TempDir()
+	file := filepath.Join(repo, "App.java")
+	content := "package a;\nimport com.acme.Ok;\nimport bad\x00line;\n"
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed writing fixture: %v", err)
+	}
+
+	graph, err := NewJavaAdapter().BuildDependencyGraph([]string{file})
+	if err != nil {
+		t.Fatalf("BuildDependencyGraph failed: %v", err)
+	}
+	node := graph.GetNode(file)
+	if node == nil {
+		t.Fatalf("expected node for %s", file)
+	}
+	if len(node.Imports) != 1 || node.Imports[0] != "com.acme.Ok" {
+		t.Fatalf("expected only safe import to survive NUL filtering, got %v", node.Imports)
+	}
 }

--- a/internal/languages/java_pilot_fixture_test.go
+++ b/internal/languages/java_pilot_fixture_test.go
@@ -1,0 +1,52 @@
+package languages
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestJavaPilotFixture_DeterministicEvidence(t *testing.T) {
+	fixture := filepath.Join("testdata", "java_pilot_fixture")
+	adapter := NewJavaAdapter()
+
+	firstFiles, err := adapter.DetectFiles(fixture)
+	if err != nil {
+		t.Fatalf("DetectFiles failed: %v", err)
+	}
+	if len(firstFiles) < 2 {
+		t.Fatalf("expected at least 2 Java files in fixture, got %d", len(firstFiles))
+	}
+
+	firstMetrics, err := adapter.CollectMetrics(firstFiles)
+	if err != nil {
+		t.Fatalf("CollectMetrics failed: %v", err)
+	}
+	if firstMetrics.TotalFiles == 0 || firstMetrics.TotalFunctions == 0 {
+		t.Fatalf("expected non-empty Java metrics from fixture, got %+v", firstMetrics)
+	}
+
+	firstGraph, err := adapter.BuildDependencyGraph(firstFiles)
+	if err != nil {
+		t.Fatalf("BuildDependencyGraph failed: %v", err)
+	}
+	firstNodes := firstGraph.NodeCount()
+	firstEdges := firstGraph.EdgeCount()
+
+	for i := 0; i < 20; i++ {
+		nextFiles, nextErr := adapter.DetectFiles(fixture)
+		if nextErr != nil {
+			t.Fatalf("DetectFiles failed on iteration %d: %v", i, nextErr)
+		}
+		if len(nextFiles) != len(firstFiles) {
+			t.Fatalf("detect files parity drift at %d: first=%d next=%d", i, len(firstFiles), len(nextFiles))
+		}
+
+		nextGraph, graphErr := adapter.BuildDependencyGraph(nextFiles)
+		if graphErr != nil {
+			t.Fatalf("BuildDependencyGraph failed on iteration %d: %v", i, graphErr)
+		}
+		if nextGraph.NodeCount() != firstNodes || nextGraph.EdgeCount() != firstEdges {
+			t.Fatalf("graph parity drift at %d: nodes %d/%d edges %d/%d", i, firstNodes, nextGraph.NodeCount(), firstEdges, nextGraph.EdgeCount())
+		}
+	}
+}

--- a/internal/languages/language_detector.go
+++ b/internal/languages/language_detector.go
@@ -151,8 +151,8 @@ func NewRepositoryLanguageDetectorWithPolicy(ignoreStrategy domain.IgnoreStrateg
 
 func defaultDetectionPolicy() DetectionPolicy {
 	return DetectionPolicy{
-		LanguageWeights: map[string]float64{"Go": 1, "Python": 1, "JavaScript": 1, "TypeScript": 1},
-		TieBreakOrder:   []string{"Python", "TypeScript", "JavaScript", "Go"},
+		LanguageWeights: map[string]float64{"Go": 1, "Python": 1, "JavaScript": 1, "TypeScript": 1, "Java": 0.8},
+		TieBreakOrder:   []string{"Python", "TypeScript", "JavaScript", "Go", "Java"},
 		SegmentWeights:  map[string]float64{"src": 1.0, "app": 1.0, "pkg": 1.0, "tools": 0.2, "scripts": 0.2},
 	}
 }

--- a/internal/languages/testdata/java_pilot_fixture/src/main/java/app/App.java
+++ b/internal/languages/testdata/java_pilot_fixture/src/main/java/app/App.java
@@ -1,0 +1,12 @@
+package app;
+
+import app.service.UserService;
+import java.util.List;
+
+public class App {
+    public static void main(String[] args) {
+        UserService svc = new UserService();
+        List<String> users = svc.listUsers();
+        System.out.println(users.size());
+    }
+}

--- a/internal/languages/testdata/java_pilot_fixture/src/main/java/app/service/UserService.java
+++ b/internal/languages/testdata/java_pilot_fixture/src/main/java/app/service/UserService.java
@@ -1,0 +1,13 @@
+package app.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UserService {
+    public List<String> listUsers() {
+        List<String> users = new ArrayList<>();
+        users.add("Ada");
+        users.add("Linus");
+        return users;
+    }
+}

--- a/main.go
+++ b/main.go
@@ -404,10 +404,7 @@ func runAdapterPipeline(absPath string) (*analysis.Result, error) {
 		policy.SegmentWeights = config.LanguageDetection.SegmentWeights
 	}
 	detector := languages.NewRepositoryLanguageDetectorWithPolicy(ignoreStrategy, policy)
-	detector.RegisterAdapter(languages.NewGoAdapter())
-	detector.RegisterAdapter(languages.NewPythonAdapter())
-	detector.RegisterAdapter(languages.NewJavaScriptAdapter())
-	detector.RegisterAdapter(languages.NewTypeScriptAdapter())
+	registerCoreAdapters(detector, config)
 
 	orchestrator := analysis.NewOrchestrator(detector)
 	return orchestrator.Analyze(absPath)

--- a/main_java_pilot_integration_test.go
+++ b/main_java_pilot_integration_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunAdapterPipeline_JavaPilotEnabled_SelectsJavaAdapter(t *testing.T) {
+	repo := t.TempDir()
+	javaFile := filepath.Join(repo, "src", "main", "java", "App.java")
+	if err := os.MkdirAll(filepath.Dir(javaFile), 0o755); err != nil {
+		t.Fatalf("failed creating java fixture dir: %v", err)
+	}
+	if err := os.WriteFile(javaFile, []byte("package demo;\nimport java.util.List;\npublic class App {}\n"), 0o644); err != nil {
+		t.Fatalf("failed writing java fixture: %v", err)
+	}
+
+	configPath := filepath.Join(repo, ".repodoctor", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("failed creating config dir: %v", err)
+	}
+	config := []byte("language_detection:\n  java_pilot_enabled: true\n  weights:\n    Java: 5\n    Go: 1\n    Python: 1\n    JavaScript: 1\n    TypeScript: 1\n")
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("failed writing config: %v", err)
+	}
+
+	result, err := runAdapterPipeline(repo)
+	if err != nil {
+		t.Fatalf("runAdapterPipeline failed: %v", err)
+	}
+	if result.AdapterName != "Java" {
+		t.Fatalf("expected Java adapter when pilot is enabled, got %s", result.AdapterName)
+	}
+}

--- a/runtime_context_builder.go
+++ b/runtime_context_builder.go
@@ -39,5 +39,5 @@ func resolveContextLanguages(primaryLanguage string) []string {
 	if primaryLanguage != "" {
 		return []string{primaryLanguage}
 	}
-	return []string{"Go", "Python", "JavaScript", "TypeScript"}
+	return []string{"Go", "Python", "JavaScript", "TypeScript", "Java"}
 }

--- a/runtime_context_builder_test.go
+++ b/runtime_context_builder_test.go
@@ -55,3 +55,13 @@ func TestBuildUnifiedRulesAnalysisContext_ConfigurationContractKeys(t *testing.T
 		t.Fatalf("configuration key %q drifted: got %v want %v", "architectureProfile", architectureProfile, "layered")
 	}
 }
+
+func TestResolveContextLanguages_DefaultIncludesJavaPilotLanguage(t *testing.T) {
+	languages := resolveContextLanguages("")
+	if len(languages) != 5 {
+		t.Fatalf("expected 5 default languages including Java, got %v", languages)
+	}
+	if languages[4] != "Java" {
+		t.Fatalf("expected Java in default language set tail, got %v", languages)
+	}
+}

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -73,7 +73,7 @@ func legacyBuildRulesAnalysisContext(absPath string, graph Graph, primaryLanguag
 		repoFiles = append(repoFiles, readRepositoryFileForContext(graph, node))
 	}
 
-	languages := []string{"Go", "Python", "JavaScript", "TypeScript"}
+	languages := []string{"Go", "Python", "JavaScript", "TypeScript", "Java"}
 	if primaryLanguage != "" {
 		languages = []string{primaryLanguage}
 	}


### PR DESCRIPTION
## Summary
- complete v0.20 Java pilot chain (RD-2001 through RD-2007) on development branch
- add gated Java adapter support with bounded parsing, extraction MVP, abuse-resistance tests, and fixture/benchmark evidence
- publish Java pilot go/no-go decision memo with explicit guardrails (GO in default-off pilot mode)

## Verification
- go test ./...
- go vet ./...
- go run . analyze -path . (100/100)

## Notes
- development branch remains preserved (not deleted)