### PR TITLE
feat(rd-13002): add safe opt-in pprof hooks

### DIFF
--- a/analysis_service.go
+++ b/analysis_service.go
@@ -13,6 +13,7 @@ type AnalyzeRequest struct {
 	Verbose         bool
 	ColorEnabled    bool
 	ExitOnViolation bool
+	Profiling       profilingRequest
 }
 
 type AnalysisService struct{}
@@ -24,6 +25,19 @@ func NewAnalysisService() *AnalysisService {
 func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	absPath := validatePath(request.Path)
 	InitColorFormatter(request.ColorEnabled)
+	profiler, profileErr := startProfiling(request.Profiling)
+	if profileErr != nil {
+		fmt.Fprintf(os.Stderr, "%s", ColorError(fmt.Sprintf("Error: profiling setup failed: %v\n", profileErr)))
+		return 1
+	}
+
+	if profiler != nil {
+		defer func() {
+			if stopErr := profiler.Stop(); stopErr != nil {
+				fmt.Fprintf(os.Stderr, "%s", ColorWarn(fmt.Sprintf("Warning: profiling finalization failed: %v\n", stopErr)))
+			}
+		}()
+	}
 
 	progress := NewProgressReporter(!request.Verbose)
 	progress.Start("Scanning repository", getStageCount("Scanning repository", absPath))
@@ -34,9 +48,6 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	analysisResult, err := runAdapterPipeline(absPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s", ColorError(fmt.Sprintf("Error: analysis pipeline failed: %v\n", err)))
-		if request.ExitOnViolation {
-			os.Exit(1)
-		}
 		return 1
 	}
 
@@ -76,10 +87,6 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	handleTrendAnalysis(absPath, report, request.Verbose)
 
 	exitCode := determineExitCode(report)
-	if request.ExitOnViolation && exitCode != 0 {
-		os.Exit(exitCode)
-	}
-
 	return exitCode
 }
 

--- a/analysis_service_test.go
+++ b/analysis_service_test.go
@@ -29,7 +29,7 @@ func TestAnalysisService_RunAndRunAnalyze_SuccessPath(t *testing.T) {
 		t.Fatalf("expected analysis service success code 0, got %d", code)
 	}
 
-	if code := runAnalyze(tmp, "text", false, false, false); code != 0 {
+	if code := runAnalyze(tmp, "text", false, false, false, profilingRequest{}); code != 0 {
 		t.Fatalf("expected runAnalyze wrapper success code 0, got %d", code)
 	}
 }

