### PR TITLE
release(v1.2): merge M5 test quality and coverage hardening

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -77,6 +77,14 @@ jobs:
           GOMAXPROCS: 1
         run: ./scripts/v110_release_stabilization_gate.ps1
 
+      - name: Run v1.2 release stabilization gate
+        shell: pwsh
+        env:
+          TZ: UTC
+          LC_ALL: C
+          GOMAXPROCS: 1
+        run: ./scripts/v120_release_stabilization_gate.ps1
+
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Current CI pipeline includes:
   - `scripts/v019_release_stabilization_gate.ps1`
   - `scripts/v100_release_stabilization_gate.ps1`
   - `scripts/v110_release_stabilization_gate.ps1`
+  - `scripts/v120_release_stabilization_gate.ps1`
 
 You can also scaffold CI templates quickly:
 

--- a/analysis_language_evidence_test.go
+++ b/analysis_language_evidence_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 
 	"RepoDoctor/internal/languages"
@@ -29,5 +30,25 @@ func TestCollectLanguageEvidenceSummary_UnknownPathFailsSoft(t *testing.T) {
 	}
 	if len(summary.ReasonCodes) == 0 {
 		t.Fatal("expected non-empty reason codes on fail-soft summary")
+	}
+}
+
+func TestLoadLanguageTieBreak_DefaultOrderWhenNoConfig(t *testing.T) {
+	tieBreak := loadLanguageTieBreak(t.TempDir())
+	want := []string{"Python", "TypeScript", "JavaScript", "Go", "Java"}
+	if !reflect.DeepEqual(tieBreak, want) {
+		t.Fatalf("unexpected default tie break order: got %v want %v", tieBreak, want)
+	}
+}
+
+func TestRankLanguageStats_UsesTieBreakPriorityOnEqualScores(t *testing.T) {
+	stats := []languages.LanguageStat{
+		{Language: "Go", ProductScore: 10, Score: 10, Lines: 10, Count: 10},
+		{Language: "Python", ProductScore: 10, Score: 10, Lines: 10, Count: 10},
+	}
+
+	ranked := rankLanguageStats(stats, []string{"Python", "Go"})
+	if ranked[0].Language != "Python" {
+		t.Fatalf("expected tie-break priority to rank Python first, got %s", ranked[0].Language)
 	}
 }

--- a/analysis_service_test.go
+++ b/analysis_service_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	analysispkg "RepoDoctor/internal/analysis"
+	"RepoDoctor/internal/model"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAnalysisService_RunAndRunAnalyze_SuccessPath(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module example.com/test\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("failed writing go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "main.go"), []byte("package main\nfunc main(){}\n"), 0o644); err != nil {
+		t.Fatalf("failed writing main.go: %v", err)
+	}
+
+	service := NewAnalysisService()
+	code := service.Run(AnalyzeRequest{
+		Path:            tmp,
+		Format:          "json-v1",
+		Verbose:         false,
+		ColorEnabled:    false,
+		ExitOnViolation: false,
+	})
+	if code != 0 {
+		t.Fatalf("expected analysis service success code 0, got %d", code)
+	}
+
+	if code := runAnalyze(tmp, "text", false, false, false); code != 0 {
+		t.Fatalf("expected runAnalyze wrapper success code 0, got %d", code)
+	}
+}
+
+func TestAnalysisService_ReportAdapterGraphHandlesNilAndPopulatedGraph(t *testing.T) {
+	service := NewAnalysisService()
+	progress := NewProgressReporter(false)
+
+	empty := service.reportAdapterGraph(progress, &analysispkg.Result{AdapterName: "Go", Graph: nil}, false)
+	if empty.GetNodeCount() != 0 || empty.GetEdgeCount() != 0 {
+		t.Fatalf("expected empty graph from nil adapter graph, got nodes=%d edges=%d", empty.GetNodeCount(), empty.GetEdgeCount())
+	}
+
+	adapterGraph := model.NewDependencyGraph()
+	adapterGraph.AddEdge("a", "b")
+	built := service.reportAdapterGraph(progress, &analysispkg.Result{AdapterName: "Go", Graph: adapterGraph}, false)
+	if built.GetNodeCount() != 2 || built.GetEdgeCount() != 1 {
+		t.Fatalf("expected converted graph with 2 nodes/1 edge, got nodes=%d edges=%d", built.GetNodeCount(), built.GetEdgeCount())
+	}
+}

--- a/cli_commands.go
+++ b/cli_commands.go
@@ -65,7 +65,7 @@ func runReport(reportPath, format string) error {
 	}
 
 	// Parse report based on format
