### PR TITLE
ci(rd-11003): add v1.1 release gate orchestration

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -69,6 +69,14 @@ jobs:
           GOMAXPROCS: 1
         run: ./scripts/v100_release_stabilization_gate.ps1
 
+      - name: Run v1.1 release stabilization gate
+        shell: pwsh
+        env:
+          TZ: UTC
+          LC_ALL: C
+          GOMAXPROCS: 1
+        run: ./scripts/v110_release_stabilization_gate.ps1
+
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -9,4 +9,4 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v0.19 | M1: v0.19 Incremental & Performance | Completed | RD-1901..RD-1908 merged; release stabilization gate and benchmark+memory CI budgets active. |
 | v0.20 | M2: v0.20 Java Pilot (Gated) | Completed (Gated GO) | RD-2001..RD-2007 completed; decision memo published (`JAVA_PILOT_DECISION_v0.20.md`), pilot remains default-off. |
 | v1.0 | M3: v1.0 UX & Polish | In Progress | RD-10001..RD-10004 merged into `dev`; RD-10005 stabilization/docs in progress. |
-| v1.1+ | M4: v1.1+ Scale (Use-case gated) | Planned | Issues RD-11001..RD-11003 created. |
+| v1.1+ | M4: v1.1+ Scale (Use-case gated) | In Progress | RD-11001 and RD-11002 merged into `dev`; RD-11003 release gate wiring in progress. |

--- a/docs/v1.1-rd-11003-release-gate.md
+++ b/docs/v1.1-rd-11003-release-gate.md
@@ -1,0 +1,26 @@
+# v1.1 RD-11003 Release Gate
+
+This document captures the release-gate composition for **M4: v1.1+ Scale (Use-case gated)**.
+
+## Scope
+
+- Add a dedicated v1.1 gate script
+- Keep prior gate layers intact and compatible
+- Validate incremental cache and memory-oriented scale changes from RD-11001 and RD-11002
+
+## v1.1 Gate Steps
+
+1. `go build .`
+2. `go test ./...`
+3. `go vet ./...`
+4. Incremental regression pack (`./internal/analysis` targeted tests)
+5. Determinism confidence suite
+6. `go run . analyze -path .` (target `100/100`)
+
+## CI Integration
+
+The workflow runs `scripts/v110_release_stabilization_gate.ps1` in addition to existing v0.18/v0.19/v1.0 gates.
+
+## Compatibility Rule
+
+The v1.1 gate is additive and does not remove earlier release guarantees.

--- a/scripts/v110_release_stabilization_gate.ps1
+++ b/scripts/v110_release_stabilization_gate.ps1
@@ -1,0 +1,23 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    Write-Host "==> $Name"
+    Invoke-Expression $Command
+}
+
+$determinismRegex = "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
+$incrementalRegex = "TestIncrementalBoundaryService_.*|TestFileIncrementalSnapshotStore_.*|TestIncrementalCorrectness_.*|TestBuildIncrementalCacheKey_.*|TestIncrementalCacheSnapshot_.*|TestHashFileSHA256Streaming_MatchesReferenceHash"
+
+Invoke-Step -Name "build" -Command "go build ."
+Invoke-Step -Name "core test suite" -Command "go test ./..."
+Invoke-Step -Name "static analysis" -Command "go vet ./..."
+Invoke-Step -Name "v1.1 incremental regression pack" -Command "go test ./internal/analysis -run '$incrementalRegex'"
+Invoke-Step -Name "determinism confidence suite" -Command "go test ./... -run '$determinismRegex'"
+Invoke-Step -Name "self-analysis 100/100 gate" -Command "go run . analyze -path ."
+
+Write-Host "v1.1 release stabilization gate passed."


### PR DESCRIPTION
## Summary
- add a dedicated `v110_release_stabilization_gate.ps1` script for v1.1 closeout checks
- wire the new v1.1 release gate into the GitHub Actions workflow while preserving previous gate layers
- publish v1.1 release gate doc and update milestone tracker status

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .
- pwsh -File ./scripts/v110_release_stabilization_gate.ps1

Closes #222