### PR TITLE
ci(rd-12006): enforce v1.2 stabilization gate in CI

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -77,6 +77,14 @@ jobs:
           GOMAXPROCS: 1
         run: ./scripts/v110_release_stabilization_gate.ps1
 
+      - name: Run v1.2 release stabilization gate
+        shell: pwsh
+        env:
+          TZ: UTC
+          LC_ALL: C
+          GOMAXPROCS: 1
+        run: ./scripts/v120_release_stabilization_gate.ps1
+
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Current CI pipeline includes:
   - `scripts/v019_release_stabilization_gate.ps1`
   - `scripts/v100_release_stabilization_gate.ps1`
   - `scripts/v110_release_stabilization_gate.ps1`
+  - `scripts/v120_release_stabilization_gate.ps1`
 
 You can also scaffold CI templates quickly:
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -10,7 +10,7 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v0.20 | M2: v0.20 Java Pilot (Gated) | Completed (Gated GO) | RD-2001..RD-2007 completed; decision memo published (`JAVA_PILOT_DECISION_v0.20.md`), pilot remains default-off. |
 | v1.0 | M3: v1.0 UX & Polish | Completed | RD-10001..RD-10005 merged to `dev` and released via `dev -> main` PR #250. |
 | v1.1+ | M4: v1.1+ Scale (Use-case gated) | Completed | RD-11001..RD-11003 merged to `dev` and released via `dev -> main` PR #254. |
-| v1.2 | M5: v1.2 Test Quality & Coverage | Planned | Issue chain RD-12001..RD-12006 prepared; execution model is branch-per-issue -> PR to `dev` -> green CI -> merge. |
+| v1.2 | M5: v1.2 Test Quality & Coverage | Completed | RD-12001..RD-12006 merged into `dev`; root/model/rules coverage hardening, parser fuzz/property determinism tests, and v1.2 gate pack activated. |
 | v1.3 | M6: v1.3 Observability | Planned | Issue chain RD-13001..RD-13005 prepared with boundary/purity controls for logging, metrics, and profiling. |
 | v1.4 | M7: v1.4 Performance Hardening | Planned | Issue chain RD-14001..RD-14004 prepared with determinism, race, benchmark, and memory budget gates. |
 | v1.5 | M8: v1.5 Developer Experience | Planned | Issue chain RD-15001..RD-15005 prepared with output-compatibility and release-distribution controls. |
@@ -43,6 +43,20 @@ Release path:
 - Feature PRs merged into `dev`: #251, #252, #253
 - Release PR (`dev -> main`): **#254**
 
+### v1.2 (M5: Test Quality & Coverage)
+
+- **RD-12001**: `internal/model` package test expansion and deterministic coverage lock
+- **RD-12002**: root package test expansion (coverage gate >=70%) + `json-v1` report path alignment
+- **RD-12003**: `internal/rules` edge/boundary and threshold behavior coverage
+- **RD-12004**: parser/extractor fuzz harnesses + malformed corpus fail-soft assertions
+- **RD-12005**: property-based determinism invariants for ordering helpers
+- **RD-12006**: v1.2 stabilization gate orchestration (`scripts/v120_release_stabilization_gate.ps1` + CI workflow wiring)
+
+Release path:
+
+- Feature PRs merged into `dev`: #282, #283, #284, #285, #286, #287
+- Release PR (`dev -> main`): pending (create after v1.2 gate PR merges and CI remains green)
+
 ## Current Branch/Release State
 
 - Latest completed release line is synchronized on `main`; `dev` may temporarily run ahead with planning/docs-only deltas before the next release merge.
@@ -63,4 +77,4 @@ Release path:
    - merge
 4. After each milestone chain closes on `dev`, open release PR `dev -> main` and keep `dev` branch intact.
 
-Son güncelleme: 1 Nisan 2026
+Son güncelleme: 3 Nisan 2026

--- a/scripts/v120_release_stabilization_gate.ps1
+++ b/scripts/v120_release_stabilization_gate.ps1
@@ -1,0 +1,26 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    Write-Host "==> $Name"
+    Invoke-Expression $Command
+}
+
+$determinismRegex = "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
+$rulesEdgeRegex = "TestCircularDependencyRule_.*|TestGodObjectRule_.*|TestCategories_AllAndValidations|TestExampleRule_ImplementsContract|TestLoadFromDir_FiltersHiddenAndNonGoFiles"
+$parserExtractorRegex = "TestImportExtractor_ExtractFromFile_MalformedFailSoft|TestImportExtractor_ExtractFromDir_SkipsMalformedKeepsValid|FuzzImportExtractor_ExtractFromFile_NoPanic|FuzzParsePythonImportLine_NoPanic|FuzzParsePythonDynamicImport_NoPanic|TestPythonAdapter_CollectEvidence_FailSoftOnMalformedAndOversized"
+
+Invoke-Step -Name "build" -Command "go build ."
+Invoke-Step -Name "core test suite" -Command "go test ./..."
+Invoke-Step -Name "static analysis" -Command "go vet ./..."
+Invoke-Step -Name "v1.2 rules edge-case regression pack" -Command "go test ./internal/rules -run '$rulesEdgeRegex'"
+Invoke-Step -Name "v1.2 parser/extractor malformed-corpus pack" -Command "go test ./... -run '$parserExtractorRegex'"
+Invoke-Step -Name "v1.2 property-based determinism pack" -Command "go test . -run 'TestProperty_'"
+Invoke-Step -Name "determinism confidence suite" -Command "go test ./... -run '$determinismRegex'"
+Invoke-Step -Name "self-analysis 100/100 gate" -Command "go run . analyze -path ."
+
+Write-Host "v1.2 release stabilization gate passed."


### PR DESCRIPTION
## Summary
- Adds `scripts/v120_release_stabilization_gate.ps1` to codify v1.2 mandatory + conditional check execution.
- Wires the new v1.2 gate into `.github/workflows/repodoctor.yml` so CI enforces it on `dev/main` push and PR events.
- Updates milestone reporting/readme notes to capture v1.2 gate readiness and closeout state.

## Validation
- `go test ./...`
- `go vet ./...`
- `go run . analyze -path .` (100/100)
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/v120_release_stabilization_gate.ps1`

Closes #262