### PR TITLE
feat(rd-10004): add CI template generator

### DIFF
--- a/cli_commands.go
+++ b/cli_commands.go
@@ -173,27 +173,70 @@ func runExtract(path, module string, verbose bool, jsonOutput bool) error {
 }
 
 func runGenerate(args []string) error {
-	if len(args) < 2 {
-		return HandleCLIUsageError("Usage: repodoctor generate rule <rule-name>", nil)
+	if len(args) == 0 {
+		return HandleCLIUsageError("Usage: repodoctor generate <rule|ci> ...", nil)
 	}
 
-	if args[0] != "rule" {
+	switch args[0] {
+	case "rule":
+		if len(args) < 2 {
+			return HandleCLIUsageError("Usage: repodoctor generate rule <rule-name>", nil)
+		}
+
+		ruleName := args[1]
+		generator := NewRuleTemplateGenerator("rules")
+
+		if err := generator.Generate(ruleName); err != nil {
+			return WrapError(err, ErrorRuntime, "Error generating rule", GetSuggestion(err.Error()))
+		}
+		return nil
+	case "ci":
+		provider, force, err := parseGenerateCIArgs(args[1:])
+		if err != nil {
+			return err
+		}
+
+		generator := NewCITemplateGenerator(".")
+		if err := generator.Generate(provider, force); err != nil {
+			return WrapError(err, ErrorRuntime, "Error generating CI template", GetSuggestion(err.Error()))
+		}
+		return nil
+	default:
 		return NewCLIError(
 			ErrorInvalidArgument,
 			fmt.Sprintf("Unknown generate type: %s", args[0]),
-			"Available types: rule",
+			"Available types: rule, ci",
+			nil,
+		)
+	}
+}
+
+func parseGenerateCIArgs(args []string) (string, bool, error) {
+	if len(args) == 0 {
+		return "", false, HandleCLIUsageError("Usage: repodoctor generate ci <github|gitlab|azure> [--force]", nil)
+	}
+
+	provider := strings.ToLower(strings.TrimSpace(args[0]))
+	if provider == "" {
+		return "", false, HandleCLIUsageError("Usage: repodoctor generate ci <github|gitlab|azure> [--force]", nil)
+	}
+
+	force := false
+	for _, arg := range args[1:] {
+		normalized := strings.ToLower(strings.TrimSpace(arg))
+		if normalized == "--force" {
+			force = true
+			continue
+		}
+		return "", false, NewCLIError(
+			ErrorInvalidArgument,
+			fmt.Sprintf("Unknown generate ci option: %s", arg),
+			"Usage: repodoctor generate ci <github|gitlab|azure> [--force]",
 			nil,
 		)
 	}
 
-	ruleName := args[1]
-	generator := NewRuleTemplateGenerator("rules")
-
-	if err := generator.Generate(ruleName); err != nil {
-		return WrapError(err, ErrorRuntime, "Error generating rule", GetSuggestion(err.Error()))
-	}
-
-	return nil
+	return provider, force, nil
 }
 
 func runWatch(path string) {

--- a/generator.go
+++ b/generator.go
@@ -15,9 +15,19 @@ type ruleTemplateData struct {
 	RuleID   string
 }
 
+type ciTemplateDefinition struct {
+	relativePath string
+	content      string
+}
+
 // RuleTemplateGenerator generates rule templates
 type RuleTemplateGenerator struct {
 	rulesDir string
+}
+
+// CITemplateGenerator generates CI pipeline templates.
+type CITemplateGenerator struct {
+	baseDir string
 }
 
 // NewRuleTemplateGenerator creates a new generator
@@ -26,6 +36,114 @@ func NewRuleTemplateGenerator(rulesDir string) *RuleTemplateGenerator {
 		rulesDir: rulesDir,
 	}
 }
+
+// NewCITemplateGenerator creates a new CI template generator.
+func NewCITemplateGenerator(baseDir string) *CITemplateGenerator {
+	return &CITemplateGenerator{baseDir: baseDir}
+}
+
+// Generate creates the CI template for the selected provider.
+func (g *CITemplateGenerator) Generate(provider string, force bool) error {
+	definition, err := resolveCITemplateDefinition(provider)
+	if err != nil {
+		return err
+	}
+
+	targetPath := filepath.Join(g.baseDir, definition.relativePath)
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		return fmt.Errorf("failed to create CI template directory: %w", err)
+	}
+
+	if _, err := os.Stat(targetPath); err == nil && !force {
+		return fmt.Errorf("CI template already exists: %s (use --force to overwrite)", targetPath)
+	}
+
+	if err := os.WriteFile(targetPath, []byte(definition.content), 0644); err != nil {
+		return fmt.Errorf("failed to write CI template: %w", err)
+	}
+
+	fmt.Printf("✅ CI template created: %s\n", targetPath)
+	return nil
+}
+
+func resolveCITemplateDefinition(provider string) (ciTemplateDefinition, error) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "github":
+		return ciTemplateDefinition{relativePath: filepath.Join(".github", "workflows", "repodoctor.yml"), content: githubActionsTemplate}, nil
+	case "gitlab":
+		return ciTemplateDefinition{relativePath: ".gitlab-ci.yml", content: gitlabCITemplate}, nil
+	case "azure":
+		return ciTemplateDefinition{relativePath: "azure-pipelines.yml", content: azurePipelinesTemplate}, nil
+	default:
+		return ciTemplateDefinition{}, fmt.Errorf("unsupported CI provider %q (supported: github, gitlab, azure)", provider)
+	}
+}
+
+const githubActionsTemplate = `name: repodoctor
+
+on:
+  push:
+    branches: ["main", "dev"]
+  pull_request:
+    branches: ["main", "dev"]
+
+jobs:
+  repodoctor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Test
+        run: go test ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Structural Analysis
+        run: go run . analyze -path .
+`
+
+const gitlabCITemplate = `stages:
+  - test
+
+repodoctor:
+  stage: test
+  image: golang:1.24
+  script:
+    - go test ./...
+    - go vet ./...
+    - go run . analyze -path .
+`
+
+const azurePipelinesTemplate = `trigger:
+  branches:
+    include:
+      - main
+      - dev
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+  - task: GoTool@0
+    inputs:
+      version: "1.24"
+
+  - script: go test ./...
+    displayName: Test
+
+  - script: go vet ./...
+    displayName: Vet
+
+  - script: go run . analyze -path .
+    displayName: Structural Analysis
+`
 
 // Generate creates a new rule template file
 func (g *RuleTemplateGenerator) Generate(ruleName string) error {

--- a/generator_test.go
+++ b/generator_test.go
@@ -58,3 +58,102 @@ func TestSanitizeRuleName_RejectsInvalidCharacters(t *testing.T) {
 		t.Fatal("expected error for invalid rule name")
 	}
 }
