### PR TITLE
release(v1.1): merge M4 scale gates from dev

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -69,6 +69,14 @@ jobs:
           GOMAXPROCS: 1
         run: ./scripts/v100_release_stabilization_gate.ps1
 
+      - name: Run v1.1 release stabilization gate
+        shell: pwsh
+        env:
+          TZ: UTC
+          LC_ALL: C
+          GOMAXPROCS: 1
+        run: ./scripts/v110_release_stabilization_gate.ps1
+
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -9,4 +9,4 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v0.19 | M1: v0.19 Incremental & Performance | Completed | RD-1901..RD-1908 merged; release stabilization gate and benchmark+memory CI budgets active. |
 | v0.20 | M2: v0.20 Java Pilot (Gated) | Completed (Gated GO) | RD-2001..RD-2007 completed; decision memo published (`JAVA_PILOT_DECISION_v0.20.md`), pilot remains default-off. |
 | v1.0 | M3: v1.0 UX & Polish | In Progress | RD-10001..RD-10004 merged into `dev`; RD-10005 stabilization/docs in progress. |
-| v1.1+ | M4: v1.1+ Scale (Use-case gated) | Planned | Issues RD-11001..RD-11003 created. |
+| v1.1+ | M4: v1.1+ Scale (Use-case gated) | In Progress | RD-11001 and RD-11002 merged into `dev`; RD-11003 release gate wiring in progress. |

--- a/docs/v1.1-rd-11003-release-gate.md
+++ b/docs/v1.1-rd-11003-release-gate.md
@@ -1,0 +1,26 @@
+# v1.1 RD-11003 Release Gate
+
+This document captures the release-gate composition for **M4: v1.1+ Scale (Use-case gated)**.
+
+## Scope
+
+- Add a dedicated v1.1 gate script
+- Keep prior gate layers intact and compatible
+- Validate incremental cache and memory-oriented scale changes from RD-11001 and RD-11002
+
+## v1.1 Gate Steps
+
+1. `go build .`
+2. `go test ./...`
+3. `go vet ./...`
+4. Incremental regression pack (`./internal/analysis` targeted tests)
+5. Determinism confidence suite
+6. `go run . analyze -path .` (target `100/100`)
+
+## CI Integration
+
+The workflow runs `scripts/v110_release_stabilization_gate.ps1` in addition to existing v0.18/v0.19/v1.0 gates.
+
+## Compatibility Rule
+
+The v1.1 gate is additive and does not remove earlier release guarantees.

--- a/internal/analysis/incremental_boundary_test.go
+++ b/internal/analysis/incremental_boundary_test.go
@@ -2,6 +2,8 @@ package analysis
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -129,5 +131,44 @@ func TestInMemoryIncrementalSnapshotStore_ClonesOnSaveAndLoad(t *testing.T) {
 	}
 	if reloaded.Fingerprints["a.go"] != "1111111111111111111111111111111111111111111111111111111111111111" {
 		t.Fatalf("store must clone on load, got %s", reloaded.Fingerprints["a.go"])
+	}
+}
+
+func TestIncrementalBoundaryService_FileStoreRoundTrip(t *testing.T) {
+	baseDir := filepath.Join(t.TempDir(), "cache")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatalf("failed to create cache dir: %v", err)
+	}
+
+	store, err := NewFileIncrementalSnapshotStore(baseDir)
+	if err != nil {
+		t.Fatalf("failed to create file snapshot store: %v", err)
+	}
+
+	cacheKey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	service, err := NewIncrementalBoundaryService(store, stubFingerprintProvider{state: map[string]string{
+		"a.go": "1111111111111111111111111111111111111111111111111111111111111111",
+	}})
+	if err != nil {
+		t.Fatalf("failed to create boundary service: %v", err)
+	}
+
+	first, err := service.Compute(baseDir, cacheKey)
+	if err != nil {
+		t.Fatalf("first compute failed: %v", err)
+	}
+	if first.CacheHit {
+		t.Fatal("first compute must be cache miss")
+	}
+
+	second, err := service.Compute(baseDir, cacheKey)
+	if err != nil {
+		t.Fatalf("second compute failed: %v", err)
+	}
+	if !second.CacheHit {
+		t.Fatal("second compute must be cache hit")
+	}
+	if len(second.Changed) != 0 || len(second.Removed) != 0 {
+		t.Fatalf("expected no diff on repeated run, changed=%v removed=%v", second.Changed, second.Removed)
 	}
 }

