### PR TITLE
test(rd-12003): add internal/rules edge and threshold coverage

### DIFF
--- a/internal/rules/circular_dependency_rule_test.go
+++ b/internal/rules/circular_dependency_rule_test.go
@@ -1,0 +1,108 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCircularDependencyRule_MetadataAndCapabilities(t *testing.T) {
+	rule := NewCircularDependencyRule(DependencyGraph{})
+
+	if rule.ID() != "rule.circular-dependency" {
+		t.Fatalf("unexpected id: %s", rule.ID())
+	}
+	if rule.Category() != string(CategoryArchitecture) {
+		t.Fatalf("unexpected category: %s", rule.Category())
+	}
+	if rule.Severity() != "critical" {
+		t.Fatalf("unexpected severity: %s", rule.Severity())
+	}
+
+	caps := rule.Capabilities()
+	if !caps.SupportsMultipleLanguages {
+		t.Fatal("expected multi-language capability")
+	}
+	if len(caps.SupportedLanguages) == 0 {
+		t.Fatal("expected non-empty supported language list")
+	}
+}
+
+func TestCircularDependencyRule_Evaluate_UsesContextDependencyGraph(t *testing.T) {
+	rule := NewCircularDependencyRule(DependencyGraph{})
+	ctx := AnalysisContext{
+		DependencyGraph: DependencyGraph{
+			Nodes: []string{"a", "b"},
+			Edges: map[string][]string{
+				"a": []string{"b"},
+				"b": []string{"a"},
+			},
+		},
+	}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 1 {
+		t.Fatalf("expected one circular violation, got %d", len(violations))
+	}
+
+	v := violations[0]
+	if v.RuleID != rule.ID() {
+		t.Fatalf("unexpected rule id: %s", v.RuleID)
+	}
+	if v.Severity != "critical" {
+		t.Fatalf("unexpected severity: %s", v.Severity)
+	}
+	if v.File != "a" {
+		t.Fatalf("expected first cycle node as file, got %s", v.File)
+	}
+	if !strings.Contains(v.Message, "a") || !strings.Contains(v.Message, "b") {
+		t.Fatalf("expected cycle message to include nodes, got %q", v.Message)
+	}
+}
+
+func TestCircularDependencyRule_Evaluate_BuildsGraphFromRepositoryFiles(t *testing.T) {
+	rule := NewCircularDependencyRule(DependencyGraph{})
+	ctx := AnalysisContext{
+		RepositoryFiles: []RepositoryFile{
+			{Path: "a.go", Imports: []string{"b.go"}},
+			{Path: "b.go", Imports: []string{"a.go"}},
+		},
+	}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 1 {
+		t.Fatalf("expected one circular violation from file imports, got %d", len(violations))
+	}
+}
+
+func TestCircularDependencyRule_Evaluate_NoCycle(t *testing.T) {
+	rule := NewCircularDependencyRule(DependencyGraph{})
+	ctx := AnalysisContext{
+		DependencyGraph: DependencyGraph{
+			Nodes: []string{"a", "b", "c"},
+			Edges: map[string][]string{
+				"a": []string{"b"},
+				"b": []string{"c"},
+				"c": []string{},
+			},
+		},
+	}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %v", violations)
+	}
+}
+
+func TestExtractCycle_StartNotFoundReturnsPath(t *testing.T) {
+	path := []string{"a", "b", "c"}
+	cycle := extractCycle(path, "x")
+	if len(cycle) != len(path) {
+		t.Fatalf("expected fallback full path, got %v", cycle)
+	}
+}
+
+func TestFormatCycle_EmptyCycle(t *testing.T) {
+	if got := formatCycle(nil); got != "" {
+		t.Fatalf("expected empty message for empty cycle, got %q", got)
+	}
+}