--- a/interactive.go
+++ b/interactive.go
@@ -78,7 +78,7 @@ func (i *InteractiveMode) analyzeMenu() {
 	switch choice {
 	case 1:
 		fmt.Println("\nAnalyzing current repository...")
-		runAnalyze(".", "text", false, true, true)
+		runAnalyze(".", "text", false, true, true, profilingRequest{})
 	case 2:
 		path := i.io.readString("\nEnter path to analyze: ")
 		if path == "" {
@@ -86,7 +86,7 @@ func (i *InteractiveMode) analyzeMenu() {
 			return
 		}
 		fmt.Printf("\nAnalyzing repository: %s\n", path)
-		runAnalyze(path, "text", false, true, true)
+		runAnalyze(path, "text", false, true, true, profilingRequest{})
 	case 3:
 		return
 	default:

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func handleAnalyzeCommand(args []string) error {
 		return nil
 	}
 
-	runAnalyze(req.path, req.format, req.verbose, req.colorEnabled, true)
+	runAnalyze(req.path, req.format, req.verbose, req.colorEnabled, true, req.profiling)
 	return nil
 }
 
@@ -85,6 +85,7 @@ type analyzeCommandRequest struct {
 	verbose      bool
 	colorEnabled bool
 	watch        bool
+	profiling    profilingRequest
 }
 
 func composeAnalyzeRequest(args []string) (*analyzeCommandRequest, error) {
@@ -99,12 +100,18 @@ func composeAnalyzeRequest(args []string) (*analyzeCommandRequest, error) {
 		return nil, normalizeErr
 	}
 
+	profiling, profilingErr := buildProfilingRequest(normalizedPath, parsed.cpuProfile, parsed.memProfile, parsed.watch)
+	if profilingErr != nil {
+		return nil, profilingErr
+	}
+
 	return &analyzeCommandRequest{
 		path:         normalizedPath,
 		format:       parsed.outputFormat,
 		verbose:      parsed.verbose,
 		colorEnabled: !parsed.noColor,
 		watch:        parsed.watch,
+		profiling:    profiling,
 	}, nil
 }
 
@@ -114,6 +121,8 @@ type analyzeFlagInput struct {
 	verbose      bool
 	watch        bool
 	noColor      bool
+	cpuProfile   string
+	memProfile   string
 	positional   []string
 }
 
@@ -127,6 +136,8 @@ func parseAnalyzeFlags(args []string) (*analyzeFlagInput, error) {
 	jsonOut := analyzeCmd.Bool("json", false, "Output in JSON format")
 	watch := analyzeCmd.Bool("watch", false, "Enable watch mode for continuous analysis")
 	noColor := analyzeCmd.Bool("no-color", false, "Disable colored output")
+	cpuProfile := analyzeCmd.String("cpu-profile", "", "Write CPU profile to a file under analyze path")
+	memProfile := analyzeCmd.String("mem-profile", "", "Write heap profile to a file under analyze path")
 
 	if err := analyzeCmd.Parse(args); err != nil {
 		return nil, NewCLIError(
@@ -148,6 +159,8 @@ func parseAnalyzeFlags(args []string) (*analyzeFlagInput, error) {
 		verbose:      *verbose,
 		watch:        *watch,
 		noColor:      *noColor,
+		cpuProfile:   *cpuProfile,
+		memProfile:   *memProfile,
 		positional:   analyzeCmd.Args(),
 	}, nil
 }
@@ -299,6 +312,8 @@ Arguments:
     -verbose   Enable verbose output
     -watch     Enable watch mode for continuous analysis
     -no-color  Disable colored output (default: enabled)
+    -cpu-profile  Write CPU profile under analyze path (opt-in)
+    -mem-profile  Write heap profile under analyze path (opt-in)
 
   extract [options]
     -path      Directory path to extract imports from (default: current directory)
@@ -323,15 +338,22 @@ Examples:
   repodoctor version`)
 }
 
-func runAnalyze(path, format string, verbose bool, colorEnabled bool, exitOnViolation bool) int {
+func runAnalyze(path, format string, verbose bool, colorEnabled bool, exitOnViolation bool, profiling profilingRequest) int {
 	service := NewAnalysisService()
-	return service.Run(AnalyzeRequest{
+	exitCode := service.Run(AnalyzeRequest{
 		Path:            path,
 		Format:          format,
 		Verbose:         verbose,
 		ColorEnabled:    colorEnabled,
 		ExitOnViolation: exitOnViolation,
+		Profiling:       profiling,
 	})
+
+	if exitOnViolation && exitCode != 0 {
+		os.Exit(exitCode)
+	}
+
+	return exitCode
 }
 
 // determineExitCode returns the appropriate exit code based on report

--- a/profiling.go
+++ b/profiling.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"strings"
+)
+
+type profilingRequest struct {
+	cpuProfilePath string
+	memProfilePath string
+}
+
+func (r profilingRequest) enabled() bool {
+	return strings.TrimSpace(r.cpuProfilePath) != "" || strings.TrimSpace(r.memProfilePath) != ""
+}
+
+func buildProfilingRequest(analyzeRoot, cpuPath, memPath string, watch bool) (profilingRequest, error) {
+	request := profilingRequest{}
+	if watch && (strings.TrimSpace(cpuPath) != "" || strings.TrimSpace(memPath) != "") {
+		return request, NewCLIError(
+			ErrorInvalidArgument,
+			"Profiling cannot be enabled in watch mode",
+			"Use analyze without -watch when collecting profiles",
+			nil,
+		)
+	}
+
+	var err error
+	request.cpuProfilePath, err = sanitizeProfilePath(analyzeRoot, cpuPath)
+	if err != nil {
+		return profilingRequest{}, err
+	}
+
+	request.memProfilePath, err = sanitizeProfilePath(analyzeRoot, memPath)
+	if err != nil {
+		return profilingRequest{}, err
+	}
+
+	return request, nil
+}
+
+func sanitizeProfilePath(analyzeRoot, profilePath string) (string, error) {
+	trimmed := strings.TrimSpace(profilePath)
+	if trimmed == "" {
+		return "", nil
+	}
+
+	root := filepath.Clean(analyzeRoot)
+	if resolvedRoot, err := filepath.EvalSymlinks(root); err == nil {
+		root = filepath.Clean(resolvedRoot)
+	}
+
+	target := filepath.Clean(trimmed)
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(root, target)
+	}
+
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return "", HandleInvalidPathError(profilePath, err)
+	}
+	absTarget = filepath.Clean(absTarget)
+	if resolvedTarget, err := filepath.EvalSymlinks(absTarget); err == nil {
+		absTarget = filepath.Clean(resolvedTarget)
+	}
+
+	rel, err := filepath.Rel(root, absTarget)
+	if err != nil {
+		return "", NewCLIError(
+			ErrorInvalidArgument,
+			fmt.Sprintf("Invalid profile path: %s", profilePath),
+			"Use a path under the analyze root directory",
+			err,
+		)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", NewCLIError(
+			ErrorInvalidArgument,
+			fmt.Sprintf("Profile path escapes analyze root: %s", profilePath),
+			"Profile artifacts must stay under the analyze root directory",
+			nil,
+		)
+	}
+
+	return absTarget, nil
+}
+
+type profileSession struct {
+	cpuFile *os.File
+	memPath string
+}
+
+func startProfiling(request profilingRequest) (*profileSession, error) {
+	if !request.enabled() {
+		return nil, nil
+	}
+
+	session := &profileSession{memPath: request.memProfilePath}
+
+	if request.cpuProfilePath != "" {
+		if err := ensureProfileParentDir(request.cpuProfilePath); err != nil {
+			return nil, err
+		}
+		cpuFile, err := os.Create(request.cpuProfilePath)
+		if err != nil {
+			return nil, err
+		}
+		if err := pprof.StartCPUProfile(cpuFile); err != nil {
+			_ = cpuFile.Close()
+			return nil, err
+		}
+		session.cpuFile = cpuFile
+	}
+
+	return session, nil
+}
+
+func (s *profileSession) Stop() error {
+	if s == nil {
+		return nil
+	}
+
+	if s.cpuFile != nil {
+		pprof.StopCPUProfile()
+		if err := s.cpuFile.Close(); err != nil {
+			return err
+		}
+	}
+
+	if s.memPath != "" {
+		if err := ensureProfileParentDir(s.memPath); err != nil {
+			return err
+		}
+		memFile, err := os.Create(s.memPath)
+		if err != nil {
+			return err
+		}
+		runtime.GC()
+		if err := pprof.WriteHeapProfile(memFile); err != nil {
+			_ = memFile.Close()
+			return err
+		}
+		if err := memFile.Close(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ensureProfileParentDir(path string) error {
+	dir := filepath.Dir(path)
+	if dir == "" || dir == "." {
+		return nil
+	}
+	return os.MkdirAll(dir, 0o755)
+}

--- a/profiling_test.go
+++ b/profiling_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildProfilingRequest_DefaultOff(t *testing.T) {
+	root := t.TempDir()
+	request, err := buildProfilingRequest(root, "", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if request.enabled() {
+		t.Fatal("profiling should be disabled by default")
+	}
+}
+
+func TestBuildProfilingRequest_WatchModeRejected(t *testing.T) {
+	root := t.TempDir()
+	_, err := buildProfilingRequest(root, "cpu.pprof", "", true)
+	if err == nil {
+		t.Fatal("expected watch mode + profiling to be rejected")
+	}
+}
+
+func TestBuildProfilingRequest_ProfilePathRootBounded(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(root, "..", "escape", "cpu.pprof")
+
+	_, err := buildProfilingRequest(root, outside, "", false)
+	if err == nil {
+		t.Fatal("expected path outside root to be rejected")
+	}
+}
+
+func TestBuildProfilingRequest_ProfilePathSanitizedUnderRoot(t *testing.T) {
+	root := t.TempDir()
+	request, err := buildProfilingRequest(root, filepath.Join(".repodoctor", "profiles", "cpu.pprof"), "", false)
+	if err != nil {
+		t.Fatalf("unexpected sanitize error: %v", err)
+	}
+
+	if !pathWithinRoot(root, request.cpuProfilePath) {
+		t.Fatalf("expected cpu profile path under root, got %s", request.cpuProfilePath)
+	}
+}
+
+func TestStartProfiling_CreatesCpuAndMemArtifacts(t *testing.T) {
+	root := t.TempDir()
+	request, err := buildProfilingRequest(root, ".repodoctor/profiles/cpu.pprof", ".repodoctor/profiles/mem.pprof", false)
+	if err != nil {
+		t.Fatalf("unexpected request error: %v", err)
+	}
+
+	session, err := startProfiling(request)
+	if err != nil {
+		t.Fatalf("startProfiling failed: %v", err)
+	}
+
+	for i := 0; i < 100000; i++ {
+		_ = i * i
+	}
+
+	if err := session.Stop(); err != nil {
+		t.Fatalf("profile stop failed: %v", err)
+	}
+
+	if info, statErr := os.Stat(request.cpuProfilePath); statErr != nil || info.Size() == 0 {
+		t.Fatalf("expected non-empty cpu profile file at %s", request.cpuProfilePath)
+	}
+	if info, statErr := os.Stat(request.memProfilePath); statErr != nil || info.Size() == 0 {
+		t.Fatalf("expected non-empty mem profile file at %s", request.memProfilePath)
+	}
+}
+
+func TestComposeAnalyzeRequest_ParsesAndNormalizesProfileFlags(t *testing.T) {
+	root := t.TempDir()
+	req, err := composeAnalyzeRequest([]string{"-path", root, "-cpu-profile", "profiles/cpu.pprof", "-mem-profile", "profiles/mem.pprof"})
+	if err != nil {
+		t.Fatalf("unexpected compose error: %v", err)
+	}
+
+	if !req.profiling.enabled() {
+		t.Fatal("expected profiling to be enabled")
+	}
+	if !pathWithinRoot(root, req.profiling.cpuProfilePath) {
+		t.Fatalf("expected cpu profile under root, got %s", req.profiling.cpuProfilePath)
+	}
+	if !pathWithinRoot(root, req.profiling.memProfilePath) {
+		t.Fatalf("expected mem profile under root, got %s", req.profiling.memProfilePath)
+	}
+}
+
+func pathWithinRoot(root, target string) bool {
+	resolvedRoot, err := filepath.Abs(filepath.Clean(root))
+	if err != nil {
+		return false
+	}
+	if next, resolveErr := filepath.EvalSymlinks(resolvedRoot); resolveErr == nil {
+		resolvedRoot = filepath.Clean(next)
+	}
+
+	resolvedTarget, err := filepath.Abs(filepath.Clean(target))
+	if err != nil {
+		return false
+	}
+	if next, resolveErr := filepath.EvalSymlinks(resolvedTarget); resolveErr == nil {
+		resolvedTarget = filepath.Clean(next)
+	}
+
+	rel, relErr := filepath.Rel(resolvedRoot, resolvedTarget)
+	if relErr != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/watcher.go
+++ b/watcher.go
@@ -155,7 +155,7 @@ func (w *Watcher) runAnalysis(changedFile string) {
 	fmt.Println(strings.Repeat("=", 60))
 
 	// Run analysis
-	if code := runAnalyze(w.path, "text", false, true, false); code != 0 {
+	if code := runAnalyze(w.path, "text", false, true, false, profilingRequest{}); code != 0 {
 		fmt.Printf("Analysis finished with exit code %d (watch continues).\n", code)
 	}
 }
@@ -220,7 +220,7 @@ func WatchAndAnalyze(path string) error {
 	// Run initial analysis
 	fmt.Println("Running initial analysis...")
 	fmt.Println()
-	if code := runAnalyze(path, "text", false, true, false); code != 0 {
+	if code := runAnalyze(path, "text", false, true, false, profilingRequest{}); code != 0 {
 		fmt.Printf("Initial analysis finished with exit code %d (watch continues).\n", code)
 	}
 


### PR DESCRIPTION
## Summary
- Adds explicit opt-in profiling hooks for `analyze` with `-cpu-profile` and `-mem-profile` flags; default remains off.
- Enforces operational safety: no profiling in watch mode, no HTTP listeners, and profile artifact paths must be sanitized/root-bounded under the analyze target.
- Adds unit coverage for path safety and profile artifact generation, and wires new profiling request through analyze service flow.

## Security Review Note
- Activation surface is CLI-flag based only (`-cpu-profile`, `-mem-profile`), default-off.
- No network listeners are introduced (no `net/http/pprof` server usage).
- Output paths are canonicalized and constrained to analyze root; path-escape attempts are rejected.
- Profiling finalization failures are surfaced as warnings without changing core analysis semantics.

## Validation
- `go test ./...`
- `go vet ./...`
- `go run . analyze -path .` (100/100)
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`

Closes #264