### PR TITLE
test(rd-12005): add property-based determinism checks

### DIFF
--- a/deterministic_properties_test.go
+++ b/deterministic_properties_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+	"testing/quick"
+
+	"RepoDoctor/internal/model"
+)
+
+func TestProperty_SortedStringCopy_IdempotentAndSorted(t *testing.T) {
+	cfg := &quick.Config{MaxCount: 200}
+	prop := func(input []string) bool {
+		original := append([]string(nil), input...)
+		got := sortedStringCopy(input)
+
+		if !sort.StringsAreSorted(got) {
+			return false
+		}
+
+		if !equalStringSlices(input, original) {
+			return false
+		}
+
+		got2 := sortedStringCopy(got)
+		return equalStringSlices(got, got2)
+	}
+
+	if err := quick.Check(prop, cfg); err != nil {
+		t.Fatalf("sortedStringCopy property failed: %v", err)
+	}
+}
+
+func equalStringSlices(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestProperty_StableSortedCopy_Ints_MatchesGoSortAndIdempotent(t *testing.T) {
+	cfg := &quick.Config{MaxCount: 200}
+	prop := func(input []int) bool {
+		got := stableSortedCopy(input, func(left, right int) bool { return left < right })
+		want := append([]int(nil), input...)
+		sort.Ints(want)
+
+		if !reflect.DeepEqual(got, want) {
+			return false
+		}
+
+		got2 := stableSortedCopy(got, func(left, right int) bool { return left < right })
+		return reflect.DeepEqual(got, got2)
+	}
+
+	if err := quick.Check(prop, cfg); err != nil {
+		t.Fatalf("stableSortedCopy property failed: %v", err)
+	}
+}
+
+func TestProperty_SortModelViolations_DeterministicAcrossPermutations(t *testing.T) {
+	cfg := &quick.Config{MaxCount: 150}
+	prop := func(a, b, c, d string, l1, l2 uint8) bool {
+		base := []model.Violation{
+			{RuleID: a, File: b, Line: int(l1), Message: c},
+			{RuleID: b, File: c, Line: int(l2), Message: d},
+			{RuleID: a, File: c, Line: int(l2), Message: b},
+			{RuleID: d, File: a, Line: int(l1), Message: a},
+		}
+
+		x := append([]model.Violation(nil), base...)
+		y := []model.Violation{base[3], base[1], base[0], base[2]}
+
+		sortModelViolationsDeterministic(x)
+		sortModelViolationsDeterministic(y)
+
+		if !reflect.DeepEqual(x, y) {
+			return false
+		}
+
+		z := append([]model.Violation(nil), x...)
+		sortModelViolationsDeterministic(z)
+		return reflect.DeepEqual(x, z)
+	}
+
+	if err := quick.Check(prop, cfg); err != nil {
+		t.Fatalf("sortModelViolationsDeterministic property failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds property-based determinism tests for core ordering helpers using randomized inputs.
- Verifies idempotence and stable normalized ordering across permutations/repeated runs without changing production ordering logic.
- Extends confidence baseline required before v1.2 stabilization gate.

## Validation
- `go test . -run "TestProperty_"`
- `go test ./...`
- `go vet ./...`
- `go run . analyze -path .` (100/100)
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`

Closes #261