### PR TITLE
release(v1.0): merge M3 UX & Polish from dev

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -61,6 +61,14 @@ jobs:
           GOMAXPROCS: 1
         run: ./scripts/v019_release_stabilization_gate.ps1
 
+      - name: Run v1.0 release stabilization gate
+        shell: pwsh
+        env:
+          TZ: UTC
+          LC_ALL: C
+          GOMAXPROCS: 1
+        run: ./scripts/v100_release_stabilization_gate.ps1
+
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ RepoDoctor is a CLI tool that analyzes your repository’s architectural health 
 It is intentionally **not** a style linter. RepoDoctor focuses on higher-level design quality: cycles, layering violations, oversized units, and god object drift.
 
 ![CLI Version](https://img.shields.io/badge/cli-0.5.0--dev-blue)
-![Roadmap Milestone](https://img.shields.io/badge/roadmap-v0.17-complete-brightgreen)
+![Roadmap Milestone](https://img.shields.io/badge/roadmap-v1.0-in_progress-blue)
 [![Go Version](https://img.shields.io/badge/go-1.21+-00ADD8)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Structural Health](https://img.shields.io/badge/structural--health-100%2F100-brightgreen)]()
@@ -176,6 +176,7 @@ repodoctor extract -path . -module RepoDoctor
 repodoctor report -path repodoctor-report.json -format text
 repodoctor history -path .
 repodoctor generate rule my-custom-rule
+repodoctor generate ci github
 repodoctor version
 ```
 
@@ -197,6 +198,10 @@ god_object:
 rules:
   enable_size_rule: true
   enable_god_object_rule: true
+  circular_severity: critical
+  layer_severity: error
+  size_severity: warning
+  god_object_severity: warning
 
 weights:
   circular: 10
@@ -220,9 +225,16 @@ language_detection:
 
 architecture:
   profile: layered
+  custom_layer_order: [handler, service, repo]
+  custom_layer_keywords:
+    handler: [handler, controller]
+    service: [service, usecase]
+    repo: [repo, repository, data]
 ```
 
 Supported `architecture.profile` values: `clean`, `layered`, `modular-monolith`.
+
+`generate ci <github|gitlab|azure> [--force]` creates CI starter templates in deterministic paths.
 
 You can keep defaults and only override needed thresholds.
 
@@ -393,12 +405,12 @@ jobs:
 
 ## Release Maturity
 
-- Roadmap release train (`v0.10` to `v0.17`) is complete.
-- Current release maturity report: `RELEASE_MATURITY_v0.17.md`.
-- Release close gate status:
-  - `go test ./...` pass
-  - `go vet ./...` pass
-  - `go run . analyze -path .` pass (`100/100`)
+- v0.18, v0.19, and v0.20 milestones are completed and released.
+- v1.0 (M3: UX & Polish) is in stabilization.
+- Current stabilization artifacts:
+  - `scripts/v019_release_stabilization_gate.ps1`
+  - `scripts/v100_release_stabilization_gate.ps1`
+  - `docs/v1.0-rd-10005-release-stabilization.md`
 
 ---
 
@@ -412,9 +424,9 @@ jobs:
 
 ### Next
 
-- next release planning starts after v0.17 stabilization window
-- expanded rule packs and profile refinements
-- tighter CI policy templates and release automation
+- complete v1.0 stabilization and docs closure
+- open `dev -> main` release PR after full matrix is green
+- continue with v1.1 scale items after v1.0 release merge
 
 ---
 

--- a/analysis_service.go
+++ b/analysis_service.go
@@ -61,11 +61,11 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	config := loadConfiguration(absPath, request.Verbose)
 
 	progress.Start("Running rules", getStageCount("Running rules", absPath))
-	profile := ""
-	if config != nil && config.Architecture != nil {
-		profile = config.Architecture.Profile
+	var architecture *ArchitectureConfig
+	if config != nil {
+		architecture = config.Architecture
 	}
-	ruleSummary := runInternalRulePipelineWithProfile(absPath, graph, analysisResult.AdapterName, profile)
+	ruleSummary := runInternalRulePipelineWithProfile(absPath, graph, analysisResult.AdapterName, architecture)
 	progress.SetProgress(progress.totalSteps / 2)
 
 	report := generateRuleEngineReport(absPath, request.Format, request.Verbose, request.ColorEnabled, config, ruleSummary)

--- a/cli_commands.go
+++ b/cli_commands.go
@@ -173,27 +173,70 @@ func runExtract(path, module string, verbose bool, jsonOutput bool) error {
 }
 
 func runGenerate(args []string) error {
-	if len(args) < 2 {
-		return HandleCLIUsageError("Usage: repodoctor generate rule <rule-name>", nil)
+	if len(args) == 0 {
+		return HandleCLIUsageError("Usage: repodoctor generate <rule|ci> ...", nil)
 	}
 
-	if args[0] != "rule" {
+	switch args[0] {
+	case "rule":
+		if len(args) < 2 {
+			return HandleCLIUsageError("Usage: repodoctor generate rule <rule-name>", nil)
+		}
+
+		ruleName := args[1]
+		generator := NewRuleTemplateGenerator("rules")
+
+		if err := generator.Generate(ruleName); err != nil {
+			return WrapError(err, ErrorRuntime, "Error generating rule", GetSuggestion(err.Error()))
+		}
+		return nil
+	case "ci":
+		provider, force, err := parseGenerateCIArgs(args[1:])
+		if err != nil {
+			return err
+		}
+
+		generator := NewCITemplateGenerator(".")
+		if err := generator.Generate(provider, force); err != nil {
+			return WrapError(err, ErrorRuntime, "Error generating CI template", GetSuggestion(err.Error()))
+		}
+		return nil
+	default:
 		return NewCLIError(
 			ErrorInvalidArgument,
 			fmt.Sprintf("Unknown generate type: %s", args[0]),
-			"Available types: rule",
+			"Available types: rule, ci",
+			nil,
+		)
+	}
+}
+
+func parseGenerateCIArgs(args []string) (string, bool, error) {
+	if len(args) == 0 {
+		return "", false, HandleCLIUsageError("Usage: repodoctor generate ci <github|gitlab|azure> [--force]", nil)
+	}
+
+	provider := strings.ToLower(strings.TrimSpace(args[0]))
+	if provider == "" {
+		return "", false, HandleCLIUsageError("Usage: repodoctor generate ci <github|gitlab|azure> [--force]", nil)
+	}
+
+	force := false
+	for _, arg := range args[1:] {
+		normalized := strings.ToLower(strings.TrimSpace(arg))
+		if normalized == "--force" {
+			force = true
+			continue
+		}
+		return "", false, NewCLIError(
+			ErrorInvalidArgument,
+			fmt.Sprintf("Unknown generate ci option: %s", arg),
+			"Usage: repodoctor generate ci <github|gitlab|azure> [--force]",
 			nil,
 		)
 	}
 
-	ruleName := args[1]
-	generator := NewRuleTemplateGenerator("rules")
-
-	if err := generator.Generate(ruleName); err != nil {
-		return WrapError(err, ErrorRuntime, "Error generating rule", GetSuggestion(err.Error()))
-	}
-
-	return nil
+	return provider, force, nil
 }
 
 func runWatch(path string) {

--- a/config.go
+++ b/config.go
@@ -23,7 +23,9 @@ type Config struct {
 }
 
 type ArchitectureConfig struct {
-	Profile string `yaml:"profile,omitempty"`
+	Profile             string              `yaml:"profile,omitempty"`
+	CustomLayerOrder    []string            `yaml:"custom_layer_order,omitempty"`
+	CustomLayerKeywords map[string][]string `yaml:"custom_layer_keywords,omitempty"`
 }
 
 type LanguageDetectionConfig struct {
@@ -164,6 +166,9 @@ func (l *ConfigLoader) validate(cfg *Config) error {
 			if _, err := domain.ParseArchitectureProfile(profile); err != nil {
 				return err
 			}
+		}
+		if err := validateCustomArchitectureProfile(cfg.Architecture); err != nil {
+			return err
 		}
 	}
 
@@ -434,7 +439,7 @@ func rejectUnknownConfigKeys(data []byte) error {
 		encoded, _ := json.Marshal(archRaw)
 		var arch map[string]interface{}
 		_ = json.Unmarshal(encoded, &arch)
-		allowedArch := map[string]bool{"profile": true}
+		allowedArch := map[string]bool{"profile": true, "custom_layer_order": true, "custom_layer_keywords": true}
 		for key := range arch {
 			if !allowedArch[key] {
 				return fmt.Errorf("config validation error: unknown architecture key '%s'", key)
@@ -478,6 +483,50 @@ func validateOptionalSeverity(value, fieldName string, valid map[string]bool) er
 	}
 	if !valid[value] {
 		return fmt.Errorf("invalid severity '%s' for %s (must be: info, warning, error, critical)", value, fieldName)
+	}
+	return nil
+}
+
+func validateCustomArchitectureProfile(architecture *ArchitectureConfig) error {
+	if architecture == nil {
+		return nil
+	}
+	if len(architecture.CustomLayerOrder) == 0 && len(architecture.CustomLayerKeywords) == 0 {
+		return nil
+	}
+	if len(architecture.CustomLayerOrder) < 2 {
+		return fmt.Errorf("architecture.custom_layer_order must contain at least two layers")
+	}
+	seen := make(map[string]bool, len(architecture.CustomLayerOrder))
+	aliasOwnership := map[string]string{}
+	for _, layer := range architecture.CustomLayerOrder {
+		normalized := strings.ToLower(strings.TrimSpace(layer))
+		if normalized == "" {
+			return fmt.Errorf("architecture.custom_layer_order cannot include empty layer names")
+		}
+		if seen[normalized] {
+			return fmt.Errorf("architecture.custom_layer_order contains duplicate layer '%s'", normalized)
+		}
+		seen[normalized] = true
+	}
+	for layer, aliases := range architecture.CustomLayerKeywords {
+		normalizedLayer := strings.ToLower(strings.TrimSpace(layer))
+		if !seen[normalizedLayer] {
+			return fmt.Errorf("architecture.custom_layer_keywords contains unknown layer '%s'", layer)
+		}
+		if len(aliases) == 0 {
+			return fmt.Errorf("architecture.custom_layer_keywords for '%s' cannot be empty", layer)
+		}
+		for _, alias := range aliases {
+			normalizedAlias := strings.ToLower(strings.TrimSpace(alias))
+			if normalizedAlias == "" {
+				return fmt.Errorf("architecture.custom_layer_keywords for '%s' contains empty alias", layer)
+			}
+			if owner, exists := aliasOwnership[normalizedAlias]; exists && owner != normalizedLayer {
+				return fmt.Errorf("architecture.custom_layer_keywords alias '%s' is ambiguous between layers '%s' and '%s'", normalizedAlias, owner, normalizedLayer)
+			}
+			aliasOwnership[normalizedAlias] = normalizedLayer
+		}
 	}
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -52,10 +52,14 @@ type GodObjectConfig struct {
 
 // RulesConfig holds rule enable/disable states
 type RulesConfig struct {
-	EnableSizeRule      *bool `yaml:"enable_size_rule,omitempty"`
-	EnableGodObjectRule *bool `yaml:"enable_god_object_rule,omitempty"`
-	EnableCircularRule  *bool `yaml:"enable_circular_rule,omitempty"`
-	EnableLayerRule     *bool `yaml:"enable_layer_rule,omitempty"`
+	EnableSizeRule      *bool  `yaml:"enable_size_rule,omitempty"`
+	EnableGodObjectRule *bool  `yaml:"enable_god_object_rule,omitempty"`
+	EnableCircularRule  *bool  `yaml:"enable_circular_rule,omitempty"`
+	EnableLayerRule     *bool  `yaml:"enable_layer_rule,omitempty"`
+	SizeSeverity        string `yaml:"size_severity,omitempty"`
+	GodObjectSeverity   string `yaml:"god_object_severity,omitempty"`
+	CircularSeverity    string `yaml:"circular_severity,omitempty"`
+	LayerSeverity       string `yaml:"layer_severity,omitempty"`
 }
 
 // WeightsConfig holds penalty weights for scoring
@@ -130,16 +134,8 @@ func (l *ConfigLoader) validate(cfg *Config) error {
 		"critical": true,
 	}
 
-	if cfg.Size != nil && cfg.Size.Severity != "" {
-		if !validSeverities[cfg.Size.Severity] {
-			return fmt.Errorf("invalid severity '%s' for size rule (must be: info, warning, error, critical)", cfg.Size.Severity)
-		}
-	}
-
-	if cfg.GodObject != nil && cfg.GodObject.Severity != "" {
-		if !validSeverities[cfg.GodObject.Severity] {
-			return fmt.Errorf("invalid severity '%s' for god object rule (must be: info, warning, error, critical)", cfg.GodObject.Severity)
-		}
+	if err := validateRuleSeverities(cfg, validSeverities); err != nil {
+		return err
 	}
 
 	// Validate weights are non-negative
@@ -158,28 +154,8 @@ func (l *ConfigLoader) validate(cfg *Config) error {
 		}
 	}
 
-	if cfg.LanguageDetection != nil {
-		for lang, weight := range cfg.LanguageDetection.Weights {
-			if lang == "" {
-				return fmt.Errorf("language_detection.weights contains empty language key")
-			}
-			if weight < 0 || weight > 100 {
-				return fmt.Errorf("language_detection weight for '%s' must be between 0 and 100", lang)
-			}
-		}
-		for _, lang := range cfg.LanguageDetection.TieBreakOrder {
-			if strings.TrimSpace(lang) == "" {
-				return fmt.Errorf("language_detection.tie_break_order cannot include empty values")
-			}
-		}
-		for segment, value := range cfg.LanguageDetection.SegmentWeights {
-			if strings.TrimSpace(segment) == "" {
-				return fmt.Errorf("language_detection.segment_weights contains empty segment key")
-			}
-			if value < 0 || value > 10 {
-				return fmt.Errorf("language_detection segment weight for '%s' must be between 0 and 10", segment)
-			}
-		}
+	if err := validateLanguageDetection(cfg); err != nil {
+		return err
 	}
 
 	if cfg.Architecture != nil {
@@ -191,6 +167,56 @@ func (l *ConfigLoader) validate(cfg *Config) error {
 		}
 	}
 
+	return nil
+}
+
+func validateRuleSeverities(cfg *Config, validSeverities map[string]bool) error {
+	if cfg.Size != nil && cfg.Size.Severity != "" && !validSeverities[cfg.Size.Severity] {
+		return fmt.Errorf("invalid severity '%s' for size rule (must be: info, warning, error, critical)", cfg.Size.Severity)
+	}
+	if cfg.GodObject != nil && cfg.GodObject.Severity != "" && !validSeverities[cfg.GodObject.Severity] {
+		return fmt.Errorf("invalid severity '%s' for god object rule (must be: info, warning, error, critical)", cfg.GodObject.Severity)
+	}
+	if cfg.Rules == nil {
+		return nil
+	}
+	if err := validateOptionalSeverity(cfg.Rules.SizeSeverity, "rules.size_severity", validSeverities); err != nil {
+		return err
+	}
+	if err := validateOptionalSeverity(cfg.Rules.GodObjectSeverity, "rules.god_object_severity", validSeverities); err != nil {
+		return err
+	}
+	if err := validateOptionalSeverity(cfg.Rules.CircularSeverity, "rules.circular_severity", validSeverities); err != nil {
+		return err
+	}
+	return validateOptionalSeverity(cfg.Rules.LayerSeverity, "rules.layer_severity", validSeverities)
+}
+
+func validateLanguageDetection(cfg *Config) error {
+	if cfg.LanguageDetection == nil {
+		return nil
+	}
+	for lang, weight := range cfg.LanguageDetection.Weights {
+		if lang == "" {
+			return fmt.Errorf("language_detection.weights contains empty language key")
+		}
+		if weight < 0 || weight > 100 {
+			return fmt.Errorf("language_detection weight for '%s' must be between 0 and 100", lang)
+		}
+	}
+	for _, lang := range cfg.LanguageDetection.TieBreakOrder {
+		if strings.TrimSpace(lang) == "" {
+			return fmt.Errorf("language_detection.tie_break_order cannot include empty values")
+		}
+	}
+	for segment, value := range cfg.LanguageDetection.SegmentWeights {
+		if strings.TrimSpace(segment) == "" {
+			return fmt.Errorf("language_detection.segment_weights contains empty segment key")
+		}
+		if value < 0 || value > 10 {
+			return fmt.Errorf("language_detection segment weight for '%s' must be between 0 and 10", segment)
+		}
+	}
 	return nil
 }
 
@@ -221,6 +247,10 @@ func (l *ConfigLoader) getDefaultConfig() *Config {
 			EnableGodObjectRule: &enableGodObject,
 			EnableCircularRule:  &enableCircular,
 			EnableLayerRule:     &enableLayer,
+			SizeSeverity:        "warning",
+			GodObjectSeverity:   "warning",
+			CircularSeverity:    "critical",
+			LayerSeverity:       "error",
 		},
 		Weights: &WeightsConfig{
 			Circular:  10.0,
@@ -323,6 +353,18 @@ func mergeRulesConfig(cfg, defaults *Config) {
 	if cfg.Rules.EnableLayerRule == nil {
 		cfg.Rules.EnableLayerRule = defaults.Rules.EnableLayerRule
 	}
+	if strings.TrimSpace(cfg.Rules.SizeSeverity) == "" {
+		cfg.Rules.SizeSeverity = defaults.Rules.SizeSeverity
+	}
+	if strings.TrimSpace(cfg.Rules.GodObjectSeverity) == "" {
+		cfg.Rules.GodObjectSeverity = defaults.Rules.GodObjectSeverity
+	}
+	if strings.TrimSpace(cfg.Rules.CircularSeverity) == "" {
+		cfg.Rules.CircularSeverity = defaults.Rules.CircularSeverity
+	}
+	if strings.TrimSpace(cfg.Rules.LayerSeverity) == "" {
+		cfg.Rules.LayerSeverity = defaults.Rules.LayerSeverity
+	}
 }
 
 func mergeWeightsConfig(cfg, defaults *Config) {
@@ -412,6 +454,31 @@ func rejectUnknownConfigKeys(data []byte) error {
 		}
 	}
 
+	if rulesRaw, ok := raw["rules"]; ok {
+		encoded, _ := json.Marshal(rulesRaw)
+		var rulesMap map[string]interface{}
+		_ = json.Unmarshal(encoded, &rulesMap)
+		allowedRules := map[string]bool{
+			"enable_size_rule": true, "enable_god_object_rule": true, "enable_circular_rule": true, "enable_layer_rule": true,
+			"size_severity": true, "god_object_severity": true, "circular_severity": true, "layer_severity": true,
+		}
+		for key := range rulesMap {
+			if !allowedRules[key] {
+				return fmt.Errorf("config validation error: unknown rules key '%s'", key)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateOptionalSeverity(value, fieldName string, valid map[string]bool) error {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	if !valid[value] {
+		return fmt.Errorf("invalid severity '%s' for %s (must be: info, warning, error, critical)", value, fieldName)
+	}
 	return nil
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -520,3 +520,93 @@ architecture:
 		t.Fatal("expected unknown architecture key to be rejected")
 	}
 }
+
+func TestConfigLoader_CustomArchitectureProfileValid(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	cfg := `
+architecture:
+  profile: layered
+  custom_layer_order:
+    - api
+    - service
+    - data
+  custom_layer_keywords:
+    api: [api, controller]
+    service: [service, usecase]
+    data: [repo, data]
+`
+	if err := os.WriteFile(configPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("failed writing config: %v", err)
+	}
+
+	loader := NewConfigLoader(configPath)
+	loaded, err := loader.Load()
+	if err != nil {
+		t.Fatalf("expected valid custom architecture config, got: %v", err)
+	}
+	if loaded.Architecture == nil || len(loaded.Architecture.CustomLayerOrder) != 3 {
+		t.Fatalf("expected custom architecture order to be loaded, got %+v", loaded.Architecture)
+	}
+}
+
+func TestConfigLoader_CustomArchitectureRejectsUnknownLayerInKeywords(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	cfg := `
+architecture:
+  custom_layer_order: [api, service, data]
+  custom_layer_keywords:
+    unknown: [foo]
+`
+	if err := os.WriteFile(configPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("failed writing config: %v", err)
+	}
+
+	loader := NewConfigLoader(configPath)
+	if _, err := loader.Load(); err == nil {
+		t.Fatal("expected unknown custom keyword layer to fail validation")
+	}
+}
+
+func TestConfigLoader_CustomArchitectureRejectsDuplicateLayers(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	cfg := `
+architecture:
+  custom_layer_order: [api, API, data]
+`
+	if err := os.WriteFile(configPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("failed writing config: %v", err)
+	}
+
+	loader := NewConfigLoader(configPath)
+	if _, err := loader.Load(); err == nil {
+		t.Fatal("expected duplicate custom layers to fail validation")
+	}
+}
+
+func TestConfigLoader_CustomArchitectureRejectsAmbiguousAliasesAcrossLayers(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	cfg := `
+architecture:
+  custom_layer_order: [api, service, data]
+  custom_layer_keywords:
+    api: [shared]
+    service: [shared]
+    data: [data]
+`
+	if err := os.WriteFile(configPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("failed writing config: %v", err)
+	}
+
+	loader := NewConfigLoader(configPath)
+	_, err := loader.Load()
+	if err == nil {
+		t.Fatal("expected ambiguous alias across layers to fail validation")
+	}
+	if !strings.Contains(err.Error(), "alias 'shared' is ambiguous") {
+		t.Fatalf("expected deterministic ambiguous alias error, got: %v", err)
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -329,6 +329,44 @@ func TestConfigLoader_JavaPilotFlagCanBeEnabled(t *testing.T) {
 	}
 }
 
+func TestConfigLoader_RuleSeverityOverrides_DefaultAndValidation(t *testing.T) {
+	loader := NewConfigLoader(filepath.Join(t.TempDir(), "missing.yaml"))
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("unexpected load error: %v", err)
+	}
+	if cfg.Rules == nil {
+		t.Fatal("expected rules defaults")
+	}
+	if cfg.Rules.CircularSeverity != "critical" || cfg.Rules.LayerSeverity != "error" || cfg.Rules.SizeSeverity != "warning" || cfg.Rules.GodObjectSeverity != "warning" {
+		t.Fatalf("unexpected default rule severities: %+v", cfg.Rules)
+	}
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	content := "rules:\n  size_severity: critical\n  layer_severity: warning\n"
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed writing config: %v", err)
+	}
+
+	loader = NewConfigLoader(configPath)
+	cfg, err = loader.Load()
+	if err != nil {
+		t.Fatalf("expected severity override config to load, got: %v", err)
+	}
+	if cfg.Rules.SizeSeverity != "critical" || cfg.Rules.LayerSeverity != "warning" {
+		t.Fatalf("expected severity overrides to be applied, got %+v", cfg.Rules)
+	}
+
+	invalid := "rules:\n  circular_severity: fatal\n"
+	if err := os.WriteFile(configPath, []byte(invalid), 0o644); err != nil {
+		t.Fatalf("failed writing invalid config: %v", err)
+	}
+	if _, err := loader.Load(); err == nil {
+		t.Fatal("expected invalid rules severity to fail validation")
+	}
+}
+
 func TestConfigLoader_MergeWithDefaults_TableDrivenInvariants(t *testing.T) {
 	loader := NewConfigLoader("")
 	enabled := false

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,52 @@
+# RepoDoctor Architecture (v1.0 Stabilization Snapshot)
+
+This document reflects the currently enforced architecture in the repository.
+
+## Architectural Style
+
+RepoDoctor is a **modular monolith CLI** with explicit package boundaries and deterministic analysis behavior.
+
+## Module Responsibilities
+
+- **`main` (root package)**
+  - CLI command parsing/composition
+  - runtime wiring and report emission
+- **`internal/analysis`**
+  - orchestration of language detection + adapter execution
+- **`internal/languages`**
+  - language adapters and detection policy logic
+- **`internal/rules` + `internal/engine`**
+  - rule implementations, registry, execution pipeline
+- **`internal/model` + `internal/domain`**
+  - domain policies and shared data structures
+
+## Dependency Direction
+
+High-level direction is preserved as:
+
+`main -> internal/analysis -> internal/languages -> internal/rules/internal/engine -> internal/model/internal/domain`
+
+Boundary expectations are continuously validated by architectural boundary tests.
+
+## Runtime Rule Context Flow
+
+1. Config is loaded from `.repodoctor/config.yaml`
+2. Runtime context is built with deterministic ordering and selected language evidence
+3. Rules are executed through the internal engine
+4. Violations are normalized and rendered in deterministic report order
+
+## v1.0 Capability Notes
+
+- Rule-level severity overrides are supported via `rules.*_severity`
+- Architecture profile supports `clean`, `layered`, `modular-monolith`
+- Custom architecture policy supports:
+  - `architecture.custom_layer_order`
+  - `architecture.custom_layer_keywords`
+- CI template scaffolding is available via `generate ci <github|gitlab|azure> [--force]`
+
+## Determinism and Safety Invariants
+
+- Deterministic ordering for graph/rule/report output is mandatory
+- Analyzer does not execute repository code and does not require network access
+- Path handling remains canonicalized and root-bounded
+- Release gates must keep `go test`, `go vet`, and self-analysis (`100/100`) green

--- a/docs/report.md
+++ b/docs/report.md
@@ -8,5 +8,5 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v0.18 | M0: v0.18 Contract Hardening | Completed | RD-1801..RD-1808 merged into `dev`; close-out, path-safety, and CI supply-chain gates active. |
 | v0.19 | M1: v0.19 Incremental & Performance | Completed | RD-1901..RD-1908 merged; release stabilization gate and benchmark+memory CI budgets active. |
 | v0.20 | M2: v0.20 Java Pilot (Gated) | Completed (Gated GO) | RD-2001..RD-2007 completed; decision memo published (`JAVA_PILOT_DECISION_v0.20.md`), pilot remains default-off. |
-| v1.0 | M3: v1.0 UX & Polish | Planned | Issues RD-10001..RD-10005 created. |
+| v1.0 | M3: v1.0 UX & Polish | In Progress | RD-10001..RD-10004 merged into `dev`; RD-10005 stabilization/docs in progress. |
 | v1.1+ | M4: v1.1+ Scale (Use-case gated) | Planned | Issues RD-11001..RD-11003 created. |

--- a/docs/v1.0-rd-10005-release-stabilization.md
+++ b/docs/v1.0-rd-10005-release-stabilization.md
@@ -1,0 +1,47 @@
+# v1.0 RD-10005 Release Stabilization
+
+This document captures the closure checklist for **M3: v1.0 UX & Polish**.
+
+## Scope
+
+- Stabilize v1.0 milestone gates
+- Sync documentation with shipped capabilities
+- Keep runtime behavior unchanged
+
+## Included Capabilities (already merged before this issue)
+
+- RD-10001: Better violation messages
+- RD-10002: Rule severity configuration
+- RD-10003: Custom architecture profiles
+- RD-10004: CI template generator (`generate ci`)
+
+## Required Gates
+
+1. `go test ./...`
+2. `go vet ./...`
+3. `go run . analyze -path .` (`100/100`)
+4. Determinism suite:
+   - `TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic`
+   - `TestJSTSParity_DeterministicAcrossRepeatedRuns`
+5. Stabilization packs:
+   - `scripts/v018_closeout_gate.ps1`
+   - `scripts/v019_benchmark_gate.ps1`
+   - `scripts/v019_release_stabilization_gate.ps1`
+   - `scripts/v100_release_stabilization_gate.ps1`
+
+## Exit Policy Contract (locked)
+
+Current behavior remains intentionally unchanged:
+
+- Exit code `0` when no circular/layer violations exist
+- Exit code `2` when circular or layer violations exist
+- Size/god-object violations do not fail the process by default
+
+This contract is validated with dedicated exit-policy tests to prevent accidental drift.
+
+## Release Flow
+
+1. Merge RD-10005 into `dev`
+2. Verify Linux + Windows matrix green
+3. Open `dev -> main` release PR for v1.0
+4. Merge release PR only after all required checks are green

--- a/generator.go
+++ b/generator.go
@@ -15,9 +15,19 @@ type ruleTemplateData struct {
 	RuleID   string
 }
 
+type ciTemplateDefinition struct {
+	relativePath string
+	content      string
+}
+
 // RuleTemplateGenerator generates rule templates
 type RuleTemplateGenerator struct {
 	rulesDir string
+}
+
+// CITemplateGenerator generates CI pipeline templates.
+type CITemplateGenerator struct {
+	baseDir string
 }
 
 // NewRuleTemplateGenerator creates a new generator
@@ -26,6 +36,114 @@ func NewRuleTemplateGenerator(rulesDir string) *RuleTemplateGenerator {
 		rulesDir: rulesDir,
 	}
 }
+
+// NewCITemplateGenerator creates a new CI template generator.
+func NewCITemplateGenerator(baseDir string) *CITemplateGenerator {
+	return &CITemplateGenerator{baseDir: baseDir}
+}
+
+// Generate creates the CI template for the selected provider.
+func (g *CITemplateGenerator) Generate(provider string, force bool) error {
+	definition, err := resolveCITemplateDefinition(provider)
+	if err != nil {
+		return err
+	}
+
+	targetPath := filepath.Join(g.baseDir, definition.relativePath)
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		return fmt.Errorf("failed to create CI template directory: %w", err)
+	}
+
+	if _, err := os.Stat(targetPath); err == nil && !force {
+		return fmt.Errorf("CI template already exists: %s (use --force to overwrite)", targetPath)
+	}
+
+	if err := os.WriteFile(targetPath, []byte(definition.content), 0644); err != nil {
+		return fmt.Errorf("failed to write CI template: %w", err)
+	}
+
+	fmt.Printf("✅ CI template created: %s\n", targetPath)
+	return nil
+}
+
+func resolveCITemplateDefinition(provider string) (ciTemplateDefinition, error) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "github":
+		return ciTemplateDefinition{relativePath: filepath.Join(".github", "workflows", "repodoctor.yml"), content: githubActionsTemplate}, nil
+	case "gitlab":
+		return ciTemplateDefinition{relativePath: ".gitlab-ci.yml", content: gitlabCITemplate}, nil
+	case "azure":
+		return ciTemplateDefinition{relativePath: "azure-pipelines.yml", content: azurePipelinesTemplate}, nil
+	default:
+		return ciTemplateDefinition{}, fmt.Errorf("unsupported CI provider %q (supported: github, gitlab, azure)", provider)
+	}
+}
+
+const githubActionsTemplate = `name: repodoctor
+
+on:
+  push:
+    branches: ["main", "dev"]
+  pull_request:
+    branches: ["main", "dev"]
+
+jobs:
+  repodoctor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Test
+        run: go test ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Structural Analysis
+        run: go run . analyze -path .
+`
+
+const gitlabCITemplate = `stages:
+  - test
+
+repodoctor:
+  stage: test
+  image: golang:1.24
+  script:
+    - go test ./...
+    - go vet ./...
+    - go run . analyze -path .
+`
+
+const azurePipelinesTemplate = `trigger:
+  branches:
+    include:
+      - main
+      - dev
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+  - task: GoTool@0
+    inputs:
+      version: "1.24"
+
+  - script: go test ./...
+    displayName: Test
+
+  - script: go vet ./...
+    displayName: Vet
+
+  - script: go run . analyze -path .
+    displayName: Structural Analysis
+`
 
 // Generate creates a new rule template file
 func (g *RuleTemplateGenerator) Generate(ruleName string) error {

--- a/generator_test.go
+++ b/generator_test.go
@@ -58,3 +58,102 @@ func TestSanitizeRuleName_RejectsInvalidCharacters(t *testing.T) {
 		t.Fatal("expected error for invalid rule name")
 	}
 }
+
+func TestCITemplateGenerator_GenerateGitHubTemplate(t *testing.T) {
+	baseDir := t.TempDir()
+	generator := NewCITemplateGenerator(baseDir)
+
+	if err := generator.Generate("github", false); err != nil {
+		t.Fatalf("expected github template generation to succeed, got: %v", err)
+	}
+
+	targetPath := filepath.Join(baseDir, ".github", "workflows", "repodoctor.yml")
+	content, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("expected github template to be written, got: %v", err)
+	}
+
+	text := string(content)
+	if !strings.Contains(text, "name: repodoctor") || !strings.Contains(text, "go run . analyze -path .") {
+		t.Fatalf("expected deterministic github template markers, got: %s", text)
+	}
+}
+
+func TestCITemplateGenerator_UnsupportedProvider(t *testing.T) {
+	generator := NewCITemplateGenerator(t.TempDir())
+	if err := generator.Generate("bitbucket", false); err == nil {
+		t.Fatal("expected unsupported provider to fail")
+	}
+}
+
+func TestCITemplateGenerator_ExistingFileRequiresForce(t *testing.T) {
+	baseDir := t.TempDir()
+	targetPath := filepath.Join(baseDir, ".gitlab-ci.yml")
+	if err := os.WriteFile(targetPath, []byte("sentinel"), 0o644); err != nil {
+		t.Fatalf("failed creating existing file: %v", err)
+	}
+
+	generator := NewCITemplateGenerator(baseDir)
+	if err := generator.Generate("gitlab", false); err == nil {
+		t.Fatal("expected existing file without force to fail")
+	}
+
+	content, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("failed reading existing file: %v", err)
+	}
+	if string(content) != "sentinel" {
+		t.Fatalf("expected existing file not to be modified without force, got: %q", string(content))
+	}
+}
+
+func TestCITemplateGenerator_ForceOverwriteReplacesFile(t *testing.T) {
+	baseDir := t.TempDir()
+	targetPath := filepath.Join(baseDir, "azure-pipelines.yml")
+	if err := os.WriteFile(targetPath, []byte("sentinel"), 0o644); err != nil {
+		t.Fatalf("failed creating existing file: %v", err)
+	}
+
+	generator := NewCITemplateGenerator(baseDir)
+	if err := generator.Generate("azure", true); err != nil {
+		t.Fatalf("expected force overwrite to succeed, got: %v", err)
+	}
+
+	content, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("failed reading overwritten file: %v", err)
+	}
+	if strings.Contains(string(content), "sentinel") {
+		t.Fatal("expected force overwrite to replace existing content")
+	}
+}
+
+func TestRunGenerate_CIMissingProviderReturnsUsageError(t *testing.T) {
+	err := runGenerate([]string{"ci"})
+	if err == nil {
+		t.Fatal("expected usage error for missing ci provider")
+	}
+}
+
+func TestRunGenerate_RulePathRemainsBackwardCompatible(t *testing.T) {
+	baseDir := t.TempDir()
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed reading working directory: %v", err)
+	}
+	if err := os.Chdir(baseDir); err != nil {
+		t.Fatalf("failed switching to temp directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWD)
+	})
+
+	if err := runGenerate([]string{"rule", "quality-gate"}); err != nil {
+		t.Fatalf("expected generate rule path to remain compatible, got: %v", err)
+	}
+
+	targetPath := filepath.Join(baseDir, "rules", "quality_gate_rule.go")
+	if _, err := os.Stat(targetPath); err != nil {
+		t.Fatalf("expected generated rule file at %s, got error: %v", targetPath, err)
+	}
+}

--- a/internal/rules/layer_validation_rule.go
+++ b/internal/rules/layer_validation_rule.go
@@ -15,11 +15,14 @@ const (
 	LayerRepo    LayerConvention = "repo"
 )
 
-// layerOrder defines the hierarchy (lower index = higher layer)
-var layerOrder = map[LayerConvention]int{
-	LayerHandler: 0,
-	LayerService: 1,
-	LayerRepo:    2,
+// layerOrder defines the default hierarchy (lower index = higher layer)
+var layerOrder = map[LayerConvention]int{LayerHandler: 0, LayerService: 1, LayerRepo: 2}
+
+type layerPolicy struct {
+	order      []LayerConvention
+	rank       map[LayerConvention]int
+	keywords   map[LayerConvention][]string
+	defaultFor LayerConvention
 }
 
 // LayerValidationRule enforces architectural layering constraints
@@ -53,16 +56,17 @@ func (r *LayerValidationRule) Capabilities() RuleCapabilities {
 func (r *LayerValidationRule) Evaluate(context AnalysisContext) []model.Violation {
 	var violations []model.Violation
 	profile := resolveArchitectureProfile(context)
+	policy := resolveLayerPolicy(context)
 
 	// Check all files and their imports
 	for _, file := range context.RepositoryFiles {
-		fromLayer := detectLayer(file.Path)
+		fromLayer := detectLayerWithPolicy(file.Path, policy)
 
 		for _, imp := range file.Imports {
-			toLayer := detectLayer(imp)
+			toLayer := detectLayerWithPolicy(imp, policy)
 
 			// Check if this is an upward import (forbidden)
-			if isUpwardImportWithProfile(fromLayer, toLayer, profile) {
+			if isUpwardImportWithProfile(fromLayer, toLayer, profile, policy.rank) {
 				violations = append(violations, model.Violation{
 					RuleID:      r.ID(),
 					Severity:    model.SeverityError,
@@ -93,25 +97,71 @@ func resolveArchitectureProfile(context AnalysisContext) string {
 	return strings.ToLower(strings.TrimSpace(profile))
 }
 
-// detectLayer detects the layer of a package based on its path
-func detectLayer(pkgPath string) LayerConvention {
-	// Check for layer keywords in the path
-	if containsLayerKeyword(pkgPath, "handler") {
-		return LayerHandler
-	}
-	if containsLayerKeyword(pkgPath, "service") {
-		return LayerService
-	}
-	if containsLayerKeyword(pkgPath, "repo") {
-		return LayerRepo
+func resolveLayerPolicy(context AnalysisContext) layerPolicy {
+	policy := defaultLayerPolicy()
+	if context.Configuration == nil {
+		return policy
 	}
 
-	// Default to service layer if no specific layer detected
-	return LayerService
+	customOrder := parseCustomLayerOrder(context.Configuration["customLayerOrder"])
+	if len(customOrder) < 2 {
+		return policy
+	}
+
+	customKeywords := parseCustomLayerKeywords(context.Configuration["customLayerKeywords"])
+	compiledKeywords := make(map[LayerConvention][]string, len(customOrder))
+	for _, layer := range customOrder {
+		aliases := customKeywords[layer]
+		if len(aliases) == 0 {
+			aliases = []string{string(layer)}
+		}
+		compiledKeywords[layer] = aliases
+	}
+
+	customRank := make(map[LayerConvention]int, len(customOrder))
+	for idx, layer := range customOrder {
+		customRank[layer] = idx
+	}
+
+	defaultLayer := customOrder[0]
+	if len(customOrder) > 1 {
+		defaultLayer = customOrder[1]
+	}
+
+	return layerPolicy{order: customOrder, rank: customRank, keywords: compiledKeywords, defaultFor: defaultLayer}
+}
+
+func defaultLayerPolicy() layerPolicy {
+	return layerPolicy{
+		order:      []LayerConvention{LayerHandler, LayerService, LayerRepo},
+		rank:       layerOrder,
+		keywords:   map[LayerConvention][]string{LayerHandler: []string{"handler"}, LayerService: []string{"service"}, LayerRepo: []string{"repo"}},
+		defaultFor: LayerService,
+	}
+}
+
+// detectLayerWithPolicy detects the layer of a package based on policy keywords.
+func detectLayerWithPolicy(pkgPath string, policy layerPolicy) LayerConvention {
+	for _, layer := range policy.order {
+		aliases := policy.keywords[layer]
+		for _, alias := range aliases {
+			if containsLayerKeyword(pkgPath, alias) {
+				return layer
+			}
+		}
+	}
+
+	return policy.defaultFor
 }
 
 // containsLayerKeyword checks if a path contains a layer keyword
 func containsLayerKeyword(path, keyword string) bool {
+	path = strings.ToLower(path)
+	keyword = strings.ToLower(strings.TrimSpace(keyword))
+	if keyword == "" {
+		return false
+	}
+
 	// Simple check: look for /keyword/ or /keyword at end
 	if len(path) >= len(keyword) {
 		for i := 0; i <= len(path)-len(keyword); i++ {
@@ -132,9 +182,9 @@ func containsLayerKeyword(path, keyword string) bool {
 }
 
 // isUpwardImport checks if an import goes upward in the layer hierarchy
-func isUpwardImport(from, to LayerConvention) bool {
-	fromLevel, fromExists := layerOrder[from]
-	toLevel, toExists := layerOrder[to]
+func isUpwardImport(from, to LayerConvention, rank map[LayerConvention]int) bool {
+	fromLevel, fromExists := rank[from]
+	toLevel, toExists := rank[to]
 
 	if !fromExists || !toExists {
 		return false
@@ -144,11 +194,63 @@ func isUpwardImport(from, to LayerConvention) bool {
 	return toLevel < fromLevel
 }
 
-func isUpwardImportWithProfile(from, to LayerConvention, profile string) bool {
+func isUpwardImportWithProfile(from, to LayerConvention, profile string, rank map[LayerConvention]int) bool {
 	if profile == "modular-monolith" {
 		return false
 	}
-	return isUpwardImport(from, to)
+	return isUpwardImport(from, to, rank)
+}
+
+func parseCustomLayerOrder(raw interface{}) []LayerConvention {
+	layers, ok := raw.([]string)
+	if !ok || len(layers) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(layers))
+	parsed := make([]LayerConvention, 0, len(layers))
+	for _, layer := range layers {
+		normalized := strings.ToLower(strings.TrimSpace(layer))
+		if normalized == "" || seen[normalized] {
+			continue
+		}
+		seen[normalized] = true
+		parsed = append(parsed, LayerConvention(normalized))
+	}
+	if len(parsed) < 2 {
+		return nil
+	}
+	return parsed
+}
+
+func parseCustomLayerKeywords(raw interface{}) map[LayerConvention][]string {
+	keywords, ok := raw.(map[string][]string)
+	if !ok || len(keywords) == 0 {
+		return nil
+	}
+	parsed := make(map[LayerConvention][]string, len(keywords))
+	for layer, aliases := range keywords {
+		normalizedLayer := strings.ToLower(strings.TrimSpace(layer))
+		if normalizedLayer == "" {
+			continue
+		}
+		seenAlias := map[string]bool{}
+		normalizedAliases := make([]string, 0, len(aliases))
+		for _, alias := range aliases {
+			normalizedAlias := strings.ToLower(strings.TrimSpace(alias))
+			if normalizedAlias == "" || seenAlias[normalizedAlias] {
+				continue
+			}
+			seenAlias[normalizedAlias] = true
+			normalizedAliases = append(normalizedAliases, normalizedAlias)
+		}
+		if len(normalizedAliases) > 0 {
+			parsed[LayerConvention(normalizedLayer)] = normalizedAliases
+		}
+	}
+	if len(parsed) == 0 {
+		return nil
+	}
+	return parsed
 }
 
 // formatLayerViolation formats a layer violation message

--- a/internal/rules/layer_validation_rule_profile_test.go
+++ b/internal/rules/layer_validation_rule_profile_test.go
@@ -79,3 +79,54 @@ func TestLayerValidationRule_JSTSProfileAlignment(t *testing.T) {
 		t.Fatalf("expected layered profile marker in violation message, got %q", violations[0].Message)
 	}
 }
+
+func TestLayerValidationRule_CustomLayerPolicyDetectsUpwardImport(t *testing.T) {
+	rule := NewLayerValidationRule()
+	ctx := AnalysisContext{
+		Configuration: Configuration{
+			"architectureProfile": "layered",
+			"customLayerOrder":    []string{"api", "service", "data"},
+			"customLayerKeywords": map[string][]string{
+				"api":     []string{"api", "controller"},
+				"service": []string{"service"},
+				"data":    []string{"repo", "data"},
+			},
+		},
+		RepositoryFiles: []RepositoryFile{{
+			Path:    "data/user_repo.go",
+			Imports: []string{"api/user_controller.go"},
+		}},
+	}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 1 {
+		t.Fatalf("expected one custom-policy upward import violation, got %d (%v)", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "data") || !strings.Contains(violations[0].Message, "api") {
+		t.Fatalf("expected custom layer names in violation message, got %q", violations[0].Message)
+	}
+}
+
+func TestLayerValidationRule_CustomLayerPolicyAllowsDownwardImport(t *testing.T) {
+	rule := NewLayerValidationRule()
+	ctx := AnalysisContext{
+		Configuration: Configuration{
+			"architectureProfile": "layered",
+			"customLayerOrder":    []string{"api", "service", "data"},
+			"customLayerKeywords": map[string][]string{
+				"api":     []string{"api", "controller"},
+				"service": []string{"service"},
+				"data":    []string{"repo", "data"},
+			},
+		},
+		RepositoryFiles: []RepositoryFile{{
+			Path:    "api/user_controller.go",
+			Imports: []string{"data/user_repo.go"},
+		}},
+	}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected no violation for downward custom import, got %v", violations)
+	}
+}

--- a/main_exit_policy_test.go
+++ b/main_exit_policy_test.go
@@ -1,0 +1,52 @@
+package main
+
+import "testing"
+
+func TestDetermineExitCode_NoViolationsReturnsZero(t *testing.T) {
+	report := &StructuralReport{HasViolations: false}
+	if got := determineExitCode(report); got != 0 {
+		t.Fatalf("expected exit code 0 for no violations, got %d", got)
+	}
+}
+
+func TestDetermineExitCode_CircularOrLayerViolationReturnsTwo(t *testing.T) {
+	tests := []struct {
+		name   string
+		report *StructuralReport
+	}{
+		{
+			name: "circular violation",
+			report: &StructuralReport{
+				HasViolations: true,
+				Circular:      []CycleViolation{{Path: []string{"a", "b"}}},
+			},
+		},
+		{
+			name: "layer violation",
+			report: &StructuralReport{
+				HasViolations: true,
+				Layer:         []LayerViolation{{From: "repo", To: "handler"}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := determineExitCode(tc.report); got != 2 {
+				t.Fatalf("expected exit code 2 for %s, got %d", tc.name, got)
+			}
+		})
+	}
+}
+
+func TestDetermineExitCode_SizeAndGodObjectViolationsRemainNonBlocking(t *testing.T) {
+	report := &StructuralReport{
+		HasViolations: true,
+		Size:          []SizeViolation{{File: "big.go", Lines: 900, Threshold: 500}},
+		GodObject:     []GodObjectViolation{{File: "god.go", StructName: "GodType", FieldCount: 25}},
+	}
+
+	if got := determineExitCode(report); got != 0 {
+		t.Fatalf("expected exit code 0 for size/god-object only violations, got %d", got)
+	}
+}

--- a/runtime_context_builder.go
+++ b/runtime_context_builder.go
@@ -9,16 +9,33 @@ type runtimeAnalysisContextInput struct {
 	Graph               Graph
 	PrimaryLanguage     string
 	ArchitectureProfile string
+	CustomLayerOrder    []string
+	CustomLayerKeywords map[string][]string
 }
 
 func buildUnifiedRulesAnalysisContext(input runtimeAnalysisContextInput) rules.AnalysisContext {
 	repositoryFiles := buildContextRepositoryFiles(input.Graph)
 	languages := resolveContextLanguages(input.PrimaryLanguage)
 
+	configuration := rules.Configuration{
+		"repositoryPath":      input.RepositoryPath,
+		"architectureProfile": input.ArchitectureProfile,
+	}
+	if len(input.CustomLayerOrder) > 0 {
+		configuration["customLayerOrder"] = append([]string{}, input.CustomLayerOrder...)
+	}
+	if len(input.CustomLayerKeywords) > 0 {
+		copiedKeywords := make(map[string][]string, len(input.CustomLayerKeywords))
+		for layer, aliases := range input.CustomLayerKeywords {
+			copiedKeywords[layer] = append([]string{}, aliases...)
+		}
+		configuration["customLayerKeywords"] = copiedKeywords
+	}
+
 	return rules.AnalysisContext{
 		RepositoryFiles: repositoryFiles,
 		DependencyGraph: toRulesDependencyGraph(input.Graph),
-		Configuration:   rules.Configuration{"repositoryPath": input.RepositoryPath, "architectureProfile": input.ArchitectureProfile},
+		Configuration:   configuration,
 		Languages:       languages,
 	}
 }

--- a/runtime_context_builder_test.go
+++ b/runtime_context_builder_test.go
@@ -56,6 +56,48 @@ func TestBuildUnifiedRulesAnalysisContext_ConfigurationContractKeys(t *testing.T
 	}
 }
 
+func TestBuildUnifiedRulesAnalysisContext_IncludesCustomArchitectureConfiguration(t *testing.T) {
+	graph := NewDependencyGraph()
+	graph.AddNode("a.go")
+
+	ctx := buildUnifiedRulesAnalysisContext(runtimeAnalysisContextInput{
+		RepositoryPath:      filepath.Clean("."),
+		Graph:               graph,
+		PrimaryLanguage:     "Go",
+		ArchitectureProfile: "layered",
+		CustomLayerOrder:    []string{"api", "service", "data"},
+		CustomLayerKeywords: map[string][]string{
+			"api":     []string{"api", "controller"},
+			"service": []string{"service"},
+			"data":    []string{"repo", "data"},
+		},
+	})
+
+	rawOrder, ok := ctx.Configuration["customLayerOrder"]
+	if !ok {
+		t.Fatalf("configuration key %q missing", "customLayerOrder")
+	}
+	order, ok := rawOrder.([]string)
+	if !ok {
+		t.Fatalf("configuration key %q has unexpected type %T", "customLayerOrder", rawOrder)
+	}
+	if len(order) != 3 || order[0] != "api" || order[2] != "data" {
+		t.Fatalf("configuration key %q drifted: got %v", "customLayerOrder", order)
+	}
+
+	rawKeywords, ok := ctx.Configuration["customLayerKeywords"]
+	if !ok {
+		t.Fatalf("configuration key %q missing", "customLayerKeywords")
+	}
+	keywords, ok := rawKeywords.(map[string][]string)
+	if !ok {
+		t.Fatalf("configuration key %q has unexpected type %T", "customLayerKeywords", rawKeywords)
+	}
+	if len(keywords["api"]) != 2 || keywords["api"][1] != "controller" {
+		t.Fatalf("configuration key %q drifted: got %v", "customLayerKeywords", keywords)
+	}
+}
+
 func TestResolveContextLanguages_DefaultIncludesJavaPilotLanguage(t *testing.T) {
 	languages := resolveContextLanguages("")
 	if len(languages) != 5 {

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -112,6 +112,7 @@ func buildReportFromRuleViolations(path string, version string, cfg *Config, vio
 	godObjectMap := make(map[string]*GodObjectViolation)
 
 	for _, v := range violations {
+		v = applyConfiguredSeverity(v, cfg)
 		switch v.RuleID {
 		case "rule.circular-dependency":
 			report.Circular = append(report.Circular, parseCircularViolation(v))
@@ -260,6 +261,45 @@ func remediationHintForViolation(v model.Violation) string {
 		return "Extract cohesive responsibilities into dedicated types and keep each object focused on one concern."
 	default:
 		return ""
+	}
+}
+
+func applyConfiguredSeverity(v model.Violation, cfg *Config) model.Violation {
+	if cfg == nil || cfg.Rules == nil {
+		return v
+	}
+	severity := ""
+	switch v.RuleID {
+	case "rule.circular-dependency":
+		severity = cfg.Rules.CircularSeverity
+	case "rule.layer-validation":
+		severity = cfg.Rules.LayerSeverity
+	case "rule.size":
+		severity = cfg.Rules.SizeSeverity
+	case "rule.god-object":
+		severity = cfg.Rules.GodObjectSeverity
+	}
+	parsed, ok := parseSeverity(severity)
+	if !ok {
+		return v
+	}
+	v.Severity = parsed
+	return v
+}
+
+func parseSeverity(raw string) (model.Severity, bool) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	switch value {
+	case "info":
+		return model.SeverityInfo, true
+	case "warning":
+		return model.SeverityWarning, true
+	case "error":
+		return model.SeverityError, true
+	case "critical":
+		return model.SeverityCritical, true
+	default:
+		return "", false
 	}
 }
 

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -17,10 +17,19 @@ type runtimeRuleSummary struct {
 }
 
 func runInternalRulePipeline(absPath string, graph Graph, primaryLanguage string) *runtimeRuleSummary {
-	return runInternalRulePipelineWithProfile(absPath, graph, primaryLanguage, "")
+	return runInternalRulePipelineWithProfile(absPath, graph, primaryLanguage, nil)
 }
 
-func runInternalRulePipelineWithProfile(absPath string, graph Graph, primaryLanguage string, architectureProfile string) *runtimeRuleSummary {
+func runInternalRulePipelineWithProfile(absPath string, graph Graph, primaryLanguage string, architecture *ArchitectureConfig) *runtimeRuleSummary {
+	profile := ""
+	customLayerOrder := []string{}
+	customLayerKeywords := map[string][]string{}
+	if architecture != nil {
+		profile = strings.TrimSpace(architecture.Profile)
+		customLayerOrder = normalizeLayerOrder(architecture.CustomLayerOrder)
+		customLayerKeywords = normalizeLayerKeywords(architecture.CustomLayerKeywords)
+	}
+
 	registry := rules.NewRuleRegistry()
 	for _, rule := range rules.GetDefaultRegistry().GetAll() {
 		registry.MustRegister(rule)
@@ -32,7 +41,9 @@ func runInternalRulePipelineWithProfile(absPath string, graph Graph, primaryLang
 		RepositoryPath:      absPath,
 		Graph:               graph,
 		PrimaryLanguage:     primaryLanguage,
-		ArchitectureProfile: architectureProfile,
+		ArchitectureProfile: profile,
+		CustomLayerOrder:    customLayerOrder,
+		CustomLayerKeywords: customLayerKeywords,
 	})
 	result := executor.Execute(context)
 	sortViolations(result.Violations)
@@ -41,6 +52,56 @@ func runInternalRulePipelineWithProfile(absPath string, graph Graph, primaryLang
 		result:       result,
 		rulesInScope: registry.Count(),
 	}
+}
+
+func normalizeLayerOrder(raw []string) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(raw))
+	normalized := make([]string, 0, len(raw))
+	for _, layer := range raw {
+		value := strings.ToLower(strings.TrimSpace(layer))
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		normalized = append(normalized, value)
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
+func normalizeLayerKeywords(raw map[string][]string) map[string][]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	normalized := make(map[string][]string, len(raw))
+	for layer, aliases := range raw {
+		normalizedLayer := strings.ToLower(strings.TrimSpace(layer))
+		if normalizedLayer == "" {
+			continue
+		}
+		seenAliases := map[string]bool{}
+		normalizedAliases := make([]string, 0, len(aliases))
+		for _, alias := range aliases {
+			value := strings.ToLower(strings.TrimSpace(alias))
+			if value == "" || seenAliases[value] {
+				continue
+			}
+			seenAliases[value] = true
+			normalizedAliases = append(normalizedAliases, value)
+		}
+		if len(normalizedAliases) > 0 {
+			normalized[normalizedLayer] = normalizedAliases
+		}
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
 }
 
 func buildRulesAnalysisContext(absPath string, graph Graph, primaryLanguage string) rules.AnalysisContext {

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"RepoDoctor/internal/engine"
 	"RepoDoctor/internal/model"
@@ -113,9 +114,9 @@ func buildReportFromRuleViolations(path string, version string, cfg *Config, vio
 	for _, v := range violations {
 		switch v.RuleID {
 		case "rule.circular-dependency":
-			report.Circular = append(report.Circular, CycleViolation{Path: []string{v.File}, Severity: string(v.Severity), Hint: remediationHintForViolation(v)})
+			report.Circular = append(report.Circular, parseCircularViolation(v))
 		case "rule.layer-validation":
-			report.Layer = append(report.Layer, LayerViolation{From: v.File, To: "", Message: v.Message, Hint: remediationHintForViolation(v)})
+			report.Layer = append(report.Layer, parseLayerViolation(v))
 		case "rule.size":
 			report.Size = append(report.Size, parseSizeViolation(v))
 		case "rule.god-object":
@@ -145,7 +146,52 @@ var (
 	sizeFuncRe  = regexp.MustCompile(`^Function '([^']+)' has (\d+) lines \(threshold: (\d+)\)`)
 	godFieldRe  = regexp.MustCompile(`^(.+) has (\d+) fields \(threshold: \d+\)`)
 	godMethodRe = regexp.MustCompile(`^(.+) has (\d+) methods \(threshold: \d+\)`)
+	layerMsgRe  = regexp.MustCompile(`^(.+?) \(([^)]+)\) -> (.+?) \(([^)]+)\): (.+)$`)
 )
+
+func parseCircularViolation(v model.Violation) CycleViolation {
+	path := parseCyclePath(v.Message)
+	if len(path) == 0 {
+		path = []string{v.File}
+	}
+	return CycleViolation{Path: path, Severity: string(v.Severity), Hint: remediationHintForViolation(v)}
+}
+
+func parseCyclePath(message string) []string {
+	trimmed := strings.TrimSpace(message)
+	if trimmed == "" {
+		return nil
+	}
+	parts := strings.Split(trimmed, "→")
+	path := make([]string, 0, len(parts))
+	for _, part := range parts {
+		node := strings.TrimSpace(part)
+		if node == "" {
+			continue
+		}
+		path = append(path, node)
+	}
+	if len(path) > 1 && path[0] == path[len(path)-1] {
+		path = path[:len(path)-1]
+	}
+	return path
+}
+
+func parseLayerViolation(v model.Violation) LayerViolation {
+	lv := LayerViolation{From: v.File, To: "", Message: v.Message, Hint: remediationHintForViolation(v)}
+	if m := layerMsgRe.FindStringSubmatch(v.Message); len(m) == 6 {
+		fromPath := strings.TrimSpace(m[1])
+		fromLayer := strings.TrimSpace(m[2])
+		toPath := strings.TrimSpace(m[3])
+		toLayer := strings.TrimSpace(m[4])
+		reason := strings.TrimSpace(m[5])
+
+		lv.From = fromPath
+		lv.To = toPath
+		lv.Message = fromLayer + " -> " + toLayer + ": " + reason
+	}
+	return lv
+}
 
 // parseSizeViolation extracts Lines, Threshold, and Function from a size
 // violation message instead of using hardcoded placeholder values.

--- a/runtime_engine_violation_messages_test.go
+++ b/runtime_engine_violation_messages_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"RepoDoctor/internal/model"
+)
+
+func TestParseCyclePath_ExtractsDeterministicNodes(t *testing.T) {
+	message := "a/service → b/repo → c/handler → a/service"
+	path := parseCyclePath(message)
+	if len(path) != 3 {
+		t.Fatalf("expected 3 nodes after cycle closure trim, got %v", path)
+	}
+	if path[0] != "a/service" || path[1] != "b/repo" || path[2] != "c/handler" {
+		t.Fatalf("unexpected parsed cycle path: %v", path)
+	}
+}
+
+func TestParseCircularViolation_FallbackToFileWhenMessageUnavailable(t *testing.T) {
+	v := model.Violation{RuleID: "rule.circular-dependency", File: "a.go", Severity: model.SeverityCritical, Message: ""}
+	parsed := parseCircularViolation(v)
+	if len(parsed.Path) != 1 || parsed.Path[0] != "a.go" {
+		t.Fatalf("expected fallback path from file, got %v", parsed.Path)
+	}
+}
+
+func TestParseLayerViolation_ImprovesMessageAndEndpoints(t *testing.T) {
+	v := model.Violation{
+		RuleID:   "rule.layer-validation",
+		File:     "src/handler/user.go",
+		Severity: model.SeverityError,
+		Message:  "src/handler/user.go (handler) -> src/repo/user.go (repo): upward import not allowed [profile:layered]",
+	}
+	parsed := parseLayerViolation(v)
+	if parsed.From != "src/handler/user.go" || parsed.To != "src/repo/user.go" {
+		t.Fatalf("expected from/to extraction, got from=%q to=%q", parsed.From, parsed.To)
+	}
+	if parsed.Message != "handler -> repo: upward import not allowed [profile:layered]" {
+		t.Fatalf("expected normalized layer message, got %q", parsed.Message)
+	}
+}

--- a/runtime_engine_violation_messages_test.go
+++ b/runtime_engine_violation_messages_test.go
@@ -40,3 +40,30 @@ func TestParseLayerViolation_ImprovesMessageAndEndpoints(t *testing.T) {
 		t.Fatalf("expected normalized layer message, got %q", parsed.Message)
 	}
 }
+
+func TestApplyConfiguredSeverity_UsesRuleOverrides(t *testing.T) {
+	cfg := &Config{Rules: &RulesConfig{
+		CircularSeverity:  "warning",
+		LayerSeverity:     "critical",
+		SizeSeverity:      "error",
+		GodObjectSeverity: "info",
+	}}
+
+	tests := []struct {
+		ruleID string
+		want   model.Severity
+	}{
+		{ruleID: "rule.circular-dependency", want: model.SeverityWarning},
+		{ruleID: "rule.layer-validation", want: model.SeverityCritical},
+		{ruleID: "rule.size", want: model.SeverityError},
+		{ruleID: "rule.god-object", want: model.SeverityInfo},
+	}
+
+	for _, tc := range tests {
+		base := model.Violation{RuleID: tc.ruleID, Severity: model.SeverityError}
+		got := applyConfiguredSeverity(base, cfg)
+		if got.Severity != tc.want {
+			t.Fatalf("expected %s severity for %s, got %s", tc.want, tc.ruleID, got.Severity)
+		}
+	}
+}

--- a/scripts/v100_release_stabilization_gate.ps1
+++ b/scripts/v100_release_stabilization_gate.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    Write-Host "==> $Name"
+    Invoke-Expression $Command
+}
+
+Invoke-Step -Name "core test suite" -Command "go test ./..."
+Invoke-Step -Name "static analysis" -Command "go vet ./..."
+Invoke-Step -Name "determinism confidence suite" -Command "go test ./... -run 'TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns'"
+Invoke-Step -Name "v1.0 feature contract pack" -Command "go test ./... -run 'TestConfigLoader_RuleSeverityOverrides_DefaultAndValidation|TestLayerValidationRule_CustomLayerPolicyDetectsUpwardImport|TestCITemplateGenerator_GenerateGitHubTemplate|TestDetermineExitCode_NoViolationsReturnsZero|TestDetermineExitCode_CircularOrLayerViolationReturnsTwo|TestDetermineExitCode_SizeAndGodObjectViolationsRemainNonBlocking'"
+Invoke-Step -Name "self-analysis 100/100 gate" -Command "go run . analyze -path ."
+
+Write-Host "v1.0 release stabilization gate passed."


### PR DESCRIPTION
## Summary
- release M3 (v1.0 UX & Polish) from `dev` to `main`
- includes merged work from RD-10001 through RD-10005:
  - better violation messages
  - rule severity configuration
  - custom architecture profiles
  - CI template generator
  - v1.0 stabilization gates and documentation sync

## Validation Baseline
- Linux + Windows CI green on all merged M3 PRs
- mandatory local gates maintained (`go test ./...`, `go vet ./...`, `go run . analyze -path .`)
- self-analysis score target preserved (`100/100`)

Closes #217
Closes #218
Closes #219