--- a/internal/analysis/incremental_fingerprint.go
+++ b/internal/analysis/incremental_fingerprint.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -53,8 +54,12 @@ func BuildGoFingerprintMap(repoPath string) (map[string]string, error) {
 		workers = len(goFiles)
 	}
 
-	paths := make(chan string, len(goFiles))
-	results := make(chan FileFingerprint, len(goFiles))
+	queueCapacity := workers * 2
+	if queueCapacity < 1 {
+		queueCapacity = 1
+	}
+	paths := make(chan string, queueCapacity)
+	var stateMu sync.Mutex
 
 	var wg sync.WaitGroup
 	for i := 0; i < workers; i++ {
@@ -62,12 +67,13 @@ func BuildGoFingerprintMap(repoPath string) (map[string]string, error) {
 		go func() {
 			defer wg.Done()
 			for path := range paths {
-				data, readErr := os.ReadFile(path)
+				hash, readErr := hashFileSHA256Streaming(path)
 				if readErr != nil {
 					continue
 				}
-				hash := sha256.Sum256(data)
-				results <- FileFingerprint{Path: path, Hash: hex.EncodeToString(hash[:])}
+				stateMu.Lock()
+				state[path] = hash
+				stateMu.Unlock()
 			}
 		}()
 	}
@@ -77,13 +83,23 @@ func BuildGoFingerprintMap(repoPath string) (map[string]string, error) {
 	}
 	close(paths)
 	wg.Wait()
-	close(results)
-
-	for fp := range results {
-		state[fp.Path] = fp.Hash
-	}
 
 	return state, nil
+}
+
+func hashFileSHA256Streaming(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
 func collectGoFiles(repoPath string) ([]string, error) {

--- a/internal/analysis/incremental_fingerprint.go
+++ b/internal/analysis/incremental_fingerprint.go
@@ -8,10 +8,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
-	"sync"
 )
 
 type FileFingerprint struct {
@@ -46,57 +44,52 @@ func BuildGoFingerprintMap(repoPath string) (map[string]string, error) {
 		return state, nil
 	}
 
-	workers := runtime.NumCPU()
-	if workers < 1 {
-		workers = 1
-	}
-	if workers > len(goFiles) {
-		workers = len(goFiles)
-	}
+	const fingerprintBatchSize = 128
+	buffer := make([]byte, 32*1024)
 
-	queueCapacity := workers * 2
-	if queueCapacity < 1 {
-		queueCapacity = 1
-	}
-	paths := make(chan string, queueCapacity)
-	var stateMu sync.Mutex
-
-	var wg sync.WaitGroup
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for path := range paths {
-				hash, readErr := hashFileSHA256Streaming(path)
-				if readErr != nil {
-					continue
-				}
-				stateMu.Lock()
-				state[path] = hash
-				stateMu.Unlock()
+	for start := 0; start < len(goFiles); start += fingerprintBatchSize {
+		end := minInt(start+fingerprintBatchSize, len(goFiles))
+		for _, path := range goFiles[start:end] {
+			hash, readErr := hashFileSHA256StreamingWithBuffer(path, buffer)
+			if readErr != nil {
+				continue
 			}
-		}()
+			state[path] = hash
+		}
 	}
-
-	for _, path := range goFiles {
-		paths <- path
-	}
-	close(paths)
-	wg.Wait()
 
 	return state, nil
 }
 
 func hashFileSHA256Streaming(path string) (string, error) {
+	return hashFileSHA256StreamingWithBuffer(path, make([]byte, 32*1024))
+}
+
+func hashFileSHA256StreamingWithBuffer(path string, buffer []byte) (string, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return "", err
 	}
 	defer file.Close()
 
+	if len(buffer) == 0 {
+		buffer = make([]byte, 32*1024)
+	}
+
 	hasher := sha256.New()
-	if _, err := io.Copy(hasher, file); err != nil {
-		return "", err
+	for {
+		readBytes, readErr := file.Read(buffer)
+		if readBytes > 0 {
+			if _, writeErr := hasher.Write(buffer[:readBytes]); writeErr != nil {
+				return "", writeErr
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return "", readErr
+		}
 	}
 
 	return hex.EncodeToString(hasher.Sum(nil)), nil

--- a/internal/analysis/incremental_fingerprint_test.go
+++ b/internal/analysis/incremental_fingerprint_test.go
@@ -1,6 +1,8 @@
 package analysis
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -82,5 +84,25 @@ func TestBuildGoFingerprintMap_DeterministicAcrossRuns(t *testing.T) {
 		if !reflect.DeepEqual(baseline, next) {
 			t.Fatalf("fingerprint map must remain deterministic; baseline=%v next=%v", baseline, next)
 		}
+	}
+}
+
+func TestHashFileSHA256Streaming_MatchesReferenceHash(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, "streaming.go")
+	content := []byte("package main\nfunc main(){ println(42) }\n")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("failed writing fixture file: %v", err)
+	}
+
+	actual, err := hashFileSHA256Streaming(path)
+	if err != nil {
+		t.Fatalf("hashFileSHA256Streaming failed: %v", err)
+	}
+
+	sum := sha256.Sum256(content)
+	expected := hex.EncodeToString(sum[:])
+	if actual != expected {
+		t.Fatalf("streaming hash mismatch: expected %s got %s", expected, actual)
 	}
 }