+
+func TestCITemplateGenerator_GenerateGitHubTemplate(t *testing.T) {
+	baseDir := t.TempDir()
+	generator := NewCITemplateGenerator(baseDir)
+
+	if err := generator.Generate("github", false); err != nil {
+		t.Fatalf("expected github template generation to succeed, got: %v", err)
+	}
+
+	targetPath := filepath.Join(baseDir, ".github", "workflows", "repodoctor.yml")
+	content, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("expected github template to be written, got: %v", err)
+	}
+
+	text := string(content)
+	if !strings.Contains(text, "name: repodoctor") || !strings.Contains(text, "go run . analyze -path .") {
+		t.Fatalf("expected deterministic github template markers, got: %s", text)
+	}
+}
+
+func TestCITemplateGenerator_UnsupportedProvider(t *testing.T) {
+	generator := NewCITemplateGenerator(t.TempDir())
+	if err := generator.Generate("bitbucket", false); err == nil {
+		t.Fatal("expected unsupported provider to fail")
+	}
+}
+
+func TestCITemplateGenerator_ExistingFileRequiresForce(t *testing.T) {
+	baseDir := t.TempDir()
+	targetPath := filepath.Join(baseDir, ".gitlab-ci.yml")
+	if err := os.WriteFile(targetPath, []byte("sentinel"), 0o644); err != nil {
+		t.Fatalf("failed creating existing file: %v", err)
+	}
+
+	generator := NewCITemplateGenerator(baseDir)
+	if err := generator.Generate("gitlab", false); err == nil {
+		t.Fatal("expected existing file without force to fail")
+	}
+
+	content, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("failed reading existing file: %v", err)
+	}
+	if string(content) != "sentinel" {
+		t.Fatalf("expected existing file not to be modified without force, got: %q", string(content))
+	}
+}
+
+func TestCITemplateGenerator_ForceOverwriteReplacesFile(t *testing.T) {
+	baseDir := t.TempDir()
+	targetPath := filepath.Join(baseDir, "azure-pipelines.yml")
+	if err := os.WriteFile(targetPath, []byte("sentinel"), 0o644); err != nil {
+		t.Fatalf("failed creating existing file: %v", err)
+	}
+
+	generator := NewCITemplateGenerator(baseDir)
+	if err := generator.Generate("azure", true); err != nil {
+		t.Fatalf("expected force overwrite to succeed, got: %v", err)
+	}
+
+	content, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("failed reading overwritten file: %v", err)
+	}
+	if strings.Contains(string(content), "sentinel") {
+		t.Fatal("expected force overwrite to replace existing content")
+	}
+}
+
+func TestRunGenerate_CIMissingProviderReturnsUsageError(t *testing.T) {
+	err := runGenerate([]string{"ci"})
+	if err == nil {
+		t.Fatal("expected usage error for missing ci provider")
+	}
+}
+
+func TestRunGenerate_RulePathRemainsBackwardCompatible(t *testing.T) {
+	baseDir := t.TempDir()
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed reading working directory: %v", err)
+	}
+	if err := os.Chdir(baseDir); err != nil {
+		t.Fatalf("failed switching to temp directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWD)
+	})
+
+	if err := runGenerate([]string{"rule", "quality-gate"}); err != nil {
+		t.Fatalf("expected generate rule path to remain compatible, got: %v", err)
+	}
+
+	targetPath := filepath.Join(baseDir, "rules", "quality_gate_rule.go")
+	if _, err := os.Stat(targetPath); err != nil {
+		t.Fatalf("expected generated rule file at %s, got error: %v", targetPath, err)
+	}
+}


### PR DESCRIPTION
## Summary
- extend `repodoctor generate` with a new `ci` subtype to scaffold provider-specific CI templates
- add a dedicated `CITemplateGenerator` for deterministic GitHub/GitLab/Azure template output with safe overwrite handling via `--force`
- preserve existing `generate rule <rule-name>` behavior and add coverage for CLI parsing and CI generator edge cases

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .
- go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"

Closes #218