### PR TITLE
feat(rd-13003): harden error taxonomy and wrapping semantics

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+const debugErrorsEnv = "REPODOCTOR_DEBUG_ERRORS"
+
 // ErrorCategory represents the category of an error
 type ErrorCategory string
 
@@ -27,6 +29,18 @@ type CLIError struct {
 	OriginalErr error
 }
 
+// ErrorClass provides a stable taxonomy for machine-readable error grouping.
+type ErrorClass string
+
+const (
+	ErrorClassUsage         ErrorClass = "usage"
+	ErrorClassConfiguration ErrorClass = "configuration"
+	ErrorClassAnalysis      ErrorClass = "analysis"
+	ErrorClassRuntime       ErrorClass = "runtime"
+	ErrorClassIO            ErrorClass = "io"
+	ErrorClassValidation    ErrorClass = "validation"
+)
+
 // Error implements the error interface
 func (e *CLIError) Error() string {
 	if e.OriginalErr != nil {
@@ -35,15 +49,40 @@ func (e *CLIError) Error() string {
 	return fmt.Sprintf("%s: %s", e.Category, e.Message)
 }
 
+// Unwrap enables errors.Is/errors.As interoperability.
+func (e *CLIError) Unwrap() error {
+	return e.OriginalErr
+}
+
+// Class returns the stable error class for taxonomy-level grouping.
+func (e *CLIError) Class() ErrorClass {
+	switch e.Category {
+	case ErrorCLIUsage:
+		return ErrorClassUsage
+	case ErrorConfiguration:
+		return ErrorClassConfiguration
+	case ErrorAnalysis:
+		return ErrorClassAnalysis
+	case ErrorRuntime:
+		return ErrorClassRuntime
+	case ErrorFileNotFound:
+		return ErrorClassIO
+	case ErrorInvalidArgument:
+		return ErrorClassValidation
+	default:
+		return ErrorClassRuntime
+	}
+}
+
 // Display prints the error with formatting and suggestions
 func (e *CLIError) Display() {
 	fmt.Fprintf(os.Stderr, "\n%s: %s\n", e.Category, e.Message)
-	
+
 	if e.Suggestion != "" {
 		fmt.Fprintf(os.Stderr, "\n💡 Suggestion: %s\n", e.Suggestion)
 	}
-	
-	if e.OriginalErr != nil {
+
+	if e.OriginalErr != nil && os.Getenv(debugErrorsEnv) == "1" {
 		fmt.Fprintf(os.Stderr, "\nDetails: %v\n", e.OriginalErr)
 	}
 	fmt.Fprintf(os.Stderr, "\n")
@@ -53,10 +92,30 @@ func (e *CLIError) Display() {
 func NewCLIError(category ErrorCategory, message, suggestion string, originalErr error) *CLIError {
 	return &CLIError{
 		Category:    category,
-		Code:        string(category),
+		Code:        CategoryCode(category),
 		Message:     message,
 		Suggestion:  suggestion,
 		OriginalErr: originalErr,
+	}
+}
+
+// CategoryCode returns stable machine-readable error codes.
+func CategoryCode(category ErrorCategory) string {
+	switch category {
+	case ErrorCLIUsage:
+		return "CLI_USAGE"
+	case ErrorConfiguration:
+		return "CONFIGURATION"
+	case ErrorAnalysis:
+		return "ANALYSIS"
+	case ErrorRuntime:
+		return "RUNTIME"
+	case ErrorFileNotFound:
+		return "FILE_NOT_FOUND"
+	case ErrorInvalidArgument:
+		return "INVALID_ARGUMENT"
+	default:
+		return "UNKNOWN"
 	}
 }
 
@@ -77,13 +136,13 @@ var errorSuggestions = map[string]string{
 // GetSuggestion returns a suggestion for a given error message
 func GetSuggestion(errMessage string) string {
 	errLower := strings.ToLower(errMessage)
-	
+
 	for key, suggestion := range errorSuggestions {
 		if strings.Contains(errLower, key) {
 			return suggestion
 		}
 	}
-	
+
 	return "Run 'repodoctor --help' for usage information"
 }
 
@@ -120,7 +179,7 @@ func HandleConfigNotFoundError(configPath string) *CLIError {
 // HandleUnknownRuleError creates an unknown rule error with suggestions
 func HandleUnknownRuleError(ruleName string, availableRules []string) *CLIError {
 	suggestion := "Available rules: " + strings.Join(availableRules, ", ")
-	
+
 	return NewCLIError(
 		ErrorInvalidArgument,
 		fmt.Sprintf("Unknown rule: %s", ruleName),

--- a/errors_test.go
+++ b/errors_test.go
@@ -20,6 +20,17 @@ func TestCLIError_ErrorAndDisplay(t *testing.T) {
 	if !strings.Contains(output, "Suggestion") || !strings.Contains(output, "runtime failed") {
 		t.Fatalf("expected display output with suggestion and message, got %q", output)
 	}
+	if strings.Contains(output, "boom") {
+		t.Fatalf("expected debug details to stay hidden by default, got %q", output)
+	}
+
+	t.Setenv(debugErrorsEnv, "1")
+	debugOutput := captureStderr(t, func() {
+		cliErr.Display()
+	})
+	if !strings.Contains(debugOutput, "Details: boom") {
+		t.Fatalf("expected debug details when %s=1, got %q", debugErrorsEnv, debugOutput)
+	}
 }
 
 func TestErrorHelpersAndSuggestionLookup(t *testing.T) {
@@ -48,6 +59,41 @@ func TestErrorHelpersAndSuggestionLookup(t *testing.T) {
 
 	if msg := FormatErrorMessage(ErrorRuntime, "x"); !strings.Contains(msg, "Runtime Error") {
 		t.Fatalf("unexpected formatted message: %q", msg)
+	}
+}
+
+func TestCLIError_CodeClassAndUnwrap(t *testing.T) {
+	original := errors.New("root-cause")
+	err := NewCLIError(ErrorInvalidArgument, "bad arg", "fix it", original)
+
+	if err.Code != "INVALID_ARGUMENT" {
+		t.Fatalf("expected stable code INVALID_ARGUMENT, got %q", err.Code)
+	}
+	if err.Class() != ErrorClassValidation {
+		t.Fatalf("expected validation class, got %q", err.Class())
+	}
+	if !errors.Is(err, original) {
+		t.Fatal("expected wrapped error to support errors.Is")
+	}
+}
+
+func TestCategoryCode_Mapping(t *testing.T) {
+	cases := []struct {
+		category ErrorCategory
+		code     string
+	}{
+		{ErrorCLIUsage, "CLI_USAGE"},
+		{ErrorConfiguration, "CONFIGURATION"},
+		{ErrorAnalysis, "ANALYSIS"},
+		{ErrorRuntime, "RUNTIME"},
+		{ErrorFileNotFound, "FILE_NOT_FOUND"},
+		{ErrorInvalidArgument, "INVALID_ARGUMENT"},
+	}
+
+	for _, tc := range cases {
+		if got := CategoryCode(tc.category); got != tc.code {
+			t.Fatalf("CategoryCode(%q) expected %q, got %q", tc.category, tc.code, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Introduces stable error taxonomy surfaces via machine-readable `Code` and `ErrorClass` mappings.
- Adds `Unwrap` support so wrapped errors preserve actionable context for `errors.Is`/`errors.As` workflows.
- Gates low-level error details behind `REPODOCTOR_DEBUG_ERRORS=1` to avoid leaking internal-only details in default user-facing output.

## Validation
- `go test . -run "TestCLIError_|TestCategoryCode_|TestErrorHelpersAndSuggestionLookup|TestPrintError_PrintsCLIAndGenericErrors"`
- `go test ./...`
- `go vet ./...`
- `go run . analyze -path .` (100/100)
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`

Closes #265