### PR TITLE
feat(rd-10003): add custom architecture profile support

### DIFF
--- a/analysis_service.go
+++ b/analysis_service.go
@@ -61,11 +61,11 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	config := loadConfiguration(absPath, request.Verbose)
 
 	progress.Start("Running rules", getStageCount("Running rules", absPath))
-	profile := ""
-	if config != nil && config.Architecture != nil {
-		profile = config.Architecture.Profile
+	var architecture *ArchitectureConfig
+	if config != nil {
+		architecture = config.Architecture
 	}
-	ruleSummary := runInternalRulePipelineWithProfile(absPath, graph, analysisResult.AdapterName, profile)
+	ruleSummary := runInternalRulePipelineWithProfile(absPath, graph, analysisResult.AdapterName, architecture)
 	progress.SetProgress(progress.totalSteps / 2)
 
 	report := generateRuleEngineReport(absPath, request.Format, request.Verbose, request.ColorEnabled, config, ruleSummary)

--- a/config.go
+++ b/config.go
@@ -23,7 +23,9 @@ type Config struct {
 }
 
 type ArchitectureConfig struct {
-	Profile string `yaml:"profile,omitempty"`
+	Profile             string              `yaml:"profile,omitempty"`
+	CustomLayerOrder    []string            `yaml:"custom_layer_order,omitempty"`
+	CustomLayerKeywords map[string][]string `yaml:"custom_layer_keywords,omitempty"`
 }
 
 type LanguageDetectionConfig struct {
@@ -164,6 +166,9 @@ func (l *ConfigLoader) validate(cfg *Config) error {
 			if _, err := domain.ParseArchitectureProfile(profile); err != nil {
 				return err
 			}
+		}
+		if err := validateCustomArchitectureProfile(cfg.Architecture); err != nil {
+			return err
 		}
 	}
 
@@ -434,7 +439,7 @@ func rejectUnknownConfigKeys(data []byte) error {
 		encoded, _ := json.Marshal(archRaw)
 		var arch map[string]interface{}
 		_ = json.Unmarshal(encoded, &arch)
-		allowedArch := map[string]bool{"profile": true}
+		allowedArch := map[string]bool{"profile": true, "custom_layer_order": true, "custom_layer_keywords": true}
 		for key := range arch {
 			if !allowedArch[key] {
 				return fmt.Errorf("config validation error: unknown architecture key '%s'", key)
@@ -478,6 +483,50 @@ func validateOptionalSeverity(value, fieldName string, valid map[string]bool) er
 	}
 	if !valid[value] {
 		return fmt.Errorf("invalid severity '%s' for %s (must be: info, warning, error, critical)", value, fieldName)
+	}
+	return nil
+}
+
+func validateCustomArchitectureProfile(architecture *ArchitectureConfig) error {
+	if architecture == nil {
+		return nil
+	}
+	if len(architecture.CustomLayerOrder) == 0 && len(architecture.CustomLayerKeywords) == 0 {
+		return nil
+	}
+	if len(architecture.CustomLayerOrder) < 2 {
+		return fmt.Errorf("architecture.custom_layer_order must contain at least two layers")
+	}
+	seen := make(map[string]bool, len(architecture.CustomLayerOrder))
+	aliasOwnership := map[string]string{}
+	for _, layer := range architecture.CustomLayerOrder {
+		normalized := strings.ToLower(strings.TrimSpace(layer))
+		if normalized == "" {
+			return fmt.Errorf("architecture.custom_layer_order cannot include empty layer names")
+		}
+		if seen[normalized] {
+			return fmt.Errorf("architecture.custom_layer_order contains duplicate layer '%s'", normalized)
+		}
+		seen[normalized] = true
+	}
+	for layer, aliases := range architecture.CustomLayerKeywords {
+		normalizedLayer := strings.ToLower(strings.TrimSpace(layer))
+		if !seen[normalizedLayer] {
+			return fmt.Errorf("architecture.custom_layer_keywords contains unknown layer '%s'", layer)
+		}
+		if len(aliases) == 0 {
+			return fmt.Errorf("architecture.custom_layer_keywords for '%s' cannot be empty", layer)
+		}
+		for _, alias := range aliases {
+			normalizedAlias := strings.ToLower(strings.TrimSpace(alias))
+			if normalizedAlias == "" {
+				return fmt.Errorf("architecture.custom_layer_keywords for '%s' contains empty alias", layer)
+			}
+			if owner, exists := aliasOwnership[normalizedAlias]; exists && owner != normalizedLayer {
+				return fmt.Errorf("architecture.custom_layer_keywords alias '%s' is ambiguous between layers '%s' and '%s'", normalizedAlias, owner, normalizedLayer)
+			}
+			aliasOwnership[normalizedAlias] = normalizedLayer
+		}
 	}
 	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -520,3 +520,93 @@ architecture:
 		t.Fatal("expected unknown architecture key to be rejected")
 	}
 }
+
+func TestConfigLoader_CustomArchitectureProfileValid(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	cfg := `
+architecture:
+  profile: layered
+  custom_layer_order:
+    - api
+    - service
+    - data
+  custom_layer_keywords:
+    api: [api, controller]
+    service: [service, usecase]
+    data: [repo, data]
+`
+	if err := os.WriteFile(configPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("failed writing config: %v", err)
+	}
+
+	loader := NewConfigLoader(configPath)
+	loaded, err := loader.Load()
+	if err != nil {
+		t.Fatalf("expected valid custom architecture config, got: %v", err)
+	}
+	if loaded.Architecture == nil || len(loaded.Architecture.CustomLayerOrder) != 3 {
+		t.Fatalf("expected custom architecture order to be loaded, got %+v", loaded.Architecture)
+	}
+}
+
+func TestConfigLoader_CustomArchitectureRejectsUnknownLayerInKeywords(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	cfg := `
+architecture:
+  custom_layer_order: [api, service, data]
+  custom_layer_keywords:
+    unknown: [foo]
+`
+	if err := os.WriteFile(configPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("failed writing config: %v", err)
+	}
+
+	loader := NewConfigLoader(configPath)
+	if _, err := loader.Load(); err == nil {
+		t.Fatal("expected unknown custom keyword layer to fail validation")
+	}
+}
+
+func TestConfigLoader_CustomArchitectureRejectsDuplicateLayers(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	cfg := `
+architecture:
+  custom_layer_order: [api, API, data]
+`
+	if err := os.WriteFile(configPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("failed writing config: %v", err)
+	}
+
+	loader := NewConfigLoader(configPath)
+	if _, err := loader.Load(); err == nil {
+		t.Fatal("expected duplicate custom layers to fail validation")
+	}
+}
+
+func TestConfigLoader_CustomArchitectureRejectsAmbiguousAliasesAcrossLayers(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	cfg := `
+architecture:
+  custom_layer_order: [api, service, data]
+  custom_layer_keywords:
+    api: [shared]
+    service: [shared]
+    data: [data]
+`
+	if err := os.WriteFile(configPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("failed writing config: %v", err)
+	}
+
+	loader := NewConfigLoader(configPath)
+	_, err := loader.Load()
+	if err == nil {
+		t.Fatal("expected ambiguous alias across layers to fail validation")
+	}
+	if !strings.Contains(err.Error(), "alias 'shared' is ambiguous") {
+		t.Fatalf("expected deterministic ambiguous alias error, got: %v", err)
+	}
+}

--- a/internal/rules/layer_validation_rule.go
+++ b/internal/rules/layer_validation_rule.go
@@ -15,11 +15,14 @@ const (
 	LayerRepo    LayerConvention = "repo"
 )
 
-// layerOrder defines the hierarchy (lower index = higher layer)
-var layerOrder = map[LayerConvention]int{
-	LayerHandler: 0,
-	LayerService: 1,
-	LayerRepo:    2,
+// layerOrder defines the default hierarchy (lower index = higher layer)
+var layerOrder = map[LayerConvention]int{LayerHandler: 0, LayerService: 1, LayerRepo: 2}
+
+type layerPolicy struct {
+	order      []LayerConvention
+	rank       map[LayerConvention]int
+	keywords   map[LayerConvention][]string
+	defaultFor LayerConvention
 }
 
 // LayerValidationRule enforces architectural layering constraints
@@ -53,16 +56,17 @@ func (r *LayerValidationRule) Capabilities() RuleCapabilities {
 func (r *LayerValidationRule) Evaluate(context AnalysisContext) []model.Violation {
 	var violations []model.Violation
 	profile := resolveArchitectureProfile(context)
+	policy := resolveLayerPolicy(context)
 
 	// Check all files and their imports
 	for _, file := range context.RepositoryFiles {
-		fromLayer := detectLayer(file.Path)
+		fromLayer := detectLayerWithPolicy(file.Path, policy)
 
 		for _, imp := range file.Imports {
-			toLayer := detectLayer(imp)
+			toLayer := detectLayerWithPolicy(imp, policy)
 
 			// Check if this is an upward import (forbidden)
-			if isUpwardImportWithProfile(fromLayer, toLayer, profile) {
+			if isUpwardImportWithProfile(fromLayer, toLayer, profile, policy.rank) {
 				violations = append(violations, model.Violation{
 					RuleID:      r.ID(),
 					Severity:    model.SeverityError,
@@ -93,25 +97,71 @@ func resolveArchitectureProfile(context AnalysisContext) string {
 	return strings.ToLower(strings.TrimSpace(profile))
 }
 
-// detectLayer detects the layer of a package based on its path
-func detectLayer(pkgPath string) LayerConvention {
-	// Check for layer keywords in the path
-	if containsLayerKeyword(pkgPath, "handler") {
-		return LayerHandler
-	}
-	if containsLayerKeyword(pkgPath, "service") {
-		return LayerService
-	}
-	if containsLayerKeyword(pkgPath, "repo") {
-		return LayerRepo
+func resolveLayerPolicy(context AnalysisContext) layerPolicy {
+	policy := defaultLayerPolicy()
+	if context.Configuration == nil {
+		return policy
 	}
 
-	// Default to service layer if no specific layer detected
-	return LayerService
+	customOrder := parseCustomLayerOrder(context.Configuration["customLayerOrder"])
+	if len(customOrder) < 2 {
+		return policy
+	}
+
+	customKeywords := parseCustomLayerKeywords(context.Configuration["customLayerKeywords"])
+	compiledKeywords := make(map[LayerConvention][]string, len(customOrder))
+	for _, layer := range customOrder {
+		aliases := customKeywords[layer]
+		if len(aliases) == 0 {
+			aliases = []string{string(layer)}
+		}
+		compiledKeywords[layer] = aliases
+	}
+
+	customRank := make(map[LayerConvention]int, len(customOrder))
+	for idx, layer := range customOrder {
+		customRank[layer] = idx
+	}
+
+	defaultLayer := customOrder[0]
+	if len(customOrder) > 1 {
+		defaultLayer = customOrder[1]
+	}
+
+	return layerPolicy{order: customOrder, rank: customRank, keywords: compiledKeywords, defaultFor: defaultLayer}
+}
+
+func defaultLayerPolicy() layerPolicy {
+	return layerPolicy{
+		order:      []LayerConvention{LayerHandler, LayerService, LayerRepo},
+		rank:       layerOrder,
+		keywords:   map[LayerConvention][]string{LayerHandler: []string{"handler"}, LayerService: []string{"service"}, LayerRepo: []string{"repo"}},
+		defaultFor: LayerService,
+	}
+}
+
+// detectLayerWithPolicy detects the layer of a package based on policy keywords.
+func detectLayerWithPolicy(pkgPath string, policy layerPolicy) LayerConvention {
+	for _, layer := range policy.order {
+		aliases := policy.keywords[layer]
+		for _, alias := range aliases {
+			if containsLayerKeyword(pkgPath, alias) {
+				return layer
+			}
+		}
+	}
+
+	return policy.defaultFor
 }
 
 // containsLayerKeyword checks if a path contains a layer keyword
 func containsLayerKeyword(path, keyword string) bool {
+	path = strings.ToLower(path)
+	keyword = strings.ToLower(strings.TrimSpace(keyword))
+	if keyword == "" {
+		return false
+	}
+
 	// Simple check: look for /keyword/ or /keyword at end
 	if len(path) >= len(keyword) {
 		for i := 0; i <= len(path)-len(keyword); i++ {
@@ -132,9 +182,9 @@ func containsLayerKeyword(path, keyword string) bool {
 }
 
 // isUpwardImport checks if an import goes upward in the layer hierarchy
-func isUpwardImport(from, to LayerConvention) bool {
-	fromLevel, fromExists := layerOrder[from]
-	toLevel, toExists := layerOrder[to]
+func isUpwardImport(from, to LayerConvention, rank map[LayerConvention]int) bool {
+	fromLevel, fromExists := rank[from]
+	toLevel, toExists := rank[to]
 
 	if !fromExists || !toExists {
 		return false
@@ -144,11 +194,63 @@ func isUpwardImport(from, to LayerConvention) bool {
 	return toLevel < fromLevel
 }
 
-func isUpwardImportWithProfile(from, to LayerConvention, profile string) bool {
+func isUpwardImportWithProfile(from, to LayerConvention, profile string, rank map[LayerConvention]int) bool {
 	if profile == "modular-monolith" {
 		return false
 	}
-	return isUpwardImport(from, to)
+	return isUpwardImport(from, to, rank)
+}
+
+func parseCustomLayerOrder(raw interface{}) []LayerConvention {
+	layers, ok := raw.([]string)
+	if !ok || len(layers) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(layers))
+	parsed := make([]LayerConvention, 0, len(layers))
+	for _, layer := range layers {
+		normalized := strings.ToLower(strings.TrimSpace(layer))
+		if normalized == "" || seen[normalized] {
+			continue
+		}
+		seen[normalized] = true
+		parsed = append(parsed, LayerConvention(normalized))
+	}
+	if len(parsed) < 2 {
+		return nil
+	}
+	return parsed
+}
+
+func parseCustomLayerKeywords(raw interface{}) map[LayerConvention][]string {
+	keywords, ok := raw.(map[string][]string)
+	if !ok || len(keywords) == 0 {
+		return nil
+	}
+	parsed := make(map[LayerConvention][]string, len(keywords))
+	for layer, aliases := range keywords {
+		normalizedLayer := strings.ToLower(strings.TrimSpace(layer))
+		if normalizedLayer == "" {
+			continue
+		}
+		seenAlias := map[string]bool{}
+		normalizedAliases := make([]string, 0, len(aliases))
+		for _, alias := range aliases {
+			normalizedAlias := strings.ToLower(strings.TrimSpace(alias))
+			if normalizedAlias == "" || seenAlias[normalizedAlias] {
+				continue
+			}
+			seenAlias[normalizedAlias] = true
+			normalizedAliases = append(normalizedAliases, normalizedAlias)
+		}
+		if len(normalizedAliases) > 0 {
+			parsed[LayerConvention(normalizedLayer)] = normalizedAliases
+		}
+	}
+	if len(parsed) == 0 {
+		return nil
+	}
+	return parsed
 }
 
 // formatLayerViolation formats a layer violation message

--- a/internal/rules/layer_validation_rule_profile_test.go
+++ b/internal/rules/layer_validation_rule_profile_test.go
@@ -79,3 +79,54 @@ func TestLayerValidationRule_JSTSProfileAlignment(t *testing.T) {
 		t.Fatalf("expected layered profile marker in violation message, got %q", violations[0].Message)
 	}
 }
+
+func TestLayerValidationRule_CustomLayerPolicyDetectsUpwardImport(t *testing.T) {
+	rule := NewLayerValidationRule()
+	ctx := AnalysisContext{
+		Configuration: Configuration{
+			"architectureProfile": "layered",
+			"customLayerOrder":    []string{"api", "service", "data"},
+			"customLayerKeywords": map[string][]string{
+				"api":     []string{"api", "controller"},
+				"service": []string{"service"},
+				"data":    []string{"repo", "data"},
+			},
+		},
+		RepositoryFiles: []RepositoryFile{{
+			Path:    "data/user_repo.go",
+			Imports: []string{"api/user_controller.go"},
+		}},
+	}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 1 {
+		t.Fatalf("expected one custom-policy upward import violation, got %d (%v)", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "data") || !strings.Contains(violations[0].Message, "api") {
+		t.Fatalf("expected custom layer names in violation message, got %q", violations[0].Message)
+	}
+}
+
+func TestLayerValidationRule_CustomLayerPolicyAllowsDownwardImport(t *testing.T) {
+	rule := NewLayerValidationRule()
+	ctx := AnalysisContext{
+		Configuration: Configuration{
+			"architectureProfile": "layered",
+			"customLayerOrder":    []string{"api", "service", "data"},
+			"customLayerKeywords": map[string][]string{
+				"api":     []string{"api", "controller"},
+				"service": []string{"service"},
+				"data":    []string{"repo", "data"},
+			},
+		},
+		RepositoryFiles: []RepositoryFile{{
+			Path:    "api/user_controller.go",
+			Imports: []string{"data/user_repo.go"},
+		}},
+	}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected no violation for downward custom import, got %v", violations)
+	}
+}

--- a/runtime_context_builder.go
+++ b/runtime_context_builder.go
@@ -9,16 +9,33 @@ type runtimeAnalysisContextInput struct {
 	Graph               Graph
 	PrimaryLanguage     string
 	ArchitectureProfile string
+	CustomLayerOrder    []string
+	CustomLayerKeywords map[string][]string
 }
 
 func buildUnifiedRulesAnalysisContext(input runtimeAnalysisContextInput) rules.AnalysisContext {
 	repositoryFiles := buildContextRepositoryFiles(input.Graph)
 	languages := resolveContextLanguages(input.PrimaryLanguage)
 
+	configuration := rules.Configuration{
+		"repositoryPath":      input.RepositoryPath,
+		"architectureProfile": input.ArchitectureProfile,
+	}
+	if len(input.CustomLayerOrder) > 0 {
+		configuration["customLayerOrder"] = append([]string{}, input.CustomLayerOrder...)
+	}
+	if len(input.CustomLayerKeywords) > 0 {
+		copiedKeywords := make(map[string][]string, len(input.CustomLayerKeywords))
+		for layer, aliases := range input.CustomLayerKeywords {
+			copiedKeywords[layer] = append([]string{}, aliases...)
+		}
+		configuration["customLayerKeywords"] = copiedKeywords
+	}
+
 	return rules.AnalysisContext{
 		RepositoryFiles: repositoryFiles,
 		DependencyGraph: toRulesDependencyGraph(input.Graph),
-		Configuration:   rules.Configuration{"repositoryPath": input.RepositoryPath, "architectureProfile": input.ArchitectureProfile},
+		Configuration:   configuration,
 		Languages:       languages,
 	}
 }

--- a/runtime_context_builder_test.go
+++ b/runtime_context_builder_test.go
@@ -56,6 +56,48 @@ func TestBuildUnifiedRulesAnalysisContext_ConfigurationContractKeys(t *testing.T
 	}
 }
 
+func TestBuildUnifiedRulesAnalysisContext_IncludesCustomArchitectureConfiguration(t *testing.T) {
+	graph := NewDependencyGraph()
+	graph.AddNode("a.go")
+
+	ctx := buildUnifiedRulesAnalysisContext(runtimeAnalysisContextInput{
+		RepositoryPath:      filepath.Clean("."),
+		Graph:               graph,
+		PrimaryLanguage:     "Go",
+		ArchitectureProfile: "layered",
+		CustomLayerOrder:    []string{"api", "service", "data"},
+		CustomLayerKeywords: map[string][]string{
+			"api":     []string{"api", "controller"},
+			"service": []string{"service"},
+			"data":    []string{"repo", "data"},
+		},
+	})
+
+	rawOrder, ok := ctx.Configuration["customLayerOrder"]
+	if !ok {
+		t.Fatalf("configuration key %q missing", "customLayerOrder")
+	}
+	order, ok := rawOrder.([]string)
+	if !ok {
+		t.Fatalf("configuration key %q has unexpected type %T", "customLayerOrder", rawOrder)
+	}
+	if len(order) != 3 || order[0] != "api" || order[2] != "data" {
+		t.Fatalf("configuration key %q drifted: got %v", "customLayerOrder", order)
+	}
+
+	rawKeywords, ok := ctx.Configuration["customLayerKeywords"]
+	if !ok {
+		t.Fatalf("configuration key %q missing", "customLayerKeywords")
+	}
+	keywords, ok := rawKeywords.(map[string][]string)
+	if !ok {
+		t.Fatalf("configuration key %q has unexpected type %T", "customLayerKeywords", rawKeywords)
+	}
+	if len(keywords["api"]) != 2 || keywords["api"][1] != "controller" {
+		t.Fatalf("configuration key %q drifted: got %v", "customLayerKeywords", keywords)
+	}
+}
+
 func TestResolveContextLanguages_DefaultIncludesJavaPilotLanguage(t *testing.T) {
 	languages := resolveContextLanguages("")
 	if len(languages) != 5 {

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -17,10 +17,19 @@ type runtimeRuleSummary struct {
 }
 
 func runInternalRulePipeline(absPath string, graph Graph, primaryLanguage string) *runtimeRuleSummary {
-	return runInternalRulePipelineWithProfile(absPath, graph, primaryLanguage, "")
+	return runInternalRulePipelineWithProfile(absPath, graph, primaryLanguage, nil)
 }
 
-func runInternalRulePipelineWithProfile(absPath string, graph Graph, primaryLanguage string, architectureProfile string) *runtimeRuleSummary {
+func runInternalRulePipelineWithProfile(absPath string, graph Graph, primaryLanguage string, architecture *ArchitectureConfig) *runtimeRuleSummary {
+	profile := ""
+	customLayerOrder := []string{}
+	customLayerKeywords := map[string][]string{}
+	if architecture != nil {
+		profile = strings.TrimSpace(architecture.Profile)
+		customLayerOrder = normalizeLayerOrder(architecture.CustomLayerOrder)
+		customLayerKeywords = normalizeLayerKeywords(architecture.CustomLayerKeywords)
+	}
+
 	registry := rules.NewRuleRegistry()
 	for _, rule := range rules.GetDefaultRegistry().GetAll() {
 		registry.MustRegister(rule)
@@ -32,7 +41,9 @@ func runInternalRulePipelineWithProfile(absPath string, graph Graph, primaryLang
 		RepositoryPath:      absPath,
 		Graph:               graph,
 		PrimaryLanguage:     primaryLanguage,
-		ArchitectureProfile: architectureProfile,
+		ArchitectureProfile: profile,
+		CustomLayerOrder:    customLayerOrder,
+		CustomLayerKeywords: customLayerKeywords,
 	})
 	result := executor.Execute(context)
 	sortViolations(result.Violations)
@@ -41,6 +52,56 @@ func runInternalRulePipelineWithProfile(absPath string, graph Graph, primaryLang
 		result:       result,
 		rulesInScope: registry.Count(),
 	}
+}
+
+func normalizeLayerOrder(raw []string) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(raw))
+	normalized := make([]string, 0, len(raw))
+	for _, layer := range raw {
+		value := strings.ToLower(strings.TrimSpace(layer))
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		normalized = append(normalized, value)
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
+func normalizeLayerKeywords(raw map[string][]string) map[string][]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	normalized := make(map[string][]string, len(raw))
+	for layer, aliases := range raw {
+		normalizedLayer := strings.ToLower(strings.TrimSpace(layer))
+		if normalizedLayer == "" {
+			continue
+		}
+		seenAliases := map[string]bool{}
+		normalizedAliases := make([]string, 0, len(aliases))
+		for _, alias := range aliases {
+			value := strings.ToLower(strings.TrimSpace(alias))
+			if value == "" || seenAliases[value] {
+				continue
+			}
+			seenAliases[value] = true
+			normalizedAliases = append(normalizedAliases, value)
+		}
+		if len(normalizedAliases) > 0 {
+			normalized[normalizedLayer] = normalizedAliases
+		}
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
 }
 
 func buildRulesAnalysisContext(absPath string, graph Graph, primaryLanguage string) rules.AnalysisContext {


### PR DESCRIPTION
## Summary
- wire `architecture.custom_layer_order` and `architecture.custom_layer_keywords` from config into runtime rule context
- extend layer validation to resolve deterministic custom layer policies while preserving default layered behavior
- add validation and regression tests for custom architecture config and rule evaluation paths

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .

Closes #217