### PR TITLE
[v1.2][RD-12001] Add deterministic internal/model package tests and coverage

### DIFF
--- a/internal/model/dependency_graph_test.go
+++ b/internal/model/dependency_graph_test.go
@@ -1,0 +1,96 @@
+package model
+
+import "testing"
+
+func TestDependencyGraph_AddNode_Idempotent(t *testing.T) {
+	g := NewDependencyGraph()
+	first := g.AddNode("a", "a.go", "pkg/a")
+	second := g.AddNode("a", "ignored.go", "ignored")
+
+	if first != second {
+		t.Fatal("expected AddNode to return existing node for duplicate id")
+	}
+	if g.NodeCount() != 1 {
+		t.Fatalf("expected node count 1, got %d", g.NodeCount())
+	}
+	if g.EdgeCount() != 0 {
+		t.Fatalf("expected edge count 0, got %d", g.EdgeCount())
+	}
+}
+
+func TestDependencyGraph_AddEdge_AutoCreatesNodes(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+
+	if g.NodeCount() != 2 {
+		t.Fatalf("expected 2 auto-created nodes, got %d", g.NodeCount())
+	}
+	if g.EdgeCount() != 1 {
+		t.Fatalf("expected 1 edge, got %d", g.EdgeCount())
+	}
+
+	deps := g.GetDependencies("a")
+	if len(deps) != 1 || deps[0] != "b" {
+		t.Fatalf("unexpected dependencies for a: %v", deps)
+	}
+	dependents := g.GetDependents("b")
+	if len(dependents) != 1 || dependents[0] != "a" {
+		t.Fatalf("unexpected dependents for b: %v", dependents)
+	}
+}
+
+func TestDependencyGraph_AddEdge_DeduplicatesEdgeAndImports(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddNode("svc", "svc.go", "service")
+	g.AddNode("repo", "repo.go", "repository")
+
+	g.AddEdge("svc", "repo")
+	g.AddEdge("svc", "repo")
+
+	if g.EdgeCount() != 1 {
+		t.Fatalf("expected de-duplicated edge count 1, got %d", g.EdgeCount())
+	}
+
+	node := g.GetNode("svc")
+	if node == nil {
+		t.Fatal("expected source node to exist")
+	}
+	if len(node.Imports) != 1 || node.Imports[0] != "repo" {
+		t.Fatalf("expected imports [repo], got %v", node.Imports)
+	}
+}
+
+func TestDependencyGraph_CountsAndAccessors(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddNode("a", "a.go", "a")
+	g.AddNode("b", "b.go", "b")
+	g.AddNode("c", "c.go", "c")
+	g.AddEdge("a", "b")
+	g.AddEdge("a", "c")
+
+	if g.NodeCount() != 3 {
+		t.Fatalf("expected node count 3, got %d", g.NodeCount())
+	}
+	if g.EdgeCount() != 2 {
+		t.Fatalf("expected edge count 2, got %d", g.EdgeCount())
+	}
+
+	node := g.GetNode("a")
+	if node == nil || node.Path != "a.go" || node.Package != "a" {
+		t.Fatalf("unexpected node metadata: %+v", node)
+	}
+}
+
+func TestDependencyGraph_UnknownNodeAccessors(t *testing.T) {
+	g := NewDependencyGraph()
+
+	if g.GetNode("missing") != nil {
+		t.Fatal("expected nil for unknown node")
+	}
+	if len(g.GetDependencies("missing")) != 0 {
+		t.Fatalf("expected empty dependencies for unknown node")
+	}
+	if len(g.GetDependents("missing")) != 0 {
+		t.Fatalf("expected empty dependents for unknown node")
+	}
+}

