### PR TITLE
docs: sync roadmap governance docs from dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,12 @@ Detailed release tracker:
 - `docs/v1.0-rd-10005-release-stabilization.md`
 - `docs/v1.1-rd-11003-release-gate.md`
 
+Planned next execution line (already prepared on GitHub):
+
+- Milestones: **M5 (v1.2)**, **M6 (v1.3)**, **M7 (v1.4)**, **M8 (v1.5)**
+- Issues: **RD-12001..RD-12006**, **RD-13001..RD-13005**, **RD-14001..RD-14004**, **RD-15001..RD-15005**
+- Execution policy: **branch-per-issue -> PR to `dev` -> green CI -> merge -> milestone release PR `dev -> main`**
+
 ---
 
 ## Contributing

--- a/docs/report.md
+++ b/docs/report.md
@@ -45,7 +45,7 @@ Release path:
 
 ## Current Branch/Release State
 
-- `main` and `dev` are synchronized to latest completed release line.
+- Latest completed release line is synchronized on `main`; `dev` may temporarily run ahead with planning/docs-only deltas before the next release merge.
 - M3 and M4 issue chains are closed.
 - Mandatory quality baseline remains green:
   - `go test ./...`

--- a/docs/report.md
+++ b/docs/report.md
@@ -10,6 +10,10 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v0.20 | M2: v0.20 Java Pilot (Gated) | Completed (Gated GO) | RD-2001..RD-2007 completed; decision memo published (`JAVA_PILOT_DECISION_v0.20.md`), pilot remains default-off. |
 | v1.0 | M3: v1.0 UX & Polish | Completed | RD-10001..RD-10005 merged to `dev` and released via `dev -> main` PR #250. |
 | v1.1+ | M4: v1.1+ Scale (Use-case gated) | Completed | RD-11001..RD-11003 merged to `dev` and released via `dev -> main` PR #254. |
+| v1.2 | M5: v1.2 Test Quality & Coverage | Planned | Issue chain RD-12001..RD-12006 prepared; execution model is branch-per-issue -> PR to `dev` -> green CI -> merge. |
+| v1.3 | M6: v1.3 Observability | Planned | Issue chain RD-13001..RD-13005 prepared with boundary/purity controls for logging, metrics, and profiling. |
+| v1.4 | M7: v1.4 Performance Hardening | Planned | Issue chain RD-14001..RD-14004 prepared with determinism, race, benchmark, and memory budget gates. |
+| v1.5 | M8: v1.5 Developer Experience | Planned | Issue chain RD-15001..RD-15005 prepared with output-compatibility and release-distribution controls. |
 
 ---
 
@@ -48,4 +52,15 @@ Release path:
   - `go vet ./...`
   - `go run . analyze -path .` (target `100/100`)
 
-Son güncelleme: 29 Mart 2026
+## Next Planned Execution Line (Ready)
+
+1. Create/validate milestones: **M5 v1.2**, **M6 v1.3**, **M7 v1.4**, **M8 v1.5**.
+2. Open roadmap-governed issues: **RD-12001..RD-12006**, **RD-13001..RD-13005**, **RD-14001..RD-14004**, **RD-15001..RD-15005**.
+3. Enforce workflow for every implementation issue:
+   - branch-per-issue from `dev`
+   - PR target `dev`
+   - mandatory + conditional checks green
+   - merge
+4. After each milestone chain closes on `dev`, open release PR `dev -> main` and keep `dev` branch intact.
+
+Son güncelleme: 1 Nisan 2026


### PR DESCRIPTION
## Summary
- sync latest README and report governance clarifications from dev to main
- keeps user-facing documentation aligned with prepared v1.2-v1.5 milestone execution workflow

## Validation baseline
- CI checks green on PR #278
- local gates: go test ./..., go vet ./..., go run . analyze -path .