-	if format == "json" {
+	if format == "json" || format == "json-v1" {
 		// Output JSON as-is
 		fmt.Println(string(data))
 	} else {

--- a/cli_commands_test.go
+++ b/cli_commands_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunReport_JSONAndJSONV1EmitRawJSON(t *testing.T) {
+	tmp := t.TempDir()
+	reportPath := filepath.Join(tmp, "report.json")
+	raw := "{\"ok\":true}\n"
+	if err := os.WriteFile(reportPath, []byte(raw), 0o644); err != nil {
+		t.Fatalf("failed writing report fixture: %v", err)
+	}
+
+	for _, format := range []string{"json", "json-v1"} {
+		t.Run(format, func(t *testing.T) {
+			output := captureStdout(t, func() {
+				if err := runReport(reportPath, format); err != nil {
+					t.Fatalf("runReport failed for format %s: %v", format, err)
+				}
+			})
+			if strings.TrimSpace(normalizeNewlines(output)) != strings.TrimSpace(raw) {
+				t.Fatalf("expected raw JSON passthrough for %s, got %q", format, output)
+			}
+		})
+	}
+}
+
+func TestRunReport_TextModeWrapsOutput(t *testing.T) {
+	tmp := t.TempDir()
+	reportPath := filepath.Join(tmp, "report.json")
+	raw := "{\"score\":100}"
+	if err := os.WriteFile(reportPath, []byte(raw), 0o644); err != nil {
+		t.Fatalf("failed writing report fixture: %v", err)
+	}
+
+	output := captureStdout(t, func() {
+		if err := runReport(reportPath, "text"); err != nil {
+			t.Fatalf("runReport text mode failed: %v", err)
+		}
+	})
+	if !strings.Contains(output, "RepoDoctor Analysis Report") || !strings.Contains(output, raw) {
+		t.Fatalf("expected wrapped text report output, got %q", output)
+	}
+}
+
+func TestRunReport_MissingFileReturnsError(t *testing.T) {
+	err := runReport(filepath.Join(t.TempDir(), "missing.json"), "json")
+	if err == nil {
+		t.Fatal("expected missing report file error")
+	}
+}
+
+func TestRunHistory_SucceedsWithoutHistoryFile(t *testing.T) {
+	output := captureStdout(t, func() {
+		if err := runHistory(t.TempDir()); err != nil {
+			t.Fatalf("runHistory failed for empty history: %v", err)
+		}
+	})
+	if !strings.Contains(output, "Score Trend History") {
+		t.Fatalf("expected history header, got %q", output)
+	}
+}
+
+func TestRunExtract_ErrorsForInvalidPathAndFilePath(t *testing.T) {
+	if err := runExtract(filepath.Join(t.TempDir(), "missing"), "RepoDoctor", false, false); err == nil {
+		t.Fatal("expected runExtract to fail for missing path")
+	}
+
+	tmp := t.TempDir()
+	filePath := filepath.Join(tmp, "file.go")
+	if err := os.WriteFile(filePath, []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("failed writing file fixture: %v", err)
+	}
+	if err := runExtract(filePath, "RepoDoctor", false, false); err == nil {
+		t.Fatal("expected runExtract to fail for file path")
+	}
+}
+
+func TestScanDirectory_CountsGoFilesAndSkipsDocsAndHidden(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "a.go"), []byte("package main\nfunc a(){}\n"), 0o644); err != nil {
+		t.Fatalf("failed writing top go file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "b.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("failed writing non-go file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, "docs"), 0o755); err != nil {
+		t.Fatalf("failed creating docs dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "docs", "ignored.go"), []byte("package docs\n"), 0o644); err != nil {
+		t.Fatalf("failed writing docs go file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, ".git"), 0o755); err != nil {
+		t.Fatalf("failed creating hidden dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".git", "ignored.go"), []byte("package git\n"), 0o644); err != nil {
+		t.Fatalf("failed writing hidden go file: %v", err)
+	}
+
+	totalFiles, goFiles, totalLines := scanDirectory(tmp, false)
+	if totalFiles != 2 {
+		t.Fatalf("expected total files 2 (a.go + b.txt), got %d", totalFiles)
+	}
+	if goFiles != 1 {
+		t.Fatalf("expected go files 1, got %d", goFiles)
+	}
+	if totalLines < 2 {
+		t.Fatalf("expected at least 2 lines counted for a.go, got %d", totalLines)
+	}
+}
+
+func TestParseGenerateCIArgs_SupportedAndInvalidOptions(t *testing.T) {
+	provider, force, err := parseGenerateCIArgs([]string{"github"})
+	if err != nil {
+		t.Fatalf("expected github provider to parse, got: %v", err)
+	}
+	if provider != "github" || force {
+		t.Fatalf("unexpected parse result: provider=%s force=%v", provider, force)
+	}
+
+	provider, force, err = parseGenerateCIArgs([]string{"gitlab", "--force"})
+	if err != nil {
+		t.Fatalf("expected gitlab with force to parse, got: %v", err)
+	}
+	if provider != "gitlab" || !force {
+		t.Fatalf("unexpected parse result with force: provider=%s force=%v", provider, force)
+	}
+
+	if _, _, err := parseGenerateCIArgs([]string{"azure", "--bad-flag"}); err == nil {
+		t.Fatal("expected invalid flag to fail parse")
+	}
+}

--- a/color_test.go
+++ b/color_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestColorFormatter_BasicFormatting(t *testing.T) {
+	formatter := NewColorFormatter(false)
+
+	if got := formatter.Color("x", ColorRed); got != "x" {
+		t.Fatalf("expected disabled formatter to return plain text, got %q", got)
+	}
+	if got := formatter.Success("ok"); got != "ok" {
+		t.Fatalf("expected success to be plain text when disabled, got %q", got)
+	}
+	if got := formatter.Bold("b"); got != "b" {
+		t.Fatalf("expected bold to be plain text when disabled, got %q", got)
+	}
+}
+
+func TestGlobalColorHelpers_WithInitializedFormatter(t *testing.T) {
+	InitColorFormatter(false)
+	if GetColorFormatter() == nil {
+		t.Fatal("expected initialized global color formatter")
+	}
+
+	if got := ColorInfo("info"); got != "info" {
+		t.Fatalf("expected ColorInfo plain text, got %q", got)
+	}
+	if got := ColorWarn("warn"); got != "warn" {
+		t.Fatalf("expected ColorWarn plain text, got %q", got)
+	}
+	if got := ColorError("err"); got != "err" {
+		t.Fatalf("expected ColorError plain text, got %q", got)
+	}
+	if got := ColorSuccess("ok"); got != "ok" {
+		t.Fatalf("expected ColorSuccess plain text, got %q", got)
+	}
+}
+
+func TestColorPrintfAndFprintf(t *testing.T) {
+	InitColorFormatter(false)
+
+	stdout := captureStdout(t, func() {
+		ColorPrintf(ColorBlue, "hello %s", "world")
+	})
+	if !strings.Contains(stdout, "hello world") {
+		t.Fatalf("expected ColorPrintf output, got %q", stdout)
+	}
+
+	stderr := captureStderr(t, func() {
+		ColorFprintf(os.Stderr, ColorGreen, "value=%d", 42)
+	})
+	if !strings.Contains(stderr, "value=42") {
+		t.Fatalf("expected ColorFprintf output, got %q", stderr)
+	}
+}

--- a/deterministic_properties_test.go
+++ b/deterministic_properties_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+	"testing/quick"
+
+	"RepoDoctor/internal/model"
+)
+
+func TestProperty_SortedStringCopy_IdempotentAndSorted(t *testing.T) {
+	cfg := &quick.Config{MaxCount: 200}
+	prop := func(input []string) bool {
+		original := append([]string(nil), input...)
+		got := sortedStringCopy(input)
+
+		if !sort.StringsAreSorted(got) {
+			return false
+		}
+
+		if !equalStringSlices(input, original) {
+			return false
+		}
+
+		got2 := sortedStringCopy(got)
+		return equalStringSlices(got, got2)
+	}
+
+	if err := quick.Check(prop, cfg); err != nil {
+		t.Fatalf("sortedStringCopy property failed: %v", err)
+	}
+}
+
+func equalStringSlices(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestProperty_StableSortedCopy_Ints_MatchesGoSortAndIdempotent(t *testing.T) {
+	cfg := &quick.Config{MaxCount: 200}
+	prop := func(input []int) bool {
+		got := stableSortedCopy(input, func(left, right int) bool { return left < right })
+		want := append([]int(nil), input...)
+		sort.Ints(want)
+
+		if !reflect.DeepEqual(got, want) {
+			return false
+		}
+
+		got2 := stableSortedCopy(got, func(left, right int) bool { return left < right })
+		return reflect.DeepEqual(got, got2)
+	}
+
+	if err := quick.Check(prop, cfg); err != nil {
+		t.Fatalf("stableSortedCopy property failed: %v", err)
+	}
+}
+
+func TestProperty_SortModelViolations_DeterministicAcrossPermutations(t *testing.T) {
+	cfg := &quick.Config{MaxCount: 150}
+	prop := func(a, b, c, d string, l1, l2 uint8) bool {
+		base := []model.Violation{
+			{RuleID: a, File: b, Line: int(l1), Message: c},
+			{RuleID: b, File: c, Line: int(l2), Message: d},
+			{RuleID: a, File: c, Line: int(l2), Message: b},
+			{RuleID: d, File: a, Line: int(l1), Message: a},
+		}
+
+		x := append([]model.Violation(nil), base...)
+		y := []model.Violation{base[3], base[1], base[0], base[2]}
+
+		sortModelViolationsDeterministic(x)
+		sortModelViolationsDeterministic(y)
+
+		if !reflect.DeepEqual(x, y) {
+			return false
+		}
+
+		z := append([]model.Violation(nil), x...)
+		sortModelViolationsDeterministic(z)
+		return reflect.DeepEqual(x, z)
+	}
+
+	if err := quick.Check(prop, cfg); err != nil {
+		t.Fatalf("sortModelViolationsDeterministic property failed: %v", err)
+	}
+}

--- a/docs/report.md
+++ b/docs/report.md
@@ -10,7 +10,7 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v0.20 | M2: v0.20 Java Pilot (Gated) | Completed (Gated GO) | RD-2001..RD-2007 completed; decision memo published (`JAVA_PILOT_DECISION_v0.20.md`), pilot remains default-off. |
 | v1.0 | M3: v1.0 UX & Polish | Completed | RD-10001..RD-10005 merged to `dev` and released via `dev -> main` PR #250. |
 | v1.1+ | M4: v1.1+ Scale (Use-case gated) | Completed | RD-11001..RD-11003 merged to `dev` and released via `dev -> main` PR #254. |
-| v1.2 | M5: v1.2 Test Quality & Coverage | Planned | Issue chain RD-12001..RD-12006 prepared; execution model is branch-per-issue -> PR to `dev` -> green CI -> merge. |
+| v1.2 | M5: v1.2 Test Quality & Coverage | Completed | RD-12001..RD-12006 merged into `dev`; root/model/rules coverage hardening, parser fuzz/property determinism tests, and v1.2 gate pack activated. |
 | v1.3 | M6: v1.3 Observability | Planned | Issue chain RD-13001..RD-13005 prepared with boundary/purity controls for logging, metrics, and profiling. |
 | v1.4 | M7: v1.4 Performance Hardening | Planned | Issue chain RD-14001..RD-14004 prepared with determinism, race, benchmark, and memory budget gates. |
 | v1.5 | M8: v1.5 Developer Experience | Planned | Issue chain RD-15001..RD-15005 prepared with output-compatibility and release-distribution controls. |
@@ -43,6 +43,20 @@ Release path:
 - Feature PRs merged into `dev`: #251, #252, #253
 - Release PR (`dev -> main`): **#254**
 
+### v1.2 (M5: Test Quality & Coverage)
+
+- **RD-12001**: `internal/model` package test expansion and deterministic coverage lock
+- **RD-12002**: root package test expansion (coverage gate >=70%) + `json-v1` report path alignment
+- **RD-12003**: `internal/rules` edge/boundary and threshold behavior coverage
+- **RD-12004**: parser/extractor fuzz harnesses + malformed corpus fail-soft assertions
+- **RD-12005**: property-based determinism invariants for ordering helpers
+- **RD-12006**: v1.2 stabilization gate orchestration (`scripts/v120_release_stabilization_gate.ps1` + CI workflow wiring)
+
+Release path:
+
+- Feature PRs merged into `dev`: #282, #283, #284, #285, #286, #287
+- Release PR (`dev -> main`): pending (create after v1.2 gate PR merges and CI remains green)
+
 ## Current Branch/Release State
 
 - Latest completed release line is synchronized on `main`; `dev` may temporarily run ahead with planning/docs-only deltas before the next release merge.
@@ -63,4 +77,4 @@ Release path:
    - merge
 4. After each milestone chain closes on `dev`, open release PR `dev -> main` and keep `dev` branch intact.
 
-Son güncelleme: 1 Nisan 2026
+Son güncelleme: 3 Nisan 2026

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCLIError_ErrorAndDisplay(t *testing.T) {
+	original := errors.New("boom")
+	cliErr := NewCLIError(ErrorRuntime, "runtime failed", "try again", original)
+
+	if !strings.Contains(cliErr.Error(), "runtime failed") {
+		t.Fatalf("expected Error() to include message, got %q", cliErr.Error())
+	}
+
+	output := captureStderr(t, func() {
+		cliErr.Display()
+	})
+	if !strings.Contains(output, "Suggestion") || !strings.Contains(output, "runtime failed") {
+		t.Fatalf("expected display output with suggestion and message, got %q", output)
+	}
+}
+
+func TestErrorHelpersAndSuggestionLookup(t *testing.T) {
+	if got := GetSuggestion("file not found"); !strings.Contains(strings.ToLower(got), "path") {
+		t.Fatalf("expected file-not-found suggestion, got %q", got)
+	}
+	if got := GetSuggestion("unmatched error"); !strings.Contains(got, "--help") {
+		t.Fatalf("expected fallback help suggestion, got %q", got)
+	}
+
+	if err := HandleFileNotFoundError("/tmp/missing", errors.New("x")); err.Category != ErrorFileNotFound {
+		t.Fatalf("expected file-not-found category, got %s", err.Category)
+	}
+	if err := HandleInvalidPathError("::bad", errors.New("x")); err.Category != ErrorInvalidArgument {
+		t.Fatalf("expected invalid-argument category, got %s", err.Category)
+	}
+	if err := HandleConfigNotFoundError("cfg"); err.Category != ErrorConfiguration {
+		t.Fatalf("expected config category, got %s", err.Category)
+	}
+	if err := HandleUnknownRuleError("foo", []string{"a", "b"}); err.Category != ErrorInvalidArgument {
+		t.Fatalf("expected invalid-argument category for unknown rule, got %s", err.Category)
+	}
+	if err := HandleRuntimeError("oops", nil); err.Category != ErrorRuntime {
+		t.Fatalf("expected runtime category, got %s", err.Category)
+	}
+
+	if msg := FormatErrorMessage(ErrorRuntime, "x"); !strings.Contains(msg, "Runtime Error") {
+		t.Fatalf("unexpected formatted message: %q", msg)
+	}
+}
+
+func TestPrintError_PrintsCLIAndGenericErrors(t *testing.T) {
+	cliOut := captureStderr(t, func() {
+		PrintError(NewCLIError(ErrorAnalysis, "bad", "fix", nil))
+	})
+	if !strings.Contains(cliOut, "bad") {
+		t.Fatalf("expected CLI error output, got %q", cliOut)
+	}
+
+	genericOut := captureStderr(t, func() {
+		PrintError(errors.New("generic"))
+	})
+	if !strings.Contains(genericOut, "Suggestion") {
+		t.Fatalf("expected generic error suggestion output, got %q", genericOut)
+	}
+}

--- a/import_extractor_fuzz_test.go
+++ b/import_extractor_fuzz_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestImportExtractor_ExtractFromFile_MalformedFailSoft(t *testing.T) {
+	extractor := NewImportExtractor("github.com/example/repo")
+	dir := t.TempDir()
+	malformed := filepath.Join(dir, "broken.go")
+
+	if err := os.WriteFile(malformed, []byte("package broken\nimport (\n\t\"fmt\"\n"), 0o644); err != nil {
+		t.Fatalf("failed writing malformed file: %v", err)
+	}
+
+	meta, err := extractor.ExtractFromFile(malformed)
+	if err != nil {
+		t.Fatalf("expected fail-soft nil error, got: %v", err)
+	}
+	if meta != nil {
+		t.Fatalf("expected nil metadata for malformed file, got: %+v", meta)
+	}
+}
+
+func TestImportExtractor_ExtractFromDir_SkipsMalformedKeepsValid(t *testing.T) {
+	extractor := NewImportExtractor("github.com/example/repo")
+	dir := t.TempDir()
+
+	valid := filepath.Join(dir, "ok.go")
+	invalid := filepath.Join(dir, "bad.go")
+
+	if err := os.WriteFile(valid, []byte("package ok\nimport \"github.com/example/repo/internal/app\"\n"), 0o644); err != nil {
+		t.Fatalf("failed writing valid file: %v", err)
+	}
+	if err := os.WriteFile(invalid, []byte("package bad\nimport (\n\t\"fmt\"\n"), 0o644); err != nil {
+		t.Fatalf("failed writing malformed file: %v", err)
+	}
+
+	imports, err := extractor.ExtractFromDir(dir)
+	if err != nil {
+		t.Fatalf("expected fail-soft directory extraction, got error: %v", err)
+	}
+	if len(imports) != 1 {
+		t.Fatalf("expected only valid file metadata, got %d entries", len(imports))
+	}
+	if meta := imports[valid]; meta == nil || meta.Package != "ok" {
+		t.Fatalf("expected valid file metadata for %s, got %+v", valid, meta)
+	}
+}
+
+func FuzzImportExtractor_ExtractFromFile_NoPanic(f *testing.F) {
+	seeds := [][]byte{
+		[]byte("package p\nimport \"fmt\"\n"),
+		[]byte("package p\nimport (\"github.com/acme/x\";\"os\")\n"),
+		[]byte("package p\nimport \"github.com/acme/x\n"),
+		[]byte("\x00\x00\x00"),
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, content []byte) {
+		extractor := NewImportExtractor("github.com/acme/project")
+		dir := t.TempDir()
+		path := filepath.Join(dir, "input.go")
+
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			t.Fatalf("failed writing fuzz input: %v", err)
+		}
+
+		meta, err := extractor.ExtractFromFile(path)
+		if err != nil {
+			t.Fatalf("expected fail-soft parse behavior, got error: %v", err)
+		}
+		if meta != nil && meta.Package == "" {
+			t.Fatalf("unexpected empty package in metadata: %+v", meta)
+		}
+	})
+}

--- a/interactive_helpers_test.go
+++ b/interactive_helpers_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInteractiveIO_ReadChoiceAndReadPositiveInt(t *testing.T) {
+	io := &interactiveIO{reader: bufio.NewReader(strings.NewReader("2\n42\n-1\n"))}
+
+	if got := io.readChoice(); got != 2 {
+		t.Fatalf("expected choice 2, got %d", got)
+	}
+	value, ok := io.readPositiveInt("Enter value")
+	if !ok || value != 42 {
+		t.Fatalf("expected positive int 42, got value=%d ok=%v", value, ok)
+	}
+	_, ok = io.readPositiveInt("Enter value")
+	if ok {
+		t.Fatal("expected negative number to be rejected")
+	}
+}
+
+func TestInteractiveIO_ReadStringAndConfirm(t *testing.T) {
+	io := &interactiveIO{reader: bufio.NewReader(strings.NewReader("  hello  \nyes\nno\n"))}
+
+	if got := io.readString("Prompt: "); got != "hello" {
+		t.Fatalf("expected trimmed readString result 'hello', got %q", got)
+	}
+	if !io.confirm("Confirm") {
+		t.Fatal("expected 'yes' to confirm true")
+	}
+	if io.confirm("Confirm") {
+		t.Fatal("expected 'no' to confirm false")
+	}
+}
+
+func TestInteractiveConfigController_TogglesAndThresholds(t *testing.T) {
+	cfg := (&ConfigLoader{}).getDefaultConfig()
+	io := &interactiveIO{reader: bufio.NewReader(strings.NewReader("100\n50\n20\n15\n"))}
+	controller := NewInteractiveConfigController(io)
+
+	controller.toggleSizeRule(cfg)
+	if *cfg.Rules.EnableSizeRule {
+		t.Fatal("expected size rule toggle to disable")
+	}
+	controller.toggleGodObjectRule(cfg)
+	if *cfg.Rules.EnableGodObjectRule {
+		t.Fatal("expected god-object rule toggle to disable")
+	}
+
+	controller.setMaxFileLines(cfg)
+	controller.setMaxFunctionLines(cfg)
+	controller.setMaxFields(cfg)
+	controller.setMaxMethods(cfg)
+
+	if cfg.Size.MaxFileLines != 100 || cfg.Size.MaxFunctionLines != 50 {
+		t.Fatalf("unexpected size thresholds: %+v", cfg.Size)
+	}
+	if cfg.GodObject.MaxFields != 20 || cfg.GodObject.MaxMethods != 15 {
+		t.Fatalf("unexpected god-object thresholds: %+v", cfg.GodObject)
+	}
+
+	menu := captureStdout(t, func() {
+		controller.showConfigMenu(cfg)
+	})
+	if !strings.Contains(menu, "Rule Configuration") {
+		t.Fatalf("expected config menu output, got %q", menu)
+	}
+}
+
+func TestSaveConfig_WritesConfigFile(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := (&ConfigLoader{}).getDefaultConfig()
+
+	if err := saveConfig(tmp, cfg); err != nil {
+		t.Fatalf("saveConfig failed: %v", err)
+	}
+
+	configPath := GetConfigPath(tmp)
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("expected config file at %s, got error: %v", configPath, err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed reading saved config: %v", err)
+	}
+	if !strings.Contains(string(data), "size:") {
+		t.Fatalf("expected yaml config content, got %q", string(data))
+	}
+
+	if !filepath.IsAbs(configPath) && strings.TrimSpace(configPath) == "" {
+		t.Fatalf("unexpected config path value: %q", configPath)
+	}
+}
+
+func TestBoolLabelValues(t *testing.T) {
+	if got := boolLabel(true); got != "Enabled" {
+		t.Fatalf("expected Enabled, got %q", got)
+	}
+	if got := boolLabel(false); got != "Disabled" {
+		t.Fatalf("expected Disabled, got %q", got)
+	}
+}

--- a/internal/languages/python_evidence_fuzz_test.go
+++ b/internal/languages/python_evidence_fuzz_test.go
@@ -1,0 +1,43 @@
+package languages
+
+import "testing"
+
+func FuzzParsePythonImportLine_NoPanic(f *testing.F) {
+	seeds := []string{
+		"import os",
+		"from .service import handler",
+		"importlib.import_module(\"json\")",
+		"__import__(\"pkg\" + name)",
+		"from .. import *",
+		"\x00\x00\x00",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, line string) {
+		results := parsePythonImportLine(line)
+		for _, ev := range results {
+			if ev.level < 0 {
+				t.Fatalf("relative level must not be negative: %d", ev.level)
+			}
+		}
+	})
+}
+
+func FuzzParsePythonDynamicImport_NoPanic(f *testing.F) {
+	seeds := []string{
+		"importlib.import_module('json')",
+		"importlib.import_module('.local')",
+		"__import__('pkg')",
+		"__import__(prefix + '.mod')",
+		"not a dynamic import",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, line string) {
+		_, _ = parsePythonDynamicImport(line)
+	})
+}

--- a/internal/model/dependency_graph_test.go
+++ b/internal/model/dependency_graph_test.go
@@ -1,0 +1,96 @@
+package model
+
+import "testing"
+
+func TestDependencyGraph_AddNode_Idempotent(t *testing.T) {
+	g := NewDependencyGraph()
+	first := g.AddNode("a", "a.go", "pkg/a")
+	second := g.AddNode("a", "ignored.go", "ignored")
+
+	if first != second {
+		t.Fatal("expected AddNode to return existing node for duplicate id")
+	}
+	if g.NodeCount() != 1 {
+		t.Fatalf("expected node count 1, got %d", g.NodeCount())
+	}
+	if g.EdgeCount() != 0 {
+		t.Fatalf("expected edge count 0, got %d", g.EdgeCount())
+	}
+}
+
+func TestDependencyGraph_AddEdge_AutoCreatesNodes(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+
+	if g.NodeCount() != 2 {
+		t.Fatalf("expected 2 auto-created nodes, got %d", g.NodeCount())
+	}
+	if g.EdgeCount() != 1 {
+		t.Fatalf("expected 1 edge, got %d", g.EdgeCount())
+	}
+
+	deps := g.GetDependencies("a")
+	if len(deps) != 1 || deps[0] != "b" {
+		t.Fatalf("unexpected dependencies for a: %v", deps)
+	}
+	dependents := g.GetDependents("b")
+	if len(dependents) != 1 || dependents[0] != "a" {
+		t.Fatalf("unexpected dependents for b: %v", dependents)
+	}
+}
+
+func TestDependencyGraph_AddEdge_DeduplicatesEdgeAndImports(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddNode("svc", "svc.go", "service")
+	g.AddNode("repo", "repo.go", "repository")
+
+	g.AddEdge("svc", "repo")
+	g.AddEdge("svc", "repo")
+
+	if g.EdgeCount() != 1 {
+		t.Fatalf("expected de-duplicated edge count 1, got %d", g.EdgeCount())
+	}
+
+	node := g.GetNode("svc")
+	if node == nil {
+		t.Fatal("expected source node to exist")
+	}
+	if len(node.Imports) != 1 || node.Imports[0] != "repo" {
+		t.Fatalf("expected imports [repo], got %v", node.Imports)
+	}
+}
+
+func TestDependencyGraph_CountsAndAccessors(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddNode("a", "a.go", "a")
+	g.AddNode("b", "b.go", "b")
+	g.AddNode("c", "c.go", "c")
+	g.AddEdge("a", "b")
+	g.AddEdge("a", "c")
+
+	if g.NodeCount() != 3 {
+		t.Fatalf("expected node count 3, got %d", g.NodeCount())
+	}
+	if g.EdgeCount() != 2 {
+		t.Fatalf("expected edge count 2, got %d", g.EdgeCount())
+	}
+
+	node := g.GetNode("a")
+	if node == nil || node.Path != "a.go" || node.Package != "a" {
+		t.Fatalf("unexpected node metadata: %+v", node)
+	}
+}
+
+func TestDependencyGraph_UnknownNodeAccessors(t *testing.T) {
+	g := NewDependencyGraph()
+
+	if g.GetNode("missing") != nil {
+		t.Fatal("expected nil for unknown node")
+	}
+	if len(g.GetDependencies("missing")) != 0 {
+		t.Fatalf("expected empty dependencies for unknown node")
+	}
+	if len(g.GetDependents("missing")) != 0 {
+		t.Fatalf("expected empty dependents for unknown node")
+	}
+}

--- a/internal/model/graph_analysis_test.go
+++ b/internal/model/graph_analysis_test.go
@@ -1,0 +1,45 @@
+package model
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFindRoots_ReturnsExpectedSet(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+	g.AddNode("c", "c.go", "c")
+
+	got := sortedNodeIDs(FindRoots(g))
+	want := []string{"a", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected roots: got %v want %v", got, want)
+	}
+}
+
+func TestFindLeaves_ReturnsExpectedSet(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+	g.AddNode("c", "c.go", "c")
+
+	got := sortedNodeIDs(FindLeaves(g))
+	want := []string{"b", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected leaves: got %v want %v", got, want)
+	}
+}
+
+func TestFindRootsAndLeaves_IsolatedNode_BothRootAndLeaf(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddNode("isolated", "isolated.go", "isolated")
+
+	roots := sortedNodeIDs(FindRoots(g))
+	leaves := sortedNodeIDs(FindLeaves(g))
+
+	if !reflect.DeepEqual(roots, []string{"isolated"}) {
+		t.Fatalf("unexpected roots for isolated graph: %v", roots)
+	}
+	if !reflect.DeepEqual(leaves, []string{"isolated"}) {
+		t.Fatalf("unexpected leaves for isolated graph: %v", leaves)
+	}
+}

--- a/internal/model/graph_cycle_detector_test.go
+++ b/internal/model/graph_cycle_detector_test.go
@@ -1,0 +1,128 @@
+package model
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGraphCycleDetector_AcyclicGraph_NoCycles(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+	g.AddEdge("b", "c")
+
+	detector := NewGraphCycleDetector(g)
+	cycles := detector.DetectCycles()
+	if len(cycles) != 0 {
+		t.Fatalf("expected no cycles, got %v", cycles)
+	}
+	if detector.HasCycles() {
+		t.Fatal("expected HasCycles false for acyclic graph")
+	}
+}
+
+func TestGraphCycleDetector_SimpleCycle_Detected(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+	g.AddEdge("b", "a")
+
+	detector := NewGraphCycleDetector(g)
+	cycles := detector.DetectCycles()
+	if len(cycles) == 0 {
+		t.Fatal("expected at least one cycle")
+	}
+
+	sigs := cycleSignatures(cycles)
+	found := false
+	for _, sig := range sigs {
+		if sig == "a->b" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected signature a->b among %v", sigs)
+	}
+}
+
+func TestGraphCycleDetector_MultipleCycles_Detected(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+	g.AddEdge("b", "a")
+	g.AddEdge("x", "y")
+	g.AddEdge("y", "x")
+
+	cycles := NewGraphCycleDetector(g).DetectCycles()
+	sigs := cycleSignatures(cycles)
+
+	if len(sigs) < 2 {
+		t.Fatalf("expected at least two cycle signatures, got %v", sigs)
+	}
+
+	hasAB := false
+	hasXY := false
+	for _, sig := range sigs {
+		if sig == "a->b" {
+			hasAB = true
+		}
+		if sig == "x->y" {
+			hasXY = true
+		}
+	}
+	if !hasAB || !hasXY {
+		t.Fatalf("expected cycle signatures for both components, got %v", sigs)
+	}
+}
+
+func TestGraphCycleDetector_SelfLoop_Detected(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("self", "self")
+
+	cycles := NewGraphCycleDetector(g).DetectCycles()
+	sigs := cycleSignatures(cycles)
+
+	foundSelf := false
+	for _, sig := range sigs {
+		if sig == "self" {
+			foundSelf = true
+			break
+		}
+	}
+	if !foundSelf {
+		t.Fatalf("expected self-loop cycle signature, got %v", sigs)
+	}
+}
+
+func TestGraphCycleDetector_HasCycles_AndGetCyclesContract(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+	g.AddEdge("b", "a")
+
+	detector := NewGraphCycleDetector(g)
+	if detector.GetCycles() == nil {
+		t.Fatal("expected initialized cycle storage")
+	}
+	if !detector.HasCycles() {
+		t.Fatal("expected HasCycles true after implicit detection")
+	}
+	if len(detector.GetCycles()) == 0 {
+		t.Fatal("expected detected cycles to be available via GetCycles")
+	}
+}
+
+func TestGraphCycleDetector_DeterministicAcross10Runs_Canonicalized(t *testing.T) {
+	g := NewDependencyGraph()
+	g.AddEdge("a", "b")
+	g.AddEdge("b", "a")
+	g.AddEdge("b", "c")
+	g.AddEdge("c", "d")
+	g.AddEdge("d", "b")
+
+	baseline := cycleSignatures(NewGraphCycleDetector(g).DetectCycles())
+
+	for i := 0; i < 10; i++ {
+		candidate := cycleSignatures(NewGraphCycleDetector(g).DetectCycles())
+		if !reflect.DeepEqual(candidate, baseline) {
+			t.Fatalf("non-deterministic cycle signatures at run %d: baseline=%v candidate=%v", i, baseline, candidate)
+		}
+	}
+}

--- a/internal/model/metrics_test.go
+++ b/internal/model/metrics_test.go
@@ -1,0 +1,60 @@
+package model
+
+import "testing"
+
+func TestNewRepositoryMetrics_InitialState(t *testing.T) {
+	m := NewRepositoryMetrics()
+
+	if m == nil {
+		t.Fatal("expected non-nil metrics instance")
+	}
+	if len(m.Files) != 0 || len(m.Functions) != 0 || len(m.Structs) != 0 {
+		t.Fatalf("expected empty slices, got files=%d functions=%d structs=%d", len(m.Files), len(m.Functions), len(m.Structs))
+	}
+	if m.TotalLines != 0 || m.TotalFiles != 0 || m.TotalFunctions != 0 || m.TotalStructs != 0 {
+		t.Fatalf("expected zero totals, got %+v", *m)
+	}
+}
+
+func TestRepositoryMetrics_AddFileMetrics_UpdatesTotals(t *testing.T) {
+	m := NewRepositoryMetrics()
+
+	m.AddFileMetrics(FileMetrics{Path: "a.go", Lines: 10, Functions: 2})
+	m.AddFileMetrics(FileMetrics{Path: "b.go", Lines: 5, Functions: 1})
+
+	if m.TotalFiles != 2 {
+		t.Fatalf("expected TotalFiles=2, got %d", m.TotalFiles)
+	}
+	if m.TotalLines != 15 {
+		t.Fatalf("expected TotalLines=15, got %d", m.TotalLines)
+	}
+	if m.TotalFunctions != 3 {
+		t.Fatalf("expected TotalFunctions=3, got %d", m.TotalFunctions)
+	}
+}
+
+func TestRepositoryMetrics_AddFunctionMetrics_AppendsOnly(t *testing.T) {
+	m := NewRepositoryMetrics()
+	m.AddFunctionMetrics(FunctionMetrics{Name: "A", File: "a.go", Lines: 10})
+	m.AddFunctionMetrics(FunctionMetrics{Name: "B", File: "b.go", Lines: 5})
+
+	if len(m.Functions) != 2 {
+		t.Fatalf("expected 2 function metrics, got %d", len(m.Functions))
+	}
+	if m.TotalFunctions != 0 {
+		t.Fatalf("expected TotalFunctions unchanged by AddFunctionMetrics, got %d", m.TotalFunctions)
+	}
+}
+
+func TestRepositoryMetrics_AddStructMetrics_AppendsAndIncrementsTotal(t *testing.T) {
+	m := NewRepositoryMetrics()
+	m.AddStructMetrics(StructMetrics{Name: "A", File: "a.go", Fields: 2, Methods: 1})
+	m.AddStructMetrics(StructMetrics{Name: "B", File: "b.go", Fields: 1, Methods: 0})
+
+	if len(m.Structs) != 2 {
+		t.Fatalf("expected 2 struct metrics, got %d", len(m.Structs))
+	}
+	if m.TotalStructs != 2 {
+		t.Fatalf("expected TotalStructs=2, got %d", m.TotalStructs)
+	}
+}

--- a/internal/model/test_helpers_test.go
+++ b/internal/model/test_helpers_test.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"sort"
+	"strings"
+)
+
+func sortedNodeIDs(nodes []*Node) []string {
+	ids := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		ids = append(ids, n.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func cycleSignatures(cycles [][]string) []string {
+	if len(cycles) == 0 {
+		return nil
+	}
+	signatures := make([]string, 0, len(cycles))
+	for _, cycle := range cycles {
+		copied := append([]string{}, cycle...)
+		sort.Strings(copied)
+		signatures = append(signatures, strings.Join(copied, "->"))
+	}
+	sort.Strings(signatures)
+	return signatures
+}

--- a/internal/rules/circular_dependency_rule_test.go
+++ b/internal/rules/circular_dependency_rule_test.go
@@ -1,0 +1,108 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCircularDependencyRule_MetadataAndCapabilities(t *testing.T) {
+	rule := NewCircularDependencyRule(DependencyGraph{})
+
+	if rule.ID() != "rule.circular-dependency" {
+		t.Fatalf("unexpected id: %s", rule.ID())
+	}
+	if rule.Category() != string(CategoryArchitecture) {
+		t.Fatalf("unexpected category: %s", rule.Category())
+	}
+	if rule.Severity() != "critical" {
+		t.Fatalf("unexpected severity: %s", rule.Severity())
+	}
+
+	caps := rule.Capabilities()
+	if !caps.SupportsMultipleLanguages {
+		t.Fatal("expected multi-language capability")
+	}
+	if len(caps.SupportedLanguages) == 0 {
+		t.Fatal("expected non-empty supported language list")
+	}
+}
+
+func TestCircularDependencyRule_Evaluate_UsesContextDependencyGraph(t *testing.T) {
+	rule := NewCircularDependencyRule(DependencyGraph{})
+	ctx := AnalysisContext{
+		DependencyGraph: DependencyGraph{
+			Nodes: []string{"a", "b"},
+			Edges: map[string][]string{
+				"a": []string{"b"},
+				"b": []string{"a"},
+			},
+		},
+	}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 1 {
+		t.Fatalf("expected one circular violation, got %d", len(violations))
+	}
+
+	v := violations[0]
+	if v.RuleID != rule.ID() {
+		t.Fatalf("unexpected rule id: %s", v.RuleID)
+	}
+	if v.Severity != "critical" {
+		t.Fatalf("unexpected severity: %s", v.Severity)
+	}
+	if v.File != "a" {
+		t.Fatalf("expected first cycle node as file, got %s", v.File)
+	}
+	if !strings.Contains(v.Message, "a") || !strings.Contains(v.Message, "b") {
+		t.Fatalf("expected cycle message to include nodes, got %q", v.Message)
+	}
+}
+
+func TestCircularDependencyRule_Evaluate_BuildsGraphFromRepositoryFiles(t *testing.T) {
+	rule := NewCircularDependencyRule(DependencyGraph{})
+	ctx := AnalysisContext{
+		RepositoryFiles: []RepositoryFile{
+			{Path: "a.go", Imports: []string{"b.go"}},
+			{Path: "b.go", Imports: []string{"a.go"}},
+		},
+	}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 1 {
+		t.Fatalf("expected one circular violation from file imports, got %d", len(violations))
+	}
+}
+
+func TestCircularDependencyRule_Evaluate_NoCycle(t *testing.T) {
+	rule := NewCircularDependencyRule(DependencyGraph{})
+	ctx := AnalysisContext{
+		DependencyGraph: DependencyGraph{
+			Nodes: []string{"a", "b", "c"},
+			Edges: map[string][]string{
+				"a": []string{"b"},
+				"b": []string{"c"},
+				"c": []string{},
+			},
+		},
+	}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %v", violations)
+	}
+}
+
+func TestExtractCycle_StartNotFoundReturnsPath(t *testing.T) {
+	path := []string{"a", "b", "c"}
+	cycle := extractCycle(path, "x")
+	if len(cycle) != len(path) {
+		t.Fatalf("expected fallback full path, got %v", cycle)
+	}
+}
+
+func TestFormatCycle_EmptyCycle(t *testing.T) {
+	if got := formatCycle(nil); got != "" {
+		t.Fatalf("expected empty message for empty cycle, got %q", got)
+	}
+}

--- a/internal/rules/god_object_rule_edge_test.go
+++ b/internal/rules/god_object_rule_edge_test.go
@@ -1,0 +1,121 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGodObjectRule_MetadataAndCapabilities(t *testing.T) {
+	rule := NewGodObjectRule()
+
+	if rule.ID() != "rule.god-object" {
+		t.Fatalf("unexpected id: %s", rule.ID())
+	}
+	if rule.Category() != string(CategoryMaintainability) {
+		t.Fatalf("unexpected category: %s", rule.Category())
+	}
+	if rule.Severity() != "warning" {
+		t.Fatalf("unexpected severity: %s", rule.Severity())
+	}
+
+	caps := rule.Capabilities()
+	if caps.SupportsMultipleLanguages {
+		t.Fatal("god object rule should be single-language")
+	}
+	if len(caps.SupportedLanguages) != 1 || caps.SupportedLanguages[0] != "Go" {
+		t.Fatalf("unexpected supported languages: %v", caps.SupportedLanguages)
+	}
+}
+
+func TestGodObjectRule_ThresholdBoundary_NoViolationAtExactThreshold(t *testing.T) {
+	rule := NewGodObjectRule()
+	rule.MaxFields = 2
+	rule.MaxMethods = 2
+
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{{
+		Path: "pkg/exact.go",
+		Content: `package pkg
+type User struct {
+	ID int
+	Name string
+}
+func (u User) First() {}
+func (u *User) Second() {}`,
+	}}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations at exact thresholds, got %v", violations)
+	}
+}
+
+func TestGodObjectRule_ThresholdBoundary_ViolatesWhenExceeded(t *testing.T) {
+	rule := NewGodObjectRule()
+	rule.MaxFields = 2
+	rule.MaxMethods = 2
+
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{{
+		Path: "pkg/exceed.go",
+		Content: `package pkg
+type User struct {
+	A int
+	B int
+	C int
+}
+func (u User) One() {}
+func (u User) Two() {}
+func (u User) Three() {}`,
+	}}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 2 {
+		t.Fatalf("expected field and method violations, got %d (%v)", len(violations), violations)
+	}
+
+	joined := violations[0].Message + "\n" + violations[1].Message
+	if !strings.Contains(joined, "fields (threshold: 2)") {
+		t.Fatalf("expected field threshold detail in messages, got %q", joined)
+	}
+	if !strings.Contains(joined, "methods (threshold: 2)") {
+		t.Fatalf("expected method threshold detail in messages, got %q", joined)
+	}
+}
+
+func TestGodObjectRule_Boundary_StructNameCollisionAcrossDirs(t *testing.T) {
+	rule := NewGodObjectRule()
+	rule.MaxFields = 10
+	rule.MaxMethods = 1
+
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{
+		{
+			Path: "module/a/user.go",
+			Content: `package a
+type User struct{}
+func (u User) A() {}`,
+		},
+		{
+			Path: "module/b/user.go",
+			Content: `package b
+type User struct{}
+func (u User) B() {}`,
+		},
+	}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected no collision-induced violations across directories, got %v", violations)
+	}
+}
+
+func TestGodObjectRule_Evaluate_MalformedFileIgnored(t *testing.T) {
+	rule := NewGodObjectRule()
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{{
+		Path:    "pkg/bad.go",
+		Content: "package broken\ntype X struct {\nfunc(",
+	}}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected malformed file to be ignored, got %v", violations)
+	}
+}

