### PR TITLE
docs: polish README and report branch-state clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,12 @@ Detailed release tracker:
 - `docs/v1.0-rd-10005-release-stabilization.md`
 - `docs/v1.1-rd-11003-release-gate.md`
 
+Planned next execution line (already prepared on GitHub):
+
+- Milestones: **M5 (v1.2)**, **M6 (v1.3)**, **M7 (v1.4)**, **M8 (v1.5)**
+- Issues: **RD-12001..RD-12006**, **RD-13001..RD-13005**, **RD-14001..RD-14004**, **RD-15001..RD-15005**
+- Execution policy: **branch-per-issue -> PR to `dev` -> green CI -> merge -> milestone release PR `dev -> main`**
+
 ---
 
 ## Contributing

--- a/docs/report.md
+++ b/docs/report.md
@@ -45,7 +45,7 @@ Release path:
 
 ## Current Branch/Release State
 
-- `main` and `dev` are synchronized to latest completed release line.
+- Latest completed release line is synchronized on `main`; `dev` may temporarily run ahead with planning/docs-only deltas before the next release merge.
 - M3 and M4 issue chains are closed.
 - Mandatory quality baseline remains green:
   - `go test ./...`


### PR DESCRIPTION
## Summary
- update README release section with prepared v1.2-v1.5 execution line visibility
- clarify branch-state wording in docs/report.md so planning/docs deltas on dev are explicitly expected
- keep user-facing documentation aligned with current roadmap governance flow

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path .