### PR TITLE
feat(rd-13001): add default-off structured logging boundaries

### DIFF
--- a/architecture_boundary_test.go
+++ b/architecture_boundary_test.go
@@ -79,9 +79,10 @@ func TestArchitecture_PurityBoundary_NoSideEffectImportsInSensitivePackages(t *t
 		modulePath + "/internal/rules",
 	}
 	bannedImports := map[string]struct{}{
-		"os/exec": {},
-		"syscall": {},
-		"unsafe":  {},
+		"os/exec":                       {},
+		"syscall":                       {},
+		"unsafe":                        {},
+		modulePath + "/internal/logger": {},
 	}
 
 	fset := token.NewFileSet()
@@ -136,6 +137,7 @@ func boundaryViolation(fromPkg, toPkg, modulePath string) (string, bool) {
 	enginePkg := modulePath + "/internal/engine"
 	modelPkg := modulePath + "/internal/model"
 	domainPkg := modulePath + "/internal/domain"
+	loggerPkg := modulePath + "/internal/logger"
 
 	if !strings.HasPrefix(fromPkg, modulePath+"/internal/") {
 		return "", false
@@ -153,7 +155,7 @@ func boundaryViolation(fromPkg, toPkg, modulePath string) (string, bool) {
 	}
 
 	if fromPkg == analysisPkg {
-		if toPkg != languagesPkg && toPkg != modelPkg && toPkg != domainPkg {
+		if toPkg != languagesPkg && toPkg != modelPkg && toPkg != domainPkg && toPkg != loggerPkg {
 			return fmt.Sprintf("%s imports forbidden internal dependency %s", fromPkg, toPkg), true
 		}
 		return "", false

--- a/internal/analysis/orchestrator.go
+++ b/internal/analysis/orchestrator.go
@@ -5,12 +5,14 @@ import (
 	"sort"
 
 	"RepoDoctor/internal/languages"
+	"RepoDoctor/internal/logger"
 	"RepoDoctor/internal/model"
 )
 
 // Orchestrator coordinates language detection and adapter-driven analysis steps.
 type Orchestrator struct {
 	detector languages.LanguageDetector
+	logger   logger.Logger
 }
 
 // Result contains adapter-driven analysis output.
@@ -23,7 +25,15 @@ type Result struct {
 
 // NewOrchestrator creates a new analysis orchestrator.
 func NewOrchestrator(detector languages.LanguageDetector) *Orchestrator {
-	return &Orchestrator{detector: detector}
+	return NewOrchestratorWithLogger(detector, logger.NewNoop())
+}
+
+// NewOrchestratorWithLogger creates a new analysis orchestrator with structured logger wiring.
+func NewOrchestratorWithLogger(detector languages.LanguageDetector, log logger.Logger) *Orchestrator {
+	if log == nil {
+		log = logger.NewNoop()
+	}
+	return &Orchestrator{detector: detector, logger: log}
 }
 
 // Analyze executes the runtime pipeline: detect adapter -> detect files -> metrics -> graph.
@@ -32,10 +42,14 @@ func (o *Orchestrator) Analyze(repoPath string) (*Result, error) {
 		return nil, fmt.Errorf("language detector is required")
 	}
 
+	o.logger.Debug("analysis.start", "repo_path", repoPath)
+
 	adapter, err := o.detector.DetectLanguage(repoPath)
 	if err != nil {
+		o.logger.Error("analysis.language_detection_failed", "repo_path", repoPath, "error", err)
 		return nil, fmt.Errorf("language detection failed: %w", err)
 	}
+	o.logger.Info("analysis.language_detected", "adapter", adapter.Name())
 
 	capabilities := adapter.Capabilities()
 	if !capabilities.SupportsDependencyGraph {
@@ -47,19 +61,24 @@ func (o *Orchestrator) Analyze(repoPath string) (*Result, error) {
 
 	files, err := adapter.DetectFiles(repoPath)
 	if err != nil {
+		o.logger.Error("analysis.file_detection_failed", "adapter", adapter.Name(), "error", err)
 		return nil, fmt.Errorf("file detection failed for %s: %w", adapter.Name(), err)
 	}
 	sort.Strings(files)
+	o.logger.Debug("analysis.files_detected", "adapter", adapter.Name(), "count", len(files))
 
 	metrics, err := adapter.CollectMetrics(files)
 	if err != nil {
+		o.logger.Error("analysis.metrics_failed", "adapter", adapter.Name(), "error", err)
 		return nil, fmt.Errorf("metrics collection failed for %s: %w", adapter.Name(), err)
 	}
 
 	graph, err := adapter.BuildDependencyGraph(files)
 	if err != nil {
+		o.logger.Error("analysis.graph_failed", "adapter", adapter.Name(), "error", err)
 		return nil, fmt.Errorf("dependency graph build failed for %s: %w", adapter.Name(), err)
 	}
+	o.logger.Info("analysis.completed", "adapter", adapter.Name(), "file_count", len(files))
 
 	return &Result{
 		AdapterName: adapter.Name(),

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,80 @@
+package logger
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Logger defines a minimal structured logging contract for orchestration/CLI layers.
+type Logger interface {
+	Debug(msg string, attrs ...any)
+	Info(msg string, attrs ...any)
+	Warn(msg string, attrs ...any)
+	Error(msg string, attrs ...any)
+}
+
+type slogLogger struct {
+	delegate *slog.Logger
+}
+
+func (l *slogLogger) Debug(msg string, attrs ...any) { l.delegate.Debug(msg, attrs...) }
+func (l *slogLogger) Info(msg string, attrs ...any)  { l.delegate.Info(msg, attrs...) }
+func (l *slogLogger) Warn(msg string, attrs ...any)  { l.delegate.Warn(msg, attrs...) }
+func (l *slogLogger) Error(msg string, attrs ...any) { l.delegate.Error(msg, attrs...) }
+
+type noopLogger struct{}
+
+func (l *noopLogger) Debug(string, ...any) {}
+func (l *noopLogger) Info(string, ...any)  {}
+func (l *noopLogger) Warn(string, ...any)  {}
+func (l *noopLogger) Error(string, ...any) {}
+
+// NewNoop returns a logger implementation that never emits output.
+func NewNoop() Logger {
+	return &noopLogger{}
+}
+
+// NewSlog wraps a slog.Logger behind the repository logging abstraction.
+func NewSlog(delegate *slog.Logger) Logger {
+	if delegate == nil {
+		return NewNoop()
+	}
+	return &slogLogger{delegate: delegate}
+}
+
+// NewFromEnv returns a structured logger controlled by REPODOCTOR_LOG_LEVEL.
+// Default is disabled (no-op), preserving deterministic output behavior.
+func NewFromEnv() Logger {
+	levelText := strings.TrimSpace(strings.ToLower(os.Getenv("REPODOCTOR_LOG_LEVEL")))
+	level, enabled := parseLevel(levelText)
+	if !enabled {
+		return NewNoop()
+	}
+
+	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+	return NewSlog(slog.New(handler))
+}
+
+func parseLevel(value string) (slog.Level, bool) {
+	switch value {
+	case "debug":
+		return slog.LevelDebug, true
+	case "info":
+		return slog.LevelInfo, true
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error":
+		return slog.LevelError, true
+	default:
+		return slog.LevelInfo, false
+	}
+}
+
+// NewTestLogger returns a structured logger writing to the provided writer.
+// Intended for deterministic unit tests.
+func NewTestLogger(writer io.Writer, level slog.Level) Logger {
+	handler := slog.NewTextHandler(writer, &slog.HandlerOptions{Level: level})
+	return NewSlog(slog.New(handler))
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,83 @@
+package logger
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestNewFromEnv_DefaultIsNoop(t *testing.T) {
+	t.Setenv("REPODOCTOR_LOG_LEVEL", "")
+
+	log := NewFromEnv()
+	log.Debug("debug", "k", "v")
+	log.Info("info", "k", "v")
+	log.Warn("warn", "k", "v")
+	log.Error("error", "k", "v")
+}
+
+func TestNewFromEnv_InvalidValueFallsBackToNoop(t *testing.T) {
+	t.Setenv("REPODOCTOR_LOG_LEVEL", "invalid")
+
+	log := NewFromEnv()
+	log.Info("ignored")
+}
+
+func TestNewTestLogger_EmitsStructuredOutput(t *testing.T) {
+	var buf bytes.Buffer
+	log := NewTestLogger(&buf, slog.LevelDebug)
+
+	log.Info("pipeline.start", "adapter", "Go", "files", 3)
+
+	out := buf.String()
+	if !strings.Contains(out, "pipeline.start") {
+		t.Fatalf("expected message in output, got %q", out)
+	}
+	if !strings.Contains(out, "adapter=Go") || !strings.Contains(out, "files=3") {
+		t.Fatalf("expected key-value attrs in output, got %q", out)
+	}
+}
+
+func TestParseLevel(t *testing.T) {
+	cases := []struct {
+		input   string
+		enabled bool
+	}{
+		{input: "debug", enabled: true},
+		{input: "info", enabled: true},
+		{input: "warn", enabled: true},
+		{input: "error", enabled: true},
+		{input: "", enabled: false},
+		{input: "off", enabled: false},
+	}
+
+	for _, tc := range cases {
+		_, enabled := parseLevel(tc.input)
+		if enabled != tc.enabled {
+			t.Fatalf("parseLevel(%q) enabled expected %v, got %v", tc.input, tc.enabled, enabled)
+		}
+	}
+}
+
+func TestNewSlog_NilDelegateReturnsNoop(t *testing.T) {
+	log := NewSlog(nil)
+	log.Info("safe")
+
+	if _, ok := log.(*noopLogger); !ok {
+		t.Fatal("expected noop logger when delegate is nil")
+	}
+}
+
+func TestNewFromEnv_RecognizesConfiguredLevels(t *testing.T) {
+	levels := []string{"debug", "info", "warn", "error"}
+	for _, level := range levels {
+		t.Run(level, func(t *testing.T) {
+			t.Setenv("REPODOCTOR_LOG_LEVEL", level)
+			log := NewFromEnv()
+			if _, ok := log.(*noopLogger); ok {
+				t.Fatalf("expected configured level %q to enable logger", level)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"RepoDoctor/internal/analysis"
 	"RepoDoctor/internal/domain"
 	"RepoDoctor/internal/languages"
+	"RepoDoctor/internal/logger"
 	"RepoDoctor/internal/model"
 	"flag"
 	"fmt"
@@ -406,7 +407,7 @@ func runAdapterPipeline(absPath string) (*analysis.Result, error) {
 	detector := languages.NewRepositoryLanguageDetectorWithPolicy(ignoreStrategy, policy)
 	registerCoreAdapters(detector, config)
 
-	orchestrator := analysis.NewOrchestrator(detector)
+	orchestrator := analysis.NewOrchestratorWithLogger(detector, logger.NewFromEnv())
 	return orchestrator.Analyze(absPath)
 }
 


### PR DESCRIPTION
## Summary
- Introduces a default-off structured logging abstraction in `internal/logger` built on `slog`.
- Wires logging into `internal/analysis` orchestration from CLI composition (`main`), keeping logs disabled unless `REPODOCTOR_LOG_LEVEL` is explicitly set.
- Strengthens architecture boundaries so `internal/model`, `internal/domain`, and `internal/rules` cannot import `internal/logger`.

## Validation
- `go test ./...`
- `go vet ./...`
- `go run . analyze -path .` (100/100)
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`
- Conditional race check attempted: `go test -race ./...` (blocked in this environment: CGO compiler `gcc` missing)

Closes #263