--- a/internal/analysis/incremental_store_file.go
+++ b/internal/analysis/incremental_store_file.go
@@ -1,0 +1,95 @@
+package analysis
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FileIncrementalSnapshotStore persists incremental snapshots on disk.
+// It is fail-closed for malformed data (treated as cache miss).
+type FileIncrementalSnapshotStore struct {
+	baseDir string
+}
+
+func NewFileIncrementalSnapshotStore(baseDir string) (*FileIncrementalSnapshotStore, error) {
+	if strings.TrimSpace(baseDir) == "" {
+		return nil, fmt.Errorf("base directory is required")
+	}
+	cleanBase := filepath.Clean(baseDir)
+	if err := os.MkdirAll(cleanBase, 0o755); err != nil {
+		return nil, fmt.Errorf("create incremental cache directory: %w", err)
+	}
+	return &FileIncrementalSnapshotStore{baseDir: cleanBase}, nil
+}
+
+func (s *FileIncrementalSnapshotStore) Load(cacheKey string) (IncrementalCacheSnapshot, bool, error) {
+	if s == nil {
+		return IncrementalCacheSnapshot{}, false, fmt.Errorf("snapshot store is required")
+	}
+	if strings.TrimSpace(cacheKey) == "" {
+		return IncrementalCacheSnapshot{}, false, fmt.Errorf("cache key is required")
+	}
+
+	path, err := s.snapshotPath(cacheKey)
+	if err != nil {
+		return IncrementalCacheSnapshot{}, false, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return IncrementalCacheSnapshot{}, false, nil
+		}
+		return IncrementalCacheSnapshot{}, false, fmt.Errorf("read incremental snapshot: %w", err)
+	}
+
+	snapshot, ok := UnmarshalIncrementalCacheSnapshotSafe(data)
+	if !ok {
+		return IncrementalCacheSnapshot{}, false, nil
+	}
+
+	return cloneSnapshot(snapshot), true, nil
+}
+
+func (s *FileIncrementalSnapshotStore) Save(snapshot IncrementalCacheSnapshot) error {
+	if s == nil {
+		return fmt.Errorf("snapshot store is required")
+	}
+	if err := snapshot.Validate(); err != nil {
+		return err
+	}
+
+	path, err := s.snapshotPath(snapshot.CacheKey)
+	if err != nil {
+		return err
+	}
+
+	data, err := MarshalIncrementalCacheSnapshot(snapshot)
+	if err != nil {
+		return err
+	}
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("write temporary incremental snapshot: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("replace incremental snapshot atomically: %w", err)
+	}
+
+	return nil
+}
+
+func (s *FileIncrementalSnapshotStore) snapshotPath(cacheKey string) (string, error) {
+	normalized := strings.TrimSpace(cacheKey)
+	if normalized == "" {
+		return "", fmt.Errorf("cache key is required")
+	}
+	if len(normalized) != 64 || !isLowerHex(normalized) {
+		return "", fmt.Errorf("cache key must be 64-char lowercase hex")
+	}
+	return filepath.Join(s.baseDir, normalized+".json"), nil
+}

