### PR TITLE
release: sync v1.1.0 version tag from dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ RepoDoctor is a CLI tool that analyzes architectural quality in code repositorie
 It focuses on **structure-level risks** (dependency cycles, layer violations, oversized units, god objects),
 not formatting or style-lint details.
 
-![CLI Version](https://img.shields.io/badge/cli-0.5.0--dev-blue)
+![CLI Version](https://img.shields.io/badge/cli-1.1.0-blue)
 ![Roadmap Milestone](https://img.shields.io/badge/roadmap-v1.1-complete-brightgreen)
 [![Go Version](https://img.shields.io/badge/go-1.21+-00ADD8)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-const version = "0.5.0-dev"
+const version = "1.1.0"
 
 func main() {
 	if len(os.Args) < 2 {

--- a/release_compatibility_matrix_test.go
+++ b/release_compatibility_matrix_test.go
@@ -66,7 +66,7 @@ func TestCompatibilityMatrix_ConfigDefaultsRemainStable(t *testing.T) {
 
 func TestCompatibilityMatrix_ReportJSONFormats(t *testing.T) {
 	base := &StructuralReport{
-		Version:       "0.5.0-dev",
+		Version:       "1.1.0",
 		SchemaVersion: "v2",
 		Path:          "repo",
 		Score:         &StructuralScore{TotalScore: 100, MaxScore: 100},

--- a/reporter_json_test.go
+++ b/reporter_json_test.go
@@ -10,7 +10,7 @@ import (
 func TestReporter_JSONV2_ContainsSchemaAndSummary(t *testing.T) {
 	reporter := NewReporter(FormatJSON)
 	report := &StructuralReport{
-		Version:       "0.5.0-dev",
+		Version:       "1.1.0",
 		SchemaVersion: "v2",
 		Path:          "/repo/demo",
 		Score: &StructuralScore{
@@ -38,7 +38,7 @@ func TestReporter_JSONV2_ContainsSchemaAndSummary(t *testing.T) {
 func TestReporter_JSONV1_CompatibilitySwitch(t *testing.T) {
 	reporter := NewReporter(FormatJSONV1)
 	report := &StructuralReport{
-		Version: "0.5.0-dev",
+		Version: "1.1.0",
 		Path:    "/repo/demo",
 		Score:   &StructuralScore{TotalScore: 90, MaxScore: 100},
 	}
@@ -55,7 +55,7 @@ func TestReporter_JSONV1_CompatibilitySwitch(t *testing.T) {
 func TestReporter_JSONV1_GoldenParity(t *testing.T) {
 	reporter := NewReporter(FormatJSONV1)
 	report := &StructuralReport{
-		Version: "0.5.0-dev",
+		Version: "1.1.0",
 		Path:    "demo/path",
 		Score: &StructuralScore{
 			TotalScore:       90,
@@ -73,7 +73,7 @@ func TestReporter_JSONV1_GoldenParity(t *testing.T) {
 
 	got := reporter.Format(report)
 	want := "{\n" +
-		"  \"version\": \"0.5.0-dev\",\n" +
+		"  \"version\": \"1.1.0\",\n" +
 		"  \"path\": \"demo/path\",\n" +
 		"  \"score\": {\n" +
 		"    \"total\": 90.00,\n" +
@@ -107,7 +107,7 @@ func TestReporter_JSONV1_GoldenParity(t *testing.T) {
 func TestReporter_JSONV2_GoldenStableOrderingAndSchema(t *testing.T) {
 	reporter := NewReporter(FormatJSON)
 	report := &StructuralReport{
-		Version:       "0.5.0-dev",
+		Version:       "1.1.0",
 		SchemaVersion: "v2",
 		Path:          filepath.Join(".", "demo", "repo"),
 		Score: &StructuralScore{
@@ -148,7 +148,7 @@ func TestReporter_JSON_DoesNotLeakAbsolutePathByDefault(t *testing.T) {
 	abs := filepath.Join("C:\\", "tmp", "sensitive", "repo")
 
 	report := &StructuralReport{
-		Version:       "0.5.0-dev",
+		Version:       "1.1.0",
 		SchemaVersion: "v2",
 		Path:          abs,
 		Score:         &StructuralScore{TotalScore: 100, MaxScore: 100},
@@ -165,7 +165,7 @@ func TestReporter_JSON_EscapesUntrustedFields(t *testing.T) {
 	malicious := "name\"with\ncontrol"
 
 	report := &StructuralReport{
-		Version:       "0.5.0-dev",
+		Version:       "1.1.0",
 		SchemaVersion: "v2",
 		Path:          ".",
 		Score:         &StructuralScore{TotalScore: 99, MaxScore: 100},
@@ -192,7 +192,7 @@ func TestReporter_JSONV1_DeterministicAcrossInputOrdering(t *testing.T) {
 	reporter := NewReporter(FormatJSONV1)
 	build := func(circular []CycleViolation, layer []LayerViolation, size []SizeViolation, god []GodObjectViolation) *StructuralReport {
 		return &StructuralReport{
-			Version: "0.5.0-dev",
+			Version: "1.1.0",
 			Path:    "repo",
 			Score: &StructuralScore{
 				TotalScore:       80,
@@ -241,7 +241,7 @@ func TestReporter_JSONV1_DeterministicAcrossInputOrdering(t *testing.T) {
 func TestReporter_JSONV1_WithViolations_StaysValidJSON(t *testing.T) {
 	reporter := NewReporter(FormatJSONV1)
 	report := &StructuralReport{
-		Version: "0.5.0-dev",
+		Version: "1.1.0",
 		Path:    "repo",
 		Score: &StructuralScore{
 			TotalScore:       92,

--- a/runtime_engine_remediation_test.go
+++ b/runtime_engine_remediation_test.go
@@ -13,7 +13,7 @@ func TestBuildReportFromRuleViolations_AttachesRemediationHints(t *testing.T) {
 		{RuleID: "rule.god-object", File: "obj.go", Severity: model.SeverityWarning, Message: "Manager has 12 methods (threshold: 10)"},
 	}
 
-	report := buildReportFromRuleViolations(".", "0.5.0-dev", nil, violations)
+	report := buildReportFromRuleViolations(".", "1.1.0", nil, violations)
 	if len(report.Layer) == 0 || report.Layer[0].Hint == "" {
 		t.Fatal("expected layer violation hint to be populated")
 	}


### PR DESCRIPTION
## Summary
- align runtime CLI version tag to 1.1.0
- sync README badge and version-sensitive test fixtures with the new tag
- keep JSON/report compatibility tests consistent with release version metadata

## Validation
- CI green on source PR #280
- local gates: go test ./..., go vet ./..., go run . analyze -path .