--- a/internal/rules/god_object_rule_edge_test.go
+++ b/internal/rules/god_object_rule_edge_test.go
@@ -1,0 +1,121 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGodObjectRule_MetadataAndCapabilities(t *testing.T) {
+	rule := NewGodObjectRule()
+
+	if rule.ID() != "rule.god-object" {
+		t.Fatalf("unexpected id: %s", rule.ID())
+	}
+	if rule.Category() != string(CategoryMaintainability) {
+		t.Fatalf("unexpected category: %s", rule.Category())
+	}
+	if rule.Severity() != "warning" {
+		t.Fatalf("unexpected severity: %s", rule.Severity())
+	}
+
+	caps := rule.Capabilities()
+	if caps.SupportsMultipleLanguages {
+		t.Fatal("god object rule should be single-language")
+	}
+	if len(caps.SupportedLanguages) != 1 || caps.SupportedLanguages[0] != "Go" {
+		t.Fatalf("unexpected supported languages: %v", caps.SupportedLanguages)
+	}
+}
+
+func TestGodObjectRule_ThresholdBoundary_NoViolationAtExactThreshold(t *testing.T) {
+	rule := NewGodObjectRule()
+	rule.MaxFields = 2
+	rule.MaxMethods = 2
+
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{{
+		Path: "pkg/exact.go",
+		Content: `package pkg
+type User struct {
+	ID int
+	Name string
+}
+func (u User) First() {}
+func (u *User) Second() {}`,
+	}}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations at exact thresholds, got %v", violations)
+	}
+}
+
+func TestGodObjectRule_ThresholdBoundary_ViolatesWhenExceeded(t *testing.T) {
+	rule := NewGodObjectRule()
+	rule.MaxFields = 2
+	rule.MaxMethods = 2
+
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{{
+		Path: "pkg/exceed.go",
+		Content: `package pkg
+type User struct {
+	A int
+	B int
+	C int
+}
+func (u User) One() {}
+func (u User) Two() {}
+func (u User) Three() {}`,
+	}}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 2 {
+		t.Fatalf("expected field and method violations, got %d (%v)", len(violations), violations)
+	}
+
+	joined := violations[0].Message + "\n" + violations[1].Message
+	if !strings.Contains(joined, "fields (threshold: 2)") {
+		t.Fatalf("expected field threshold detail in messages, got %q", joined)
+	}
+	if !strings.Contains(joined, "methods (threshold: 2)") {
+		t.Fatalf("expected method threshold detail in messages, got %q", joined)
+	}
+}
+
+func TestGodObjectRule_Boundary_StructNameCollisionAcrossDirs(t *testing.T) {
+	rule := NewGodObjectRule()
+	rule.MaxFields = 10
+	rule.MaxMethods = 1
+
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{
+		{
+			Path: "module/a/user.go",
+			Content: `package a
+type User struct{}
+func (u User) A() {}`,
+		},
+		{
+			Path: "module/b/user.go",
+			Content: `package b
+type User struct{}
+func (u User) B() {}`,
+		},
+	}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected no collision-induced violations across directories, got %v", violations)
+	}
+}
+
+func TestGodObjectRule_Evaluate_MalformedFileIgnored(t *testing.T) {
+	rule := NewGodObjectRule()
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{{
+		Path:    "pkg/bad.go",
+		Content: "package broken\ntype X struct {\nfunc(",
+	}}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected malformed file to be ignored, got %v", violations)
+	}
+}

--- a/internal/rules/rules_edge_coverage_test.go
+++ b/internal/rules/rules_edge_coverage_test.go
@@ -1,0 +1,75 @@
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCategories_AllAndValidations(t *testing.T) {
+	categories := AllCategories()
+	if len(categories) < 5 {
+		t.Fatalf("expected all standard categories, got %v", categories)
+	}
+
+	for _, c := range categories {
+		if !IsValidCategory(string(c)) {
+			t.Fatalf("expected category %q to be valid", c)
+		}
+	}
+
+	if IsValidCategory("unknown") {
+		t.Fatal("expected unknown category to be invalid")
+	}
+}
+
+func TestExampleRule_ImplementsContract(t *testing.T) {
+	rule := &ExampleRule{}
+	if rule.ID() != "rule.example" {
+		t.Fatalf("unexpected id: %s", rule.ID())
+	}
+	if rule.Category() != "structural" {
+		t.Fatalf("unexpected category: %s", rule.Category())
+	}
+	if rule.Severity() != "info" {
+		t.Fatalf("unexpected severity: %s", rule.Severity())
+	}
+
+	violations := rule.Evaluate(AnalysisContext{})
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %v", violations)
+	}
+}
+
+func TestLoadFromDir_FiltersHiddenAndNonGoFiles(t *testing.T) {
+	root := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, "ok.go"), []byte("package sample\n"), 0o644); err != nil {
+		t.Fatalf("failed writing go file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("ignore"), 0o644); err != nil {
+		t.Fatalf("failed writing non-go file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".hidden.go"), []byte("package hidden\n"), 0o644); err != nil {
+		t.Fatalf("failed writing hidden file: %v", err)
+	}
+
+	hiddenDir := filepath.Join(root, ".git")
+	if err := os.MkdirAll(hiddenDir, 0o755); err != nil {
+		t.Fatalf("failed creating hidden dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hiddenDir, "ignored.go"), []byte("package git\n"), 0o644); err != nil {
+		t.Fatalf("failed writing hidden-dir go file: %v", err)
+	}
+
+	files, err := LoadFromDir(root)
+	if err != nil {
+		t.Fatalf("LoadFromDir returned error: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected exactly one visible go file, got %d (%v)", len(files), files)
+	}
+	if filepath.Base(files[0].Path) != "ok.go" {
+		t.Fatalf("expected ok.go, got %s", files[0].Path)
+	}
+}


### PR DESCRIPTION
## Summary
- Expands `internal/rules` edge/boundary test matrix for circular-dependency and god-object rule paths.
- Adds explicit threshold-boundary assertions (exact-threshold pass, over-threshold fail) without modifying rule implementations.
- Adds deterministic category/example/loader edge checks to strengthen rule-package confidence.

## Validation
- `go test ./internal/rules`
- `go test -covermode=atomic -coverprofile rules.cover.out ./internal/rules` => **84.4%**
- `go test ./...`
- `go vet ./...`
- `go run . analyze -path .` (100/100)
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`

Closes #259