--- a/internal/model/graph_analysis_test.go
+++ b/internal/model/graph_analysis_test.go
@@ -1,0 +1,45 @@
+package model
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFindRoots_ReturnsExpectedSet(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+	g.AddNode("c", "c.go", "c")
+
+	got := sortedNodeIDs(FindRoots(g))
+	want := []string{"a", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected roots: got %v want %v", got, want)
+	}
+}
+
+func TestFindLeaves_ReturnsExpectedSet(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+	g.AddNode("c", "c.go", "c")
+
+	got := sortedNodeIDs(FindLeaves(g))
+	want := []string{"b", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected leaves: got %v want %v", got, want)
+	}
+}
+
+func TestFindRootsAndLeaves_IsolatedNode_BothRootAndLeaf(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddNode("isolated", "isolated.go", "isolated")
+
+	roots := sortedNodeIDs(FindRoots(g))
+	leaves := sortedNodeIDs(FindLeaves(g))
+
+	if !reflect.DeepEqual(roots, []string{"isolated"}) {
+		t.Fatalf("unexpected roots for isolated graph: %v", roots)
+	}
+	if !reflect.DeepEqual(leaves, []string{"isolated"}) {
+		t.Fatalf("unexpected leaves for isolated graph: %v", leaves)
+	}
+}

--- a/internal/model/graph_cycle_detector_test.go
+++ b/internal/model/graph_cycle_detector_test.go
@@ -1,0 +1,128 @@
+package model
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGraphCycleDetector_AcyclicGraph_NoCycles(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+	g.AddEdge("b", "c")
+
+	detector := NewGraphCycleDetector(g)
+	cycles := detector.DetectCycles()
+	if len(cycles) != 0 {
+		t.Fatalf("expected no cycles, got %v", cycles)
+	}
+	if detector.HasCycles() {
+		t.Fatal("expected HasCycles false for acyclic graph")
+	}
+}
+
+func TestGraphCycleDetector_SimpleCycle_Detected(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+	g.AddEdge("b", "a")
+
+	detector := NewGraphCycleDetector(g)
+	cycles := detector.DetectCycles()
+	if len(cycles) == 0 {
+		t.Fatal("expected at least one cycle")
+	}
+
+	sigs := cycleSignatures(cycles)
+	found := false
+	for _, sig := range sigs {
+		if sig == "a->b" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected signature a->b among %v", sigs)
+	}
+}
+
+func TestGraphCycleDetector_MultipleCycles_Detected(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+	g.AddEdge("b", "a")
+	g.AddEdge("x", "y")
+	g.AddEdge("y", "x")
+
+	cycles := NewGraphCycleDetector(g).DetectCycles()
+	sigs := cycleSignatures(cycles)
+
+	if len(sigs) < 2 {
+		t.Fatalf("expected at least two cycle signatures, got %v", sigs)
+	}
+
+	hasAB := false
+	hasXY := false
+	for _, sig := range sigs {
+		if sig == "a->b" {
+			hasAB = true
+		}
+		if sig == "x->y" {
+			hasXY = true
+		}
+	}
+	if !hasAB || !hasXY {
+		t.Fatalf("expected cycle signatures for both components, got %v", sigs)
+	}
+}
+
+func TestGraphCycleDetector_SelfLoop_Detected(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("self", "self")
+
+	cycles := NewGraphCycleDetector(g).DetectCycles()
+	sigs := cycleSignatures(cycles)
+
+	foundSelf := false
+	for _, sig := range sigs {
+		if sig == "self" {
+			foundSelf = true
+			break
+		}
+	}
+	if !foundSelf {
+		t.Fatalf("expected self-loop cycle signature, got %v", sigs)
+	}
+}
+
+func TestGraphCycleDetector_HasCycles_AndGetCyclesContract(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+	g.AddEdge("b", "a")
+
+	detector := NewGraphCycleDetector(g)
+	if detector.GetCycles() == nil {
+		t.Fatal("expected initialized cycle storage")
+	}
+	if !detector.HasCycles() {
+		t.Fatal("expected HasCycles true after implicit detection")
+	}
+	if len(detector.GetCycles()) == 0 {
+		t.Fatal("expected detected cycles to be available via GetCycles")
+	}
+}
+
+func TestGraphCycleDetector_DeterministicAcross10Runs_Canonicalized(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+	g.AddEdge("b", "a")
+	g.AddEdge("b", "c")
+	g.AddEdge("c", "d")
+	g.AddEdge("d", "b")
+
+	baseline := cycleSignatures(NewGraphCycleDetector(g).DetectCycles())
+
+	for i := 0; i < 10; i++ {
+		candidate := cycleSignatures(NewGraphCycleDetector(g).DetectCycles())
+		if !reflect.DeepEqual(candidate, baseline) {
+			t.Fatalf("non-deterministic cycle signatures at run %d: baseline=%v candidate=%v", i, baseline, candidate)
+		}
+	}
+}