--- a/internal/analysis/incremental_store_file_test.go
+++ b/internal/analysis/incremental_store_file_test.go
@@ -1,0 +1,100 @@
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileIncrementalSnapshotStore_RoundTrip(t *testing.T) {
+	store, err := NewFileIncrementalSnapshotStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create file store: %v", err)
+	}
+
+	cacheKey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	snapshot := NewIncrementalCacheSnapshot(cacheKey, map[string]string{
+		"a.go": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	})
+
+	if err := store.Save(snapshot); err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	loaded, found, err := store.Load(cacheKey)
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected snapshot to be found")
+	}
+	if loaded.CacheKey != cacheKey {
+		t.Fatalf("expected cache key %s, got %s", cacheKey, loaded.CacheKey)
+	}
+	if loaded.Fingerprints["a.go"] != snapshot.Fingerprints["a.go"] {
+		t.Fatalf("expected persisted fingerprint %s, got %s", snapshot.Fingerprints["a.go"], loaded.Fingerprints["a.go"])
+	}
+}
+
+func TestFileIncrementalSnapshotStore_LoadCorruptPayloadFailsClosed(t *testing.T) {
+	baseDir := t.TempDir()
+	store, err := NewFileIncrementalSnapshotStore(baseDir)
+	if err != nil {
+		t.Fatalf("failed to create file store: %v", err)
+	}
+
+	cacheKey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	corruptPath := filepath.Join(baseDir, cacheKey+".json")
+	if err := os.WriteFile(corruptPath, []byte(`{"schemaVersion":"v1",`), 0o644); err != nil {
+		t.Fatalf("failed writing corrupt payload: %v", err)
+	}
+
+	_, found, err := store.Load(cacheKey)
+	if err != nil {
+		t.Fatalf("expected corrupt payload to fail-closed without error, got: %v", err)
+	}
+	if found {
+		t.Fatal("expected corrupt payload to be treated as cache miss")
+	}
+}
+
+func TestFileIncrementalSnapshotStore_RejectsInvalidCacheKeyFormat(t *testing.T) {
+	store, err := NewFileIncrementalSnapshotStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to create file store: %v", err)
+	}
+
+	if _, _, err := store.Load("cache-key"); err == nil {
+		t.Fatal("expected invalid cache key format to be rejected")
+	}
+}
+
+func TestFileIncrementalSnapshotStore_SaveAtomicReplace(t *testing.T) {
+	baseDir := t.TempDir()
+	store, err := NewFileIncrementalSnapshotStore(baseDir)
+	if err != nil {
+		t.Fatalf("failed to create file store: %v", err)
+	}
+
+	cacheKey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	first := NewIncrementalCacheSnapshot(cacheKey, map[string]string{"a.go": "1111111111111111111111111111111111111111111111111111111111111111"})
+	second := NewIncrementalCacheSnapshot(cacheKey, map[string]string{"a.go": "2222222222222222222222222222222222222222222222222222222222222222"})
+
+	if err := store.Save(first); err != nil {
+		t.Fatalf("first save failed: %v", err)
+	}
+	if err := store.Save(second); err != nil {
+		t.Fatalf("second save failed: %v", err)
+	}
+
+	loaded, found, err := store.Load(cacheKey)
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if !found {
+		t.Fatal("expected snapshot to be found")
+	}
+	if loaded.Fingerprints["a.go"] != second.Fingerprints["a.go"] {
+		t.Fatalf("expected latest snapshot hash %s, got %s", second.Fingerprints["a.go"], loaded.Fingerprints["a.go"])
+	}
+}

