### PR TITLE
[v1.0][RD-10001] Better violation messages

### DIFF
--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"RepoDoctor/internal/engine"
 	"RepoDoctor/internal/model"
@@ -113,9 +114,9 @@ func buildReportFromRuleViolations(path string, version string, cfg *Config, vio
 	for _, v := range violations {
 		switch v.RuleID {
 		case "rule.circular-dependency":
-			report.Circular = append(report.Circular, CycleViolation{Path: []string{v.File}, Severity: string(v.Severity), Hint: remediationHintForViolation(v)})
+			report.Circular = append(report.Circular, parseCircularViolation(v))
 		case "rule.layer-validation":
-			report.Layer = append(report.Layer, LayerViolation{From: v.File, To: "", Message: v.Message, Hint: remediationHintForViolation(v)})
+			report.Layer = append(report.Layer, parseLayerViolation(v))
 		case "rule.size":
 			report.Size = append(report.Size, parseSizeViolation(v))
 		case "rule.god-object":
@@ -145,7 +146,52 @@ var (
 	sizeFuncRe  = regexp.MustCompile(`^Function '([^']+)' has (\d+) lines \(threshold: (\d+)\)`)
 	godFieldRe  = regexp.MustCompile(`^(.+) has (\d+) fields \(threshold: \d+\)`)
 	godMethodRe = regexp.MustCompile(`^(.+) has (\d+) methods \(threshold: \d+\)`)
+	layerMsgRe  = regexp.MustCompile(`^(.+?) \(([^)]+)\) -> (.+?) \(([^)]+)\): (.+)$`)
 )
+
+func parseCircularViolation(v model.Violation) CycleViolation {
+	path := parseCyclePath(v.Message)
+	if len(path) == 0 {
+		path = []string{v.File}
+	}
+	return CycleViolation{Path: path, Severity: string(v.Severity), Hint: remediationHintForViolation(v)}
+}
+
+func parseCyclePath(message string) []string {
+	trimmed := strings.TrimSpace(message)
+	if trimmed == "" {
+		return nil
+	}
+	parts := strings.Split(trimmed, "→")
+	path := make([]string, 0, len(parts))
+	for _, part := range parts {
+		node := strings.TrimSpace(part)
+		if node == "" {
+			continue
+		}
+		path = append(path, node)
+	}
+	if len(path) > 1 && path[0] == path[len(path)-1] {
+		path = path[:len(path)-1]
+	}
+	return path
+}
+
+func parseLayerViolation(v model.Violation) LayerViolation {
+	lv := LayerViolation{From: v.File, To: "", Message: v.Message, Hint: remediationHintForViolation(v)}
+	if m := layerMsgRe.FindStringSubmatch(v.Message); len(m) == 6 {
+		fromPath := strings.TrimSpace(m[1])
+		fromLayer := strings.TrimSpace(m[2])
+		toPath := strings.TrimSpace(m[3])
+		toLayer := strings.TrimSpace(m[4])
+		reason := strings.TrimSpace(m[5])
+
+		lv.From = fromPath
+		lv.To = toPath
+		lv.Message = fromLayer + " -> " + toLayer + ": " + reason
+	}
+	return lv
+}
 
 // parseSizeViolation extracts Lines, Threshold, and Function from a size
 // violation message instead of using hardcoded placeholder values.

--- a/runtime_engine_violation_messages_test.go
+++ b/runtime_engine_violation_messages_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"RepoDoctor/internal/model"
+)
+
+func TestParseCyclePath_ExtractsDeterministicNodes(t *testing.T) {
+	message := "a/service → b/repo → c/handler → a/service"
+	path := parseCyclePath(message)
+	if len(path) != 3 {
+		t.Fatalf("expected 3 nodes after cycle closure trim, got %v", path)
+	}
+	if path[0] != "a/service" || path[1] != "b/repo" || path[2] != "c/handler" {
+		t.Fatalf("unexpected parsed cycle path: %v", path)
+	}
+}
+
+func TestParseCircularViolation_FallbackToFileWhenMessageUnavailable(t *testing.T) {
+	v := model.Violation{RuleID: "rule.circular-dependency", File: "a.go", Severity: model.SeverityCritical, Message: ""}
+	parsed := parseCircularViolation(v)
+	if len(parsed.Path) != 1 || parsed.Path[0] != "a.go" {
+		t.Fatalf("expected fallback path from file, got %v", parsed.Path)
+	}
+}
+
+func TestParseLayerViolation_ImprovesMessageAndEndpoints(t *testing.T) {
+	v := model.Violation{
+		RuleID:   "rule.layer-validation",
+		File:     "src/handler/user.go",
+		Severity: model.SeverityError,
+		Message:  "src/handler/user.go (handler) -> src/repo/user.go (repo): upward import not allowed [profile:layered]",
+	}
+	parsed := parseLayerViolation(v)
+	if parsed.From != "src/handler/user.go" || parsed.To != "src/repo/user.go" {
+		t.Fatalf("expected from/to extraction, got from=%q to=%q", parsed.From, parsed.To)
+	}
+	if parsed.Message != "handler -> repo: upward import not allowed [profile:layered]" {
+		t.Fatalf("expected normalized layer message, got %q", parsed.Message)
+	}
+}


### PR DESCRIPTION
## Summary
- parse circular violation payloads into readable cycle paths instead of file-only fallbacks
- parse layer violation payloads into explicit from/to endpoints and normalized directional message text
- add focused tests for cycle-path parsing, layer message normalization, and safe fallback behavior

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .

Closes #215