--- a/internal/model/metrics_test.go
+++ b/internal/model/metrics_test.go
@@ -1,0 +1,60 @@
+package model
+
+import "testing"
+
+func TestNewRepositoryMetrics_InitialState(t *testing.T) {
+	m := NewRepositoryMetrics()
+
+	if m == nil {
+		t.Fatal("expected non-nil metrics instance")
+	}
+	if len(m.Files) != 0 || len(m.Functions) != 0 || len(m.Structs) != 0 {
+		t.Fatalf("expected empty slices, got files=%d functions=%d structs=%d", len(m.Files), len(m.Functions), len(m.Structs))
+	}
+	if m.TotalLines != 0 || m.TotalFiles != 0 || m.TotalFunctions != 0 || m.TotalStructs != 0 {
+		t.Fatalf("expected zero totals, got %+v", *m)
+	}
+}
+
+func TestRepositoryMetrics_AddFileMetrics_UpdatesTotals(t *testing.T) {
+	m := NewRepositoryMetrics()
+
+	m.AddFileMetrics(FileMetrics{Path: "a.go", Lines: 10, Functions: 2})
+	m.AddFileMetrics(FileMetrics{Path: "b.go", Lines: 5, Functions: 1})
+
+	if m.TotalFiles != 2 {
+		t.Fatalf("expected TotalFiles=2, got %d", m.TotalFiles)
+	}
+	if m.TotalLines != 15 {
+		t.Fatalf("expected TotalLines=15, got %d", m.TotalLines)
+	}
+	if m.TotalFunctions != 3 {
+		t.Fatalf("expected TotalFunctions=3, got %d", m.TotalFunctions)
+	}
+}
+
+func TestRepositoryMetrics_AddFunctionMetrics_AppendsOnly(t *testing.T) {
+	m := NewRepositoryMetrics()
+	m.AddFunctionMetrics(FunctionMetrics{Name: "A", File: "a.go", Lines: 10})
+	m.AddFunctionMetrics(FunctionMetrics{Name: "B", File: "b.go", Lines: 5})
+
+	if len(m.Functions) != 2 {
+		t.Fatalf("expected 2 function metrics, got %d", len(m.Functions))
+	}
+	if m.TotalFunctions != 0 {
+		t.Fatalf("expected TotalFunctions unchanged by AddFunctionMetrics, got %d", m.TotalFunctions)
+	}
+}
+
+func TestRepositoryMetrics_AddStructMetrics_AppendsAndIncrementsTotal(t *testing.T) {
+	m := NewRepositoryMetrics()
+	m.AddStructMetrics(StructMetrics{Name: "A", File: "a.go", Fields: 2, Methods: 1})
+	m.AddStructMetrics(StructMetrics{Name: "B", File: "b.go", Fields: 1, Methods: 0})
+
+	if len(m.Structs) != 2 {
+		t.Fatalf("expected 2 struct metrics, got %d", len(m.Structs))
+	}
+	if m.TotalStructs != 2 {
+		t.Fatalf("expected TotalStructs=2, got %d", m.TotalStructs)
+	}
+}

--- a/internal/model/test_helpers_test.go
+++ b/internal/model/test_helpers_test.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"sort"
+	"strings"
+)
+
+func sortedNodeIDs(nodes []*Node) []string {
+	ids := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		ids = append(ids, n.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func cycleSignatures(cycles [][]string) []string {
+	if len(cycles) == 0 {
+		return nil
+	}
+	signatures := make([]string, 0, len(cycles))
+	for _, cycle := range cycles {
+		copied := append([]string{}, cycle...)
+		sort.Strings(copied)
+		signatures = append(signatures, strings.Join(copied, "->"))
+	}
+	sort.Strings(signatures)
+	return signatures
+}


### PR DESCRIPTION
## Summary
- add comprehensive tests for internal/model graph storage, analysis, cycle detection, and metrics aggregation
- add deterministic cycle-output assertions across 10 repeated runs using canonicalized signatures
- raise internal/model package coverage to 98.1% with no production code changes

## Validation
- go test ./internal/model -count=1
- go test ./internal/model -count=10
- go test ./internal/model -count=1 -covermode=atomic -coverprofile coverage.internal_model.out
- go test ./...
- go vet ./...
- go run . analyze -path .

Closes #257