--- a/internal/rules/rules_edge_coverage_test.go
+++ b/internal/rules/rules_edge_coverage_test.go
@@ -1,0 +1,75 @@
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCategories_AllAndValidations(t *testing.T) {
+	categories := AllCategories()
+	if len(categories) < 5 {
+		t.Fatalf("expected all standard categories, got %v", categories)
+	}
+
+	for _, c := range categories {
+		if !IsValidCategory(string(c)) {
+			t.Fatalf("expected category %q to be valid", c)
+		}
+	}
+
+	if IsValidCategory("unknown") {
+		t.Fatal("expected unknown category to be invalid")
+	}
+}
+
+func TestExampleRule_ImplementsContract(t *testing.T) {
+	rule := &ExampleRule{}
+	if rule.ID() != "rule.example" {
+		t.Fatalf("unexpected id: %s", rule.ID())
+	}
+	if rule.Category() != "structural" {
+		t.Fatalf("unexpected category: %s", rule.Category())
+	}
+	if rule.Severity() != "info" {
+		t.Fatalf("unexpected severity: %s", rule.Severity())
+	}
+
+	violations := rule.Evaluate(AnalysisContext{})
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %v", violations)
+	}
+}
+
+func TestLoadFromDir_FiltersHiddenAndNonGoFiles(t *testing.T) {
+	root := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, "ok.go"), []byte("package sample\n"), 0o644); err != nil {
+		t.Fatalf("failed writing go file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("ignore"), 0o644); err != nil {
+		t.Fatalf("failed writing non-go file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".hidden.go"), []byte("package hidden\n"), 0o644); err != nil {
+		t.Fatalf("failed writing hidden file: %v", err)
+	}
+
+	hiddenDir := filepath.Join(root, ".git")
+	if err := os.MkdirAll(hiddenDir, 0o755); err != nil {
+		t.Fatalf("failed creating hidden dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hiddenDir, "ignored.go"), []byte("package git\n"), 0o644); err != nil {
+		t.Fatalf("failed writing hidden-dir go file: %v", err)
+	}
+
+	files, err := LoadFromDir(root)
+	if err != nil {
+		t.Fatalf("LoadFromDir returned error: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected exactly one visible go file, got %d (%v)", len(files), files)
+	}
+	if filepath.Base(files[0].Path) != "ok.go" {
+		t.Fatalf("expected ok.go, got %s", files[0].Path)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -211,7 +211,7 @@ func handleExtractCommand(args []string) error {
 func handleReportCommand(args []string) error {
 	reportCmd := flag.NewFlagSet("report", flag.ExitOnError)
 	path := reportCmd.String("path", "repodoctor-report.json", "Path to report file")
-	format := reportCmd.String("format", "text", "Output format (text, json)")
+	format := reportCmd.String("format", "text", "Output format (text, json, json-v1)")
 	jsonOut := reportCmd.Bool("json", false, "Output in JSON format")
 	reportCmd.Parse(args)
 
@@ -468,7 +468,7 @@ func generateReport(scorer *StructuralScorer, absPath, format string, verbose bo
 	reporter := NewColoredReporter(OutputFormat(format), colorEnabled)
 	report := reporter.GenerateReport(scorer, absPath, version)
 
-	if format == "json" {
+	if format == "json" || format == "json-v1" {
 		fmt.Println(reporter.Format(report))
 	} else {
 		// Use colored output for text format
@@ -495,7 +495,7 @@ func generateRuleEngineReport(absPath, format string, verbose bool, colorEnabled
 	}
 
 	reporter := NewColoredReporter(OutputFormat(format), colorEnabled)
-	if format == "json" {
+	if format == "json" || format == "json-v1" {
 		fmt.Println(reporter.Format(report))
 	} else {
 		var sb strings.Builder

--- a/main_command_dispatch_test.go
+++ b/main_command_dispatch_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestExecuteCommand_VersionAndHelpCommands(t *testing.T) {
+	versionOutput := captureStdout(t, func() {
+		if err := executeCommand("version", nil); err != nil {
+			t.Fatalf("version command failed: %v", err)
+		}
+	})
+	if !strings.Contains(versionOutput, "RepoDoctor v1.1.0") {
+		t.Fatalf("expected version output to include current version, got %q", versionOutput)
+	}
+
+	helpOutput := captureStdout(t, func() {
+		if err := executeCommand("help", nil); err != nil {
+			t.Fatalf("help command failed: %v", err)
+		}
+	})
+	if !strings.Contains(helpOutput, "RepoDoctor - Static Architecture Intelligence") {
+		t.Fatalf("expected help output header, got %q", helpOutput)
+	}
+}
+
+func TestExecuteCommand_UnknownCommandReturnsCLIErrorWithSuggestion(t *testing.T) {
+	err := executeCommand("ver", nil)
+	if err == nil {
+		t.Fatal("expected unknown command error")
+	}
+
+	var cliErr *CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected CLIError type, got %T", err)
+	}
+	if cliErr.Category != ErrorCLIUsage {
+		t.Fatalf("expected ErrorCLIUsage category, got %s", cliErr.Category)
+	}
+	if !strings.Contains(cliErr.Suggestion, "Did you mean 'version'?") {
+		t.Fatalf("expected suggestion to include version hint, got %q", cliErr.Suggestion)
+	}
+}
+
+func TestParseAnalyzeFlags_InvalidArgumentReturnsUsageError(t *testing.T) {
+	_, err := parseAnalyzeFlags([]string{"-unknown-flag"})
+	if err == nil {
+		t.Fatal("expected parseAnalyzeFlags to return usage error")
+	}
+
+	var cliErr *CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("expected CLIError type, got %T", err)
+	}
+	if cliErr.Category != ErrorCLIUsage {
+		t.Fatalf("expected ErrorCLIUsage, got %s", cliErr.Category)
+	}
+}
+
+func TestNormalizeAnalyzePathInput_EmptyRejected(t *testing.T) {
+	_, err := normalizeAnalyzePathInput("   ")
+	if err == nil {
+		t.Fatal("expected empty analyze path to be rejected")
+	}
+}
+
+func TestHasExplicitPathFlag_DetectionVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "short flag", args: []string{"-path", "."}, want: true},
+		{name: "long flag", args: []string{"--path", "."}, want: true},
+		{name: "short equals", args: []string{"-path=."}, want: true},
+		{name: "long equals", args: []string{"--path=."}, want: true},
+		{name: "no flag", args: []string{"."}, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasExplicitPathFlag(tc.args); got != tc.want {
+				t.Fatalf("hasExplicitPathFlag(%v)=%v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}

--- a/main_output_modes_test.go
+++ b/main_output_modes_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"RepoDoctor/internal/engine"
+	"strings"
+	"testing"
+)
+
+func TestGenerateReport_OutputModes_TextJSONJSONV1(t *testing.T) {
+	scorer := NewStructuralScorer(NewDependencyGraph(), nil, "")
+
+	t.Run("text", func(t *testing.T) {
+		output := captureStdout(t, func() {
+			_ = generateReport(scorer, ".", "text", false, false)
+		})
+		if !strings.Contains(output, "RepoDoctor Structural Analysis Report") {
+			t.Fatalf("expected text report header, got %q", output)
+		}
+	})
+
+	t.Run("json", func(t *testing.T) {
+		output := captureStdout(t, func() {
+			_ = generateReport(scorer, ".", "json", false, false)
+		})
+		if !strings.Contains(output, "\"schemaVersion\": \"v2\"") {
+			t.Fatalf("expected json output to include schema version, got %q", output)
+		}
+	})
+
+	t.Run("json-v1", func(t *testing.T) {
+		output := captureStdout(t, func() {
+			_ = generateReport(scorer, ".", "json-v1", false, false)
+		})
+		if !strings.Contains(output, "\"version\"") {
+			t.Fatalf("expected json-v1 output to include version field, got %q", output)
+		}
+		if strings.Contains(output, "\"schemaVersion\"") {
+			t.Fatalf("expected json-v1 output to omit v2 schema field, got %q", output)
+		}
+	})
+}
+
+func TestGenerateRuleEngineReport_JSONV1Path(t *testing.T) {
+	summary := &runtimeRuleSummary{
+		result:       &engine.ExecutionResult{Violations: nil, RulesExecuted: 0, TimedOut: false},
+		rulesInScope: 0,
+	}
+
+	output := captureStdout(t, func() {
+		_ = generateRuleEngineReport(".", "json-v1", false, false, nil, summary)
+	})
+
+	if !strings.Contains(output, "\"version\"") {
+		t.Fatalf("expected json-v1 rule-engine output to include version, got %q", output)
+	}
+	if strings.Contains(output, "\"schemaVersion\"") {
+		t.Fatalf("expected json-v1 rule-engine output to omit schemaVersion, got %q", output)
+	}
+}

--- a/progress_test.go
+++ b/progress_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProgressReporter_RenderAndLifecycle(t *testing.T) {
+	reporter := NewProgressReporter(true)
+
+	output := captureStdout(t, func() {
+		reporter.Start("Scanning", 4)
+		reporter.Update()
+		reporter.SetProgress(3)
+		reporter.Complete()
+	})
+
+	if !strings.Contains(output, "Scanning") {
+		t.Fatalf("expected stage name in progress output, got %q", output)
+	}
+	if reporter.currentStep != reporter.totalSteps {
+		t.Fatalf("expected reporter to complete all steps, current=%d total=%d", reporter.currentStep, reporter.totalSteps)
+	}
+	_ = reporter.GetElapsedTime()
+}
+
+func TestProgressReporter_RenderBarAndProgressBarHelpers(t *testing.T) {
+	reporter := NewProgressReporter(true)
+	bar := reporter.renderBar(50, 10)
+	if len([]rune(bar)) != 10 {
+		t.Fatalf("expected renderBar width 10, got %q", bar)
+	}
+
+	line := renderProgressBar("Rules", 1, 2)
+	if !strings.Contains(line, "Rules") || !strings.Contains(line, "50%") {
+		t.Fatalf("unexpected progress bar line: %q", line)
+	}
+}
+
+func TestCountFilesAndStageCount(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "a.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("failed to write go file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "b.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("failed to write non-go file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, ".hidden"), 0o755); err != nil {
+		t.Fatalf("failed creating hidden dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".hidden", "ignored.go"), []byte("package hidden\n"), 0o644); err != nil {
+		t.Fatalf("failed writing hidden go file: %v", err)
+	}
+
+	count := countFiles(tmp)
+	if count != 1 {
+		t.Fatalf("expected one visible go file, got %d", count)
+	}
+
+	if got := getStageCount("Scanning repository", tmp); got != 1 {
+		t.Fatalf("expected scanning stage count 1, got %d", got)
+	}
+	if got := getStageCount("Unknown", tmp); got != 10 {
+		t.Fatalf("expected default stage count 10, got %d", got)
+	}
+}

--- a/reporter_methods_test.go
+++ b/reporter_methods_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReporterWriteSections_TextMethods(t *testing.T) {
+	report := &StructuralReport{
+		Version: "1.1.0",
+		Path:    ".",
+		Score: &StructuralScore{
+			TotalScore:       85,
+			MaxScore:         100,
+			CircularPenalty:  10,
+			LayerPenalty:     5,
+			SizePenalty:      0,
+			GodObjectPenalty: 0,
+		},
+		Circular: []CycleViolation{{Path: []string{"a", "b"}}},
+		Layer:    []LayerViolation{{From: "repo", To: "handler"}},
+		Size:     []SizeViolation{{File: "big.go", Lines: 800, Threshold: 500}},
+		GodObject: []GodObjectViolation{{
+			File:        "god.go",
+			StructName:  "God",
+			FieldCount:  20,
+			MethodCount: 12,
+		}},
+		HasViolations: true,
+	}
+
+	var sb strings.Builder
+	writeHeader(&sb)
+	writeScoreSection(&sb, report)
+	writeViolationsSummary(&sb, report)
+	writeCircularViolations(&sb, report)
+	writeLayerViolations(&sb, report)
+	writeSizeViolations(&sb, report)
+	writeGodObjectViolations(&sb, report)
+	writeScoreBreakdown(&sb, report)
+
+	out := sb.String()
+	checks := []string{"STRUCTURAL HEALTH SCORE", "CIRCULAR DEPENDENCIES", "LAYER VIOLATIONS", "SIZE VIOLATIONS", "GOD OBJECT VIOLATIONS", "SCORE BREAKDOWN"}
+	for _, token := range checks {
+		if !strings.Contains(out, token) {
+			t.Fatalf("expected output to include %q, got %q", token, out)
+		}
+	}
+}

--- a/root_misc_coverage_test.go
+++ b/root_misc_coverage_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildDependencyGraph_FromImportMetadata(t *testing.T) {
+	imports := map[string]*ImportMetadata{
+		"a.go": {Package: "a", Imports: []string{"b"}},
+	}
+
+	graph := buildDependencyGraph(imports, false)
+	if graph.GetNodeCount() != 2 {
+		t.Fatalf("expected two nodes in graph, got %d", graph.GetNodeCount())
+	}
+	if graph.GetEdgeCount() != 1 {
+		t.Fatalf("expected one edge in graph, got %d", graph.GetEdgeCount())
+	}
+
+	deps := graph.GetDependencies("a.go")
+	if len(deps) != 1 || deps[0] != "b" {
+		t.Fatalf("expected dependency a.go -> b, got %v", deps)
+	}
+}
+
+func TestStructuralScorer_GettersAndExplanation(t *testing.T) {
+	scorer := NewStructuralScorer(NewDependencyGraph(), nil, "")
+	if scorer.GetCircularRule() == nil || scorer.GetLayerRule() == nil {
+		t.Fatal("expected circular and layer rule getters to return non-nil")
+	}
+
+	_ = scorer.CalculateScore()
+	if !strings.Contains(scorer.GetScoreExplanation(), "Structural Score Breakdown") {
+		t.Fatalf("expected score explanation output, got %q", scorer.GetScoreExplanation())
+	}
+
+	_ = scorer.HasCriticalViolations()
+}
+
+func TestStructuralScorer_HasCriticalViolations_WithCycle(t *testing.T) {
+	graph := NewDependencyGraph()
+	graph.AddEdge("a", "b")
+	graph.AddEdge("b", "a")
+
+	scorer := NewStructuralScorer(graph, nil, "")
+	if !scorer.HasCriticalViolations() {
+		t.Fatal("expected critical violations for cyclic graph")
+	}
+}
+
+func TestTrendAnalyzer_LoadHistoryMalformed_StartsFresh(t *testing.T) {
+	baseDir := t.TempDir()
+	analyzer := NewTrendAnalyzer(baseDir)
+
+	historyDir := filepath.Join(baseDir, ".repodoctor")
+	if err := os.MkdirAll(historyDir, 0o755); err != nil {
+		t.Fatalf("failed creating history dir: %v", err)
+	}
+
+	historyPath := filepath.Join(historyDir, "history.json")
+	if err := os.WriteFile(historyPath, []byte("{not-json"), 0o644); err != nil {
+		t.Fatalf("failed writing malformed history: %v", err)
+	}
+
+	if err := analyzer.LoadHistory(); err != nil {
+		t.Fatalf("expected malformed history to be tolerated, got error: %v", err)
+	}
+
+	if got := len(analyzer.GetAllHistory()); got != 0 {
+		t.Fatalf("expected empty history after malformed input, got %d entries", got)
+	}
+}
+
+func TestRuleMetadata_Accessors(t *testing.T) {
+	graph := NewDependencyGraph()
+
+	circular := NewCircularDependencyRule(graph)
+	if circular.Name() != "circular-dependency" {
+		t.Fatalf("unexpected circular rule name: %s", circular.Name())
+	}
+	if circular.Message() != "No circular dependencies detected" {
+		t.Fatalf("unexpected circular no-violation message: %q", circular.Message())
+	}
+
+	layer := NewLayerValidationRule(graph)
+	if layer.Name() != "layer-validation" {
+		t.Fatalf("unexpected layer rule name: %s", layer.Name())
+	}
+	if layer.Severity() != "high" {
+		t.Fatalf("unexpected layer rule severity: %s", layer.Severity())
+	}
+}
+
+func TestTrendAnalyzer_GetAllHistory(t *testing.T) {
+	analyzer := NewTrendAnalyzer(t.TempDir())
+	if err := analyzer.AppendScore(90); err != nil {
+		t.Fatalf("failed appending score: %v", err)
+	}
+	history := analyzer.GetAllHistory()
+	if len(history) != 1 {
+		t.Fatalf("expected one history entry, got %d", len(history))
+	}
+}

--- a/root_testio_helpers_test.go
+++ b/root_testio_helpers_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed creating stdout pipe: %v", err)
+	}
+	os.Stdout = writer
+
+	defer func() {
+		os.Stdout = original
+	}()
+
+	fn()
+	_ = writer.Close()
+
+	out, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("failed reading stdout capture: %v", err)
+	}
+	return string(out)
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	original := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed creating stderr pipe: %v", err)
+	}
+	os.Stderr = writer
+
+	defer func() {
+		os.Stderr = original
+	}()
+
+	fn()
+	_ = writer.Close()
+
+	out, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("failed reading stderr capture: %v", err)
+	}
+	return string(out)
+}
+
+func normalizeNewlines(s string) string {
+	return strings.ReplaceAll(s, "\r\n", "\n")
+}

--- a/scripts/v120_release_stabilization_gate.ps1
+++ b/scripts/v120_release_stabilization_gate.ps1
@@ -1,0 +1,26 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    Write-Host "==> $Name"
+    Invoke-Expression $Command
+}
+
+$determinismRegex = "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
+$rulesEdgeRegex = "TestCircularDependencyRule_.*|TestGodObjectRule_.*|TestCategories_AllAndValidations|TestExampleRule_ImplementsContract|TestLoadFromDir_FiltersHiddenAndNonGoFiles"
+$parserExtractorRegex = "TestImportExtractor_ExtractFromFile_MalformedFailSoft|TestImportExtractor_ExtractFromDir_SkipsMalformedKeepsValid|FuzzImportExtractor_ExtractFromFile_NoPanic|FuzzParsePythonImportLine_NoPanic|FuzzParsePythonDynamicImport_NoPanic|TestPythonAdapter_CollectEvidence_FailSoftOnMalformedAndOversized"
+
+Invoke-Step -Name "build" -Command "go build ."
+Invoke-Step -Name "core test suite" -Command "go test ./..."
+Invoke-Step -Name "static analysis" -Command "go vet ./..."
+Invoke-Step -Name "v1.2 rules edge-case regression pack" -Command "go test ./internal/rules -run '$rulesEdgeRegex'"
+Invoke-Step -Name "v1.2 parser/extractor malformed-corpus pack" -Command "go test ./... -run '$parserExtractorRegex'"
+Invoke-Step -Name "v1.2 property-based determinism pack" -Command "go test . -run 'TestProperty_'"
+Invoke-Step -Name "determinism confidence suite" -Command "go test ./... -run '$determinismRegex'"
+Invoke-Step -Name "self-analysis 100/100 gate" -Command "go run . analyze -path ."
+
+Write-Host "v1.2 release stabilization gate passed."

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gopkg.in/fsnotify.v1"
+)
+
+func TestWatcher_NewStartStopAndIsRunning(t *testing.T) {
+	tmp := t.TempDir()
+	w, err := NewWatcher(tmp)
+	if err != nil {
+		t.Fatalf("NewWatcher failed: %v", err)
+	}
+
+	if w.IsRunning() {
+		t.Fatal("new watcher should not be running")
+	}
+
+	if err := w.Start(); err != nil {
+		t.Fatalf("watcher start failed: %v", err)
+	}
+	if !w.IsRunning() {
+		t.Fatal("watcher expected running after start")
+	}
+
+	if err := w.Stop(); err != nil {
+		t.Fatalf("watcher stop failed: %v", err)
+	}
+	if w.IsRunning() {
+		t.Fatal("watcher should not be running after stop")
+	}
+}
+
+func TestWatcher_HandleEventNonGoAndCreateDirPaths(t *testing.T) {
+	tmp := t.TempDir()
+	childDir := filepath.Join(tmp, "child")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		t.Fatalf("failed creating child dir: %v", err)
+	}
+
+	w, err := NewWatcher(tmp)
+	if err != nil {
+		t.Fatalf("NewWatcher failed: %v", err)
+	}
+	defer func() { _ = w.Stop() }()
+
+	// keep debounce from triggering runAnalyze during this test
+	w.debounceTime = 5 * time.Second
+
+	if err := w.Start(); err != nil {
+		t.Fatalf("watcher start failed: %v", err)
+	}
+
+	// Non-go file should be ignored early.
+	w.handleEvent(fsnotify.Event{Name: filepath.Join(tmp, "notes.txt"), Op: fsnotify.Write})
+
+	// Create event for directory should traverse addDirectoryIfNeeded path.
+	w.handleEvent(fsnotify.Event{Name: childDir, Op: fsnotify.Create})
+}


### PR DESCRIPTION
## Summary
- Delivers M5 (v1.2) chain: RD-12001..RD-12006 on `dev`.
- Includes model/root/rules test hardening, parser-extractor fuzz abuse resistance, property-based determinism checks, and CI v1.2 stabilization gate activation.
- Keeps mandatory quality baseline and determinism/self-analysis gates green across Linux+Windows CI.

## Included PRs
- #282, #283, #284, #285, #286, #287

## Release Validation
- `go test ./...`
- `go vet ./...`
- `go run . analyze -path .` (100/100)
- `scripts/v120_release_stabilization_gate.ps1`