### PR TITLE
feat(rd-11001): harden incremental cache persistence

### DIFF
--- a/internal/analysis/incremental_boundary_test.go
+++ b/internal/analysis/incremental_boundary_test.go
@@ -2,6 +2,8 @@ package analysis
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -129,5 +131,44 @@ func TestInMemoryIncrementalSnapshotStore_ClonesOnSaveAndLoad(t *testing.T) {
 	}
 	if reloaded.Fingerprints["a.go"] != "1111111111111111111111111111111111111111111111111111111111111111" {
 		t.Fatalf("store must clone on load, got %s", reloaded.Fingerprints["a.go"])
+	}
+}
+
+func TestIncrementalBoundaryService_FileStoreRoundTrip(t *testing.T) {
+	baseDir := filepath.Join(t.TempDir(), "cache")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatalf("failed to create cache dir: %v", err)
+	}
+
+	store, err := NewFileIncrementalSnapshotStore(baseDir)
+	if err != nil {
+		t.Fatalf("failed to create file snapshot store: %v", err)
+	}
+
+	cacheKey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	service, err := NewIncrementalBoundaryService(store, stubFingerprintProvider{state: map[string]string{
+		"a.go": "1111111111111111111111111111111111111111111111111111111111111111",
+	}})
+	if err != nil {
+		t.Fatalf("failed to create boundary service: %v", err)
+	}
+
+	first, err := service.Compute(baseDir, cacheKey)
+	if err != nil {
+		t.Fatalf("first compute failed: %v", err)
+	}
+	if first.CacheHit {
+		t.Fatal("first compute must be cache miss")
+	}
+
+	second, err := service.Compute(baseDir, cacheKey)
+	if err != nil {
+		t.Fatalf("second compute failed: %v", err)
+	}
+	if !second.CacheHit {
+		t.Fatal("second compute must be cache hit")
+	}
+	if len(second.Changed) != 0 || len(second.Removed) != 0 {
+		t.Fatalf("expected no diff on repeated run, changed=%v removed=%v", second.Changed, second.Removed)
 	}
 }

--- a/internal/analysis/incremental_store_file.go
+++ b/internal/analysis/incremental_store_file.go
@@ -1,0 +1,95 @@
+package analysis
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FileIncrementalSnapshotStore persists incremental snapshots on disk.
+// It is fail-closed for malformed data (treated as cache miss).
+type FileIncrementalSnapshotStore struct {
+	baseDir string
+}
+
+func NewFileIncrementalSnapshotStore(baseDir string) (*FileIncrementalSnapshotStore, error) {
+	if strings.TrimSpace(baseDir) == "" {
+		return nil, fmt.Errorf("base directory is required")
+	}
+	cleanBase := filepath.Clean(baseDir)
+	if err := os.MkdirAll(cleanBase, 0o755); err != nil {
+		return nil, fmt.Errorf("create incremental cache directory: %w", err)
+	}
+	return &FileIncrementalSnapshotStore{baseDir: cleanBase}, nil
+}
+
+func (s *FileIncrementalSnapshotStore) Load(cacheKey string) (IncrementalCacheSnapshot, bool, error) {
+	if s == nil {
+		return IncrementalCacheSnapshot{}, false, fmt.Errorf("snapshot store is required")
+	}
+	if strings.TrimSpace(cacheKey) == "" {
+		return IncrementalCacheSnapshot{}, false, fmt.Errorf("cache key is required")
+	}
+
+	path, err := s.snapshotPath(cacheKey)
+	if err != nil {
+		return IncrementalCacheSnapshot{}, false, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return IncrementalCacheSnapshot{}, false, nil
+		}
+		return IncrementalCacheSnapshot{}, false, fmt.Errorf("read incremental snapshot: %w", err)
+	}
+
+	snapshot, ok := UnmarshalIncrementalCacheSnapshotSafe(data)
+	if !ok {
+		return IncrementalCacheSnapshot{}, false, nil
+	}
+
+	return cloneSnapshot(snapshot), true, nil
+}
+
+func (s *FileIncrementalSnapshotStore) Save(snapshot IncrementalCacheSnapshot) error {
+	if s == nil {
+		return fmt.Errorf("snapshot store is required")
+	}
+	if err := snapshot.Validate(); err != nil {
+		return err
+	}
+
+	path, err := s.snapshotPath(snapshot.CacheKey)
+	if err != nil {
+		return err
+	}
+
+	data, err := MarshalIncrementalCacheSnapshot(snapshot)
+	if err != nil {
+		return err
+	}
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("write temporary incremental snapshot: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("replace incremental snapshot atomically: %w", err)
+	}
+
+	return nil
+}
+
+func (s *FileIncrementalSnapshotStore) snapshotPath(cacheKey string) (string, error) {
+	normalized := strings.TrimSpace(cacheKey)
+	if normalized == "" {
+		return "", fmt.Errorf("cache key is required")
+	}
+	if len(normalized) != 64 || !isLowerHex(normalized) {
+		return "", fmt.Errorf("cache key must be 64-char lowercase hex")
+	}
+	return filepath.Join(s.baseDir, normalized+".json"), nil
+}