--- a/internal/analysis/incremental_store_memory.go
+++ b/internal/analysis/incremental_store_memory.go
@@ -1,11 +1,15 @@
 package analysis
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 // InMemoryIncrementalSnapshotStore is a deterministic test-friendly store
 // implementation kept within analysis boundaries.
 type InMemoryIncrementalSnapshotStore struct {
 	snapshots map[string]IncrementalCacheSnapshot
+	mu        sync.RWMutex
 }
 
 func NewInMemoryIncrementalSnapshotStore() *InMemoryIncrementalSnapshotStore {
@@ -22,6 +26,9 @@ func (s *InMemoryIncrementalSnapshotStore) Load(cacheKey string) (IncrementalCac
 		return IncrementalCacheSnapshot{}, false, fmt.Errorf("cache key is required")
 	}
 
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	snapshot, ok := s.snapshots[cacheKey]
 	if !ok {
 		return IncrementalCacheSnapshot{}, false, nil
@@ -36,6 +43,10 @@ func (s *InMemoryIncrementalSnapshotStore) Save(snapshot IncrementalCacheSnapsho
 	if err := snapshot.Validate(); err != nil {
 		return err
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.snapshots[snapshot.CacheKey] = cloneSnapshot(snapshot)
 	return nil
 }

--- a/scripts/v110_release_stabilization_gate.ps1
+++ b/scripts/v110_release_stabilization_gate.ps1
@@ -1,0 +1,23 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    Write-Host "==> $Name"
+    Invoke-Expression $Command
+}
+
+$determinismRegex = "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
+$incrementalRegex = "TestIncrementalBoundaryService_.*|TestFileIncrementalSnapshotStore_.*|TestIncrementalCorrectness_.*|TestBuildIncrementalCacheKey_.*|TestIncrementalCacheSnapshot_.*|TestHashFileSHA256Streaming_MatchesReferenceHash"
+
+Invoke-Step -Name "build" -Command "go build ."
+Invoke-Step -Name "core test suite" -Command "go test ./..."
+Invoke-Step -Name "static analysis" -Command "go vet ./..."
+Invoke-Step -Name "v1.1 incremental regression pack" -Command "go test ./internal/analysis -run '$incrementalRegex'"
+Invoke-Step -Name "determinism confidence suite" -Command "go test ./... -run '$determinismRegex'"
+Invoke-Step -Name "self-analysis 100/100 gate" -Command "go run . analyze -path ."
+
+Write-Host "v1.1 release stabilization gate passed."


### PR DESCRIPTION
## Summary
- release M4 (v1.1+ Scale, use-case gated) from `dev` to `main`
- includes RD-11001..RD-11003:
  - durable incremental snapshot store foundations
  - memory optimization via streaming + bounded fingerprint processing
  - v1.1 release stabilization gate orchestration in CI

## Validation Baseline
- Linux + Windows CI green on merged M4 PRs
- required quality gates preserved (`go test ./...`, `go vet ./...`, `go run . analyze -path .`)
- self-analysis score remains `100/100`

Closes #220
Closes #221
Closes #222