### PR TITLE
docs(rd-10005): stabilize v1.0 gates and milestone docs

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -61,6 +61,14 @@ jobs:
           GOMAXPROCS: 1
         run: ./scripts/v019_release_stabilization_gate.ps1
 
+      - name: Run v1.0 release stabilization gate
+        shell: pwsh
+        env:
+          TZ: UTC
+          LC_ALL: C
+          GOMAXPROCS: 1
+        run: ./scripts/v100_release_stabilization_gate.ps1
+
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ RepoDoctor is a CLI tool that analyzes your repository’s architectural health 
 It is intentionally **not** a style linter. RepoDoctor focuses on higher-level design quality: cycles, layering violations, oversized units, and god object drift.
 
 ![CLI Version](https://img.shields.io/badge/cli-0.5.0--dev-blue)
-![Roadmap Milestone](https://img.shields.io/badge/roadmap-v0.17-complete-brightgreen)
+![Roadmap Milestone](https://img.shields.io/badge/roadmap-v1.0-in_progress-blue)
 [![Go Version](https://img.shields.io/badge/go-1.21+-00ADD8)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Structural Health](https://img.shields.io/badge/structural--health-100%2F100-brightgreen)]()
@@ -176,6 +176,7 @@ repodoctor extract -path . -module RepoDoctor
 repodoctor report -path repodoctor-report.json -format text
 repodoctor history -path .
 repodoctor generate rule my-custom-rule
+repodoctor generate ci github
 repodoctor version
 ```
 
@@ -197,6 +198,10 @@ god_object:
 rules:
   enable_size_rule: true
   enable_god_object_rule: true
+  circular_severity: critical
+  layer_severity: error
+  size_severity: warning
+  god_object_severity: warning
 
 weights:
   circular: 10
@@ -220,9 +225,16 @@ language_detection:
 
 architecture:
   profile: layered
+  custom_layer_order: [handler, service, repo]
+  custom_layer_keywords:
+    handler: [handler, controller]
+    service: [service, usecase]
+    repo: [repo, repository, data]
 ```
 
 Supported `architecture.profile` values: `clean`, `layered`, `modular-monolith`.
+
+`generate ci <github|gitlab|azure> [--force]` creates CI starter templates in deterministic paths.
 
 You can keep defaults and only override needed thresholds.
 
@@ -393,12 +405,12 @@ jobs:
 
 ## Release Maturity
 
-- Roadmap release train (`v0.10` to `v0.17`) is complete.
-- Current release maturity report: `RELEASE_MATURITY_v0.17.md`.
-- Release close gate status:
-  - `go test ./...` pass
-  - `go vet ./...` pass
-  - `go run . analyze -path .` pass (`100/100`)
+- v0.18, v0.19, and v0.20 milestones are completed and released.
+- v1.0 (M3: UX & Polish) is in stabilization.
+- Current stabilization artifacts:
+  - `scripts/v019_release_stabilization_gate.ps1`
+  - `scripts/v100_release_stabilization_gate.ps1`
+  - `docs/v1.0-rd-10005-release-stabilization.md`
 
 ---
 
@@ -412,9 +424,9 @@ jobs:
 
 ### Next
 
-- next release planning starts after v0.17 stabilization window
-- expanded rule packs and profile refinements
-- tighter CI policy templates and release automation
+- complete v1.0 stabilization and docs closure
+- open `dev -> main` release PR after full matrix is green
+- continue with v1.1 scale items after v1.0 release merge
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,52 @@
+# RepoDoctor Architecture (v1.0 Stabilization Snapshot)
+
+This document reflects the currently enforced architecture in the repository.
+
+## Architectural Style
+
+RepoDoctor is a **modular monolith CLI** with explicit package boundaries and deterministic analysis behavior.
+
+## Module Responsibilities
+
+- **`main` (root package)**
+  - CLI command parsing/composition
+  - runtime wiring and report emission
+- **`internal/analysis`**
+  - orchestration of language detection + adapter execution
+- **`internal/languages`**
+  - language adapters and detection policy logic
+- **`internal/rules` + `internal/engine`**
+  - rule implementations, registry, execution pipeline
+- **`internal/model` + `internal/domain`**
+  - domain policies and shared data structures
+
+## Dependency Direction
+
+High-level direction is preserved as:
+
+`main -> internal/analysis -> internal/languages -> internal/rules/internal/engine -> internal/model/internal/domain`
+
+Boundary expectations are continuously validated by architectural boundary tests.
+
+## Runtime Rule Context Flow
+
+1. Config is loaded from `.repodoctor/config.yaml`
+2. Runtime context is built with deterministic ordering and selected language evidence
+3. Rules are executed through the internal engine
+4. Violations are normalized and rendered in deterministic report order
+
+## v1.0 Capability Notes
+
+- Rule-level severity overrides are supported via `rules.*_severity`
+- Architecture profile supports `clean`, `layered`, `modular-monolith`
+- Custom architecture policy supports:
+  - `architecture.custom_layer_order`
+  - `architecture.custom_layer_keywords`
+- CI template scaffolding is available via `generate ci <github|gitlab|azure> [--force]`
+
+## Determinism and Safety Invariants
+
+- Deterministic ordering for graph/rule/report output is mandatory
+- Analyzer does not execute repository code and does not require network access
+- Path handling remains canonicalized and root-bounded
+- Release gates must keep `go test`, `go vet`, and self-analysis (`100/100`) green

--- a/docs/report.md
+++ b/docs/report.md
@@ -8,5 +8,5 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v0.18 | M0: v0.18 Contract Hardening | Completed | RD-1801..RD-1808 merged into `dev`; close-out, path-safety, and CI supply-chain gates active. |
 | v0.19 | M1: v0.19 Incremental & Performance | Completed | RD-1901..RD-1908 merged; release stabilization gate and benchmark+memory CI budgets active. |
 | v0.20 | M2: v0.20 Java Pilot (Gated) | Completed (Gated GO) | RD-2001..RD-2007 completed; decision memo published (`JAVA_PILOT_DECISION_v0.20.md`), pilot remains default-off. |
-| v1.0 | M3: v1.0 UX & Polish | Planned | Issues RD-10001..RD-10005 created. |
+| v1.0 | M3: v1.0 UX & Polish | In Progress | RD-10001..RD-10004 merged into `dev`; RD-10005 stabilization/docs in progress. |
 | v1.1+ | M4: v1.1+ Scale (Use-case gated) | Planned | Issues RD-11001..RD-11003 created. |

--- a/docs/v1.0-rd-10005-release-stabilization.md
+++ b/docs/v1.0-rd-10005-release-stabilization.md
@@ -1,0 +1,47 @@
+# v1.0 RD-10005 Release Stabilization
+
+This document captures the closure checklist for **M3: v1.0 UX & Polish**.
+
+## Scope
+
+- Stabilize v1.0 milestone gates
+- Sync documentation with shipped capabilities
+- Keep runtime behavior unchanged
+
+## Included Capabilities (already merged before this issue)
+
+- RD-10001: Better violation messages
+- RD-10002: Rule severity configuration
+- RD-10003: Custom architecture profiles
+- RD-10004: CI template generator (`generate ci`)
+
+## Required Gates
+
+1. `go test ./...`
+2. `go vet ./...`
+3. `go run . analyze -path .` (`100/100`)
+4. Determinism suite:
+   - `TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic`
+   - `TestJSTSParity_DeterministicAcrossRepeatedRuns`
+5. Stabilization packs:
+   - `scripts/v018_closeout_gate.ps1`
+   - `scripts/v019_benchmark_gate.ps1`
+   - `scripts/v019_release_stabilization_gate.ps1`
+   - `scripts/v100_release_stabilization_gate.ps1`
+
+## Exit Policy Contract (locked)
+
+Current behavior remains intentionally unchanged:
+
+- Exit code `0` when no circular/layer violations exist
+- Exit code `2` when circular or layer violations exist
+- Size/god-object violations do not fail the process by default
+
+This contract is validated with dedicated exit-policy tests to prevent accidental drift.
+
+## Release Flow
+
+1. Merge RD-10005 into `dev`
+2. Verify Linux + Windows matrix green
+3. Open `dev -> main` release PR for v1.0
+4. Merge release PR only after all required checks are green

--- a/main_exit_policy_test.go
+++ b/main_exit_policy_test.go
@@ -1,0 +1,52 @@
+package main
+
+import "testing"
+
+func TestDetermineExitCode_NoViolationsReturnsZero(t *testing.T) {
+	report := &StructuralReport{HasViolations: false}
+	if got := determineExitCode(report); got != 0 {
+		t.Fatalf("expected exit code 0 for no violations, got %d", got)
+	}
+}
+
+func TestDetermineExitCode_CircularOrLayerViolationReturnsTwo(t *testing.T) {
+	tests := []struct {
+		name   string
+		report *StructuralReport
+	}{
+		{
+			name: "circular violation",
+			report: &StructuralReport{
+				HasViolations: true,
+				Circular:      []CycleViolation{{Path: []string{"a", "b"}}},
+			},
+		},
+		{
+			name: "layer violation",
+			report: &StructuralReport{
+				HasViolations: true,
+				Layer:         []LayerViolation{{From: "repo", To: "handler"}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := determineExitCode(tc.report); got != 2 {
+				t.Fatalf("expected exit code 2 for %s, got %d", tc.name, got)
+			}
+		})
+	}
+}
+
+func TestDetermineExitCode_SizeAndGodObjectViolationsRemainNonBlocking(t *testing.T) {
+	report := &StructuralReport{
+		HasViolations: true,
+		Size:          []SizeViolation{{File: "big.go", Lines: 900, Threshold: 500}},
+		GodObject:     []GodObjectViolation{{File: "god.go", StructName: "GodType", FieldCount: 25}},
+	}
+
+	if got := determineExitCode(report); got != 0 {
+		t.Fatalf("expected exit code 0 for size/god-object only violations, got %d", got)
+	}
+}

--- a/scripts/v100_release_stabilization_gate.ps1
+++ b/scripts/v100_release_stabilization_gate.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    Write-Host "==> $Name"
+    Invoke-Expression $Command
+}
+
+Invoke-Step -Name "core test suite" -Command "go test ./..."
+Invoke-Step -Name "static analysis" -Command "go vet ./..."
+Invoke-Step -Name "determinism confidence suite" -Command "go test ./... -run 'TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns'"
+Invoke-Step -Name "v1.0 feature contract pack" -Command "go test ./... -run 'TestConfigLoader_RuleSeverityOverrides_DefaultAndValidation|TestLayerValidationRule_CustomLayerPolicyDetectsUpwardImport|TestCITemplateGenerator_GenerateGitHubTemplate|TestDetermineExitCode_NoViolationsReturnsZero|TestDetermineExitCode_CircularOrLayerViolationReturnsTwo|TestDetermineExitCode_SizeAndGodObjectViolationsRemainNonBlocking'"
+Invoke-Step -Name "self-analysis 100/100 gate" -Command "go run . analyze -path ."
+
+Write-Host "v1.0 release stabilization gate passed."


### PR DESCRIPTION
## Summary
- add a dedicated v1.0 stabilization gate script and wire it into CI without changing runtime analysis behavior
- sync milestone documentation (README, architecture snapshot, report tracker) with shipped v1.0 capabilities
- lock current analyze exit-policy contract with focused tests to prevent accidental drift

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .
- pwsh -File ./scripts/v018_closeout_gate.ps1
- pwsh -File ./scripts/v100_release_stabilization_gate.ps1

## Notes
- `scripts/v019_benchmark_gate.ps1` exceeded local budget on this workstation; CI matrix remains source of truth for benchmark-budget checks.
- no runtime/engine behavior changes were introduced in this PR.

Closes #219