### PR TITLE
test(rd-12004): add parser/extractor fuzz abuse-resistance targets

### DIFF
--- a/import_extractor_fuzz_test.go
+++ b/import_extractor_fuzz_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestImportExtractor_ExtractFromFile_MalformedFailSoft(t *testing.T) {
+	extractor := NewImportExtractor("github.com/example/repo")
+	dir := t.TempDir()
+	malformed := filepath.Join(dir, "broken.go")
+
+	if err := os.WriteFile(malformed, []byte("package broken\nimport (\n\t\"fmt\"\n"), 0o644); err != nil {
+		t.Fatalf("failed writing malformed file: %v", err)
+	}
+
+	meta, err := extractor.ExtractFromFile(malformed)
+	if err != nil {
+		t.Fatalf("expected fail-soft nil error, got: %v", err)
+	}
+	if meta != nil {
+		t.Fatalf("expected nil metadata for malformed file, got: %+v", meta)
+	}
+}
+
+func TestImportExtractor_ExtractFromDir_SkipsMalformedKeepsValid(t *testing.T) {
+	extractor := NewImportExtractor("github.com/example/repo")
+	dir := t.TempDir()
+
+	valid := filepath.Join(dir, "ok.go")
+	invalid := filepath.Join(dir, "bad.go")
+
+	if err := os.WriteFile(valid, []byte("package ok\nimport \"github.com/example/repo/internal/app\"\n"), 0o644); err != nil {
+		t.Fatalf("failed writing valid file: %v", err)
+	}
+	if err := os.WriteFile(invalid, []byte("package bad\nimport (\n\t\"fmt\"\n"), 0o644); err != nil {
+		t.Fatalf("failed writing malformed file: %v", err)
+	}
+
+	imports, err := extractor.ExtractFromDir(dir)
+	if err != nil {
+		t.Fatalf("expected fail-soft directory extraction, got error: %v", err)
+	}
+	if len(imports) != 1 {
+		t.Fatalf("expected only valid file metadata, got %d entries", len(imports))
+	}
+	if meta := imports[valid]; meta == nil || meta.Package != "ok" {
+		t.Fatalf("expected valid file metadata for %s, got %+v", valid, meta)
+	}
+}
+
+func FuzzImportExtractor_ExtractFromFile_NoPanic(f *testing.F) {
+	seeds := [][]byte{
+		[]byte("package p\nimport \"fmt\"\n"),
+		[]byte("package p\nimport (\"github.com/acme/x\";\"os\")\n"),
+		[]byte("package p\nimport \"github.com/acme/x\n"),
+		[]byte("\x00\x00\x00"),
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, content []byte) {
+		extractor := NewImportExtractor("github.com/acme/project")
+		dir := t.TempDir()
+		path := filepath.Join(dir, "input.go")
+
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			t.Fatalf("failed writing fuzz input: %v", err)
+		}
+
+		meta, err := extractor.ExtractFromFile(path)
+		if err != nil {
+			t.Fatalf("expected fail-soft parse behavior, got error: %v", err)
+		}
+		if meta != nil && meta.Package == "" {
+			t.Fatalf("unexpected empty package in metadata: %+v", meta)
+		}
+	})
+}

--- a/internal/languages/python_evidence_fuzz_test.go
+++ b/internal/languages/python_evidence_fuzz_test.go
@@ -1,0 +1,43 @@
+package languages
+
+import "testing"
+
+func FuzzParsePythonImportLine_NoPanic(f *testing.F) {
+	seeds := []string{
+		"import os",
+		"from .service import handler",
+		"importlib.import_module(\"json\")",
+		"__import__(\"pkg\" + name)",
+		"from .. import *",
+		"\x00\x00\x00",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, line string) {
+		results := parsePythonImportLine(line)
+		for _, ev := range results {
+			if ev.level < 0 {
+				t.Fatalf("relative level must not be negative: %d", ev.level)
+			}
+		}
+	})
+}
+
+func FuzzParsePythonDynamicImport_NoPanic(f *testing.F) {
+	seeds := []string{
+		"importlib.import_module('json')",
+		"importlib.import_module('.local')",
+		"__import__('pkg')",
+		"__import__(prefix + '.mod')",
+		"not a dynamic import",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, line string) {
+		_, _ = parsePythonDynamicImport(line)
+	})
+}


### PR DESCRIPTION
## Summary
- Adds fuzz targets for root import extraction and python parser evidence lines to stress malformed/adversarial input handling.
- Adds explicit fail-soft tests for malformed extractor inputs and mixed valid+malformed directory scans.
- Keeps production behavior unchanged while hardening parser/extractor abuse-resistance confidence.

## Validation
- `go test . -run "TestImportExtractor_ExtractFromFile_MalformedFailSoft|TestImportExtractor_ExtractFromDir_SkipsMalformedKeepsValid|FuzzImportExtractor_ExtractFromFile_NoPanic"`
- `go test ./internal/languages -run "FuzzParsePythonImportLine_NoPanic|FuzzParsePythonDynamicImport_NoPanic|TestPythonAdapter_CollectEvidence_FailSoftOnMalformedAndOversized"`
- `go test ./...`
- `go vet ./...`
- `go run . analyze -path .` (100/100)
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`

Closes #260