--- a/internal/analysis/incremental_store_file_test.go
+++ b/internal/analysis/incremental_store_file_test.go
@@ -1,0 +1,100 @@
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileIncrementalSnapshotStore_RoundTrip(t *testing.T) {
+	store, err := NewFileIncrementalSnapshotStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create file store: %v", err)
+	}
+
+	cacheKey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	snapshot := NewIncrementalCacheSnapshot(cacheKey, map[string]string{
+		"a.go": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	})
+
+	if err := store.Save(snapshot); err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	loaded, found, err := store.Load(cacheKey)
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected snapshot to be found")
+	}
+	if loaded.CacheKey != cacheKey {
+		t.Fatalf("expected cache key %s, got %s", cacheKey, loaded.CacheKey)
+	}
+	if loaded.Fingerprints["a.go"] != snapshot.Fingerprints["a.go"] {
+		t.Fatalf("expected persisted fingerprint %s, got %s", snapshot.Fingerprints["a.go"], loaded.Fingerprints["a.go"])
+	}
+}
+
+func TestFileIncrementalSnapshotStore_LoadCorruptPayloadFailsClosed(t *testing.T) {
+	baseDir := t.TempDir()
+	store, err := NewFileIncrementalSnapshotStore(baseDir)
+	if err != nil {
+		t.Fatalf("failed to create file store: %v", err)
+	}
+
+	cacheKey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	corruptPath := filepath.Join(baseDir, cacheKey+".json")
+	if err := os.WriteFile(corruptPath, []byte(`{"schemaVersion":"v1",`), 0o644); err != nil {
+		t.Fatalf("failed writing corrupt payload: %v", err)
+	}
+
+	_, found, err := store.Load(cacheKey)
+	if err != nil {
+		t.Fatalf("expected corrupt payload to fail-closed without error, got: %v", err)
+	}
+	if found {
+		t.Fatal("expected corrupt payload to be treated as cache miss")
+	}
+}
+
+func TestFileIncrementalSnapshotStore_RejectsInvalidCacheKeyFormat(t *testing.T) {
+	store, err := NewFileIncrementalSnapshotStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create file store: %v", err)
+	}
+
+	if _, _, err := store.Load("cache-key"); err == nil {
+		t.Fatal("expected invalid cache key format to be rejected")
+	}
+}
+
+func TestFileIncrementalSnapshotStore_SaveAtomicReplace(t *testing.T) {
+	baseDir := t.TempDir()
+	store, err := NewFileIncrementalSnapshotStore(baseDir)
+	if err != nil {
+		t.Fatalf("failed to create file store: %v", err)
+	}
+
+	cacheKey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	first := NewIncrementalCacheSnapshot(cacheKey, map[string]string{"a.go": "1111111111111111111111111111111111111111111111111111111111111111"})
+	second := NewIncrementalCacheSnapshot(cacheKey, map[string]string{"a.go": "2222222222222222222222222222222222222222222222222222222222222222"})
+
+	if err := store.Save(first); err != nil {
+		t.Fatalf("first save failed: %v", err)
+	}
+	if err := store.Save(second); err != nil {
+		t.Fatalf("second save failed: %v", err)
+	}
+
+	loaded, found, err := store.Load(cacheKey)
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected snapshot to be found")
+	}
+	if loaded.Fingerprints["a.go"] != second.Fingerprints["a.go"] {
+		t.Fatalf("expected latest snapshot hash %s, got %s", second.Fingerprints["a.go"], loaded.Fingerprints["a.go"])
+	}
+}

--- a/internal/analysis/incremental_store_memory.go
+++ b/internal/analysis/incremental_store_memory.go
@@ -1,11 +1,15 @@
 package analysis
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 // InMemoryIncrementalSnapshotStore is a deterministic test-friendly store
 // implementation kept within analysis boundaries.
 type InMemoryIncrementalSnapshotStore struct {
 	snapshots map[string]IncrementalCacheSnapshot
+	mu        sync.RWMutex
 }
 
 func NewInMemoryIncrementalSnapshotStore() *InMemoryIncrementalSnapshotStore {
@@ -22,6 +26,9 @@ func (s *InMemoryIncrementalSnapshotStore) Load(cacheKey string) (IncrementalCac
 		return IncrementalCacheSnapshot{}, false, fmt.Errorf("cache key is required")
 	}
 
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	snapshot, ok := s.snapshots[cacheKey]
 	if !ok {
 		return IncrementalCacheSnapshot{}, false, nil
@@ -36,6 +43,10 @@ func (s *InMemoryIncrementalSnapshotStore) Save(snapshot IncrementalCacheSnapsho
 	if err := snapshot.Validate(); err != nil {
 		return err
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.snapshots[snapshot.CacheKey] = cloneSnapshot(snapshot)
 	return nil
 }


### PR DESCRIPTION
## Summary
- add a file-backed incremental snapshot store with atomic replace semantics and fail-closed corrupt payload handling
- make in-memory incremental snapshot store race-safe for concurrent access
- extend incremental boundary tests with persistent store roundtrip coverage

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .
- go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"

## Notes
- `go test -race` was attempted but requires `CGO_ENABLED=1` in this local environment.

Closes #220