### PR TITLE
feat(rd-13004): add deterministic metrics export and boundaries

### DIFF
--- a/analysis_service.go
+++ b/analysis_service.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	analysispkg "RepoDoctor/internal/analysis"
+	metricsPkg "RepoDoctor/internal/metrics"
 )
 
 type AnalyzeRequest struct {
@@ -85,9 +86,40 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	progress.Complete()
 
 	handleTrendAnalysis(absPath, report, request.Verbose)
+	if metricsErr := exportMetricsSnapshot(absPath, request.Format, analysisResult, report); metricsErr != nil {
+		fmt.Fprintf(os.Stderr, "%s", ColorWarn(fmt.Sprintf("Warning: metrics export skipped: %v\n", metricsErr)))
+	}
 
 	exitCode := determineExitCode(report)
 	return exitCode
+}
+
+func exportMetricsSnapshot(absPath, outputFormat string, result *analysispkg.Result, report *StructuralReport) error {
+	metricsPath, enabled, err := resolveMetricsExportPath(absPath)
+	if err != nil || !enabled {
+		return err
+	}
+
+	snapshot := metricsPkg.Snapshot{
+		Version:         version,
+		Adapter:         result.AdapterName,
+		OutputFormat:    outputFormat,
+		FilesDetected:   len(result.Files),
+		GraphNodes:      0,
+		GraphEdges:      0,
+		CircularCount:   len(report.Circular),
+		LayerCount:      len(report.Layer),
+		SizeCount:       len(report.Size),
+		GodObjectCount:  len(report.GodObject),
+		TotalViolations: len(report.Circular) + len(report.Layer) + len(report.Size) + len(report.GodObject),
+	}
+
+	if result.Graph != nil {
+		snapshot.GraphNodes = result.Graph.NodeCount()
+		snapshot.GraphEdges = result.Graph.EdgeCount()
+	}
+
+	return metricsPkg.Write(metricsPath, snapshot)
 }
 
 func (s *AnalysisService) reportAdapterGraph(progress *ProgressReporter, result *analysispkg.Result, verbose bool) Graph {

--- a/architecture_boundary_test.go
+++ b/architecture_boundary_test.go
@@ -79,10 +79,11 @@ func TestArchitecture_PurityBoundary_NoSideEffectImportsInSensitivePackages(t *t
 		modulePath + "/internal/rules",
 	}
 	bannedImports := map[string]struct{}{
-		"os/exec":                       {},
-		"syscall":                       {},
-		"unsafe":                        {},
-		modulePath + "/internal/logger": {},
+		"os/exec":                        {},
+		"syscall":                        {},
+		"unsafe":                         {},
+		modulePath + "/internal/logger":  {},
+		modulePath + "/internal/metrics": {},
 	}
 
 	fset := token.NewFileSet()
@@ -138,6 +139,7 @@ func boundaryViolation(fromPkg, toPkg, modulePath string) (string, bool) {
 	modelPkg := modulePath + "/internal/model"
 	domainPkg := modulePath + "/internal/domain"
 	loggerPkg := modulePath + "/internal/logger"
+	metricsPkg := modulePath + "/internal/metrics"
 
 	if !strings.HasPrefix(fromPkg, modulePath+"/internal/") {
 		return "", false
@@ -155,7 +157,7 @@ func boundaryViolation(fromPkg, toPkg, modulePath string) (string, bool) {
 	}
 
 	if fromPkg == analysisPkg {
-		if toPkg != languagesPkg && toPkg != modelPkg && toPkg != domainPkg && toPkg != loggerPkg {
+		if toPkg != languagesPkg && toPkg != modelPkg && toPkg != domainPkg && toPkg != loggerPkg && toPkg != metricsPkg {
 			return fmt.Sprintf("%s imports forbidden internal dependency %s", fromPkg, toPkg), true
 		}
 		return "", false

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,41 @@
+package metrics
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Snapshot is a deterministic metrics export payload for one analyze run.
+type Snapshot struct {
+	Version         string `json:"version"`
+	Adapter         string `json:"adapter"`
+	OutputFormat    string `json:"outputFormat"`
+	FilesDetected   int    `json:"filesDetected"`
+	GraphNodes      int    `json:"graphNodes"`
+	GraphEdges      int    `json:"graphEdges"`
+	CircularCount   int    `json:"circularCount"`
+	LayerCount      int    `json:"layerCount"`
+	SizeCount       int    `json:"sizeCount"`
+	GodObjectCount  int    `json:"godObjectCount"`
+	TotalViolations int    `json:"totalViolations"`
+}
+
+// Marshal serializes the snapshot in deterministic key order.
+func (s Snapshot) Marshal() ([]byte, error) {
+	return json.MarshalIndent(s, "", "  ")
+}
+
+// Write writes the snapshot to disk using deterministic JSON representation.
+func Write(path string, snapshot Snapshot) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	payload, err := snapshot.Marshal()
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, payload, 0o644)
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,44 @@
+package metrics
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSnapshotMarshal_Deterministic(t *testing.T) {
+	snapshot := Snapshot{
+		Version:         "1.1.0",
+		Adapter:         "Go",
+		OutputFormat:    "text",
+		FilesDetected:   3,
+		GraphNodes:      4,
+		GraphEdges:      2,
+		CircularCount:   0,
+		LayerCount:      1,
+		SizeCount:       2,
+		GodObjectCount:  0,
+		TotalViolations: 3,
+	}
+
+	first, err := snapshot.Marshal()
+	if err != nil {
+		t.Fatalf("first marshal failed: %v", err)
+	}
+	second, err := snapshot.Marshal()
+	if err != nil {
+		t.Fatalf("second marshal failed: %v", err)
+	}
+
+	if string(first) != string(second) {
+		t.Fatalf("expected deterministic serialization\nfirst=%s\nsecond=%s", string(first), string(second))
+	}
+}
+
+func TestWrite_CreatesSnapshotFile(t *testing.T) {
+	output := filepath.Join(t.TempDir(), ".repodoctor", "metrics", "snapshot.json")
+
+	err := Write(output, Snapshot{Version: "1.1.0", Adapter: "Go", OutputFormat: "json"})
+	if err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+}

--- a/metrics_export.go
+++ b/metrics_export.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+const metricsPathEnv = "REPODOCTOR_METRICS_PATH"
+
+func resolveMetricsExportPath(analyzeRoot string) (string, bool, error) {
+	raw := strings.TrimSpace(os.Getenv(metricsPathEnv))
+	if raw == "" {
+		return "", false, nil
+	}
+
+	path, err := sanitizeProfilePath(analyzeRoot, raw)
+	if err != nil {
+		return "", false, err
+	}
+
+	return path, true, nil
+}

--- a/metrics_export_test.go
+++ b/metrics_export_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveMetricsExportPath_DefaultDisabled(t *testing.T) {
+	t.Setenv(metricsPathEnv, "")
+	path, enabled, err := resolveMetricsExportPath(t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enabled || path != "" {
+		t.Fatalf("expected metrics export disabled, got enabled=%v path=%q", enabled, path)
+	}
+}
+
+func TestResolveMetricsExportPath_RootBounded(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(metricsPathEnv, filepath.Join(".repodoctor", "metrics", "run.json"))
+
+	path, enabled, err := resolveMetricsExportPath(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected metrics export enabled")
+	}
+	if !pathWithinRoot(root, path) {
+		t.Fatalf("expected metrics path under root, got %s", path)
+	}
+}
+
+func TestResolveMetricsExportPath_RejectsEscape(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(metricsPathEnv, filepath.Join("..", "outside", "metrics.json"))
+
+	_, enabled, err := resolveMetricsExportPath(root)
+	if err == nil {
+		t.Fatal("expected path escape to fail")
+	}
+	if enabled {
+		t.Fatal("expected disabled result on invalid path")
+	}
+}
+
+func TestAnalysisService_Run_ExportsMetricsWhenEnabled(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/test\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("failed writing go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\nfunc main(){}\n"), 0o644); err != nil {
+		t.Fatalf("failed writing main.go: %v", err)
+	}
+
+	t.Setenv(metricsPathEnv, filepath.Join(".repodoctor", "metrics", "run.json"))
+
+	service := NewAnalysisService()
+	code := service.Run(AnalyzeRequest{Path: root, Format: "json-v1", ColorEnabled: false})
+	if code != 0 {
+		t.Fatalf("expected success code, got %d", code)
+	}
+
+	metricsPath := filepath.Join(root, ".repodoctor", "metrics", "run.json")
+	if info, err := os.Stat(metricsPath); err != nil || info.Size() == 0 {
+		t.Fatalf("expected non-empty metrics artifact at %s", metricsPath)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic metrics export package (`internal/metrics`) with stable JSON snapshot payloads.
- Introduces default-off metrics export controlled by `REPODOCTOR_METRICS_PATH`, with root-bounded/sanitized artifact paths.
- Updates architecture boundary tests to enforce no metrics coupling in pure `internal/model`, `internal/domain`, and `internal/rules` layers.

## Validation
- `go test ./internal/metrics . -run "TestResolveMetricsExportPath_|TestAnalysisService_Run_ExportsMetricsWhenEnabled|TestSnapshotMarshal_Deterministic|TestWrite_CreatesSnapshotFile|TestArchitecture_"`
- `go test ./...`
- `go vet ./...`
- `go run . analyze -path .` (100/100)
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`

Closes #266