### PR TITLE
ci(rd-13005): add v1.3 observability stabilization gate

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -85,6 +85,14 @@ jobs:
           GOMAXPROCS: 1
         run: ./scripts/v120_release_stabilization_gate.ps1
 
+      - name: Run v1.3 release stabilization gate
+        shell: pwsh
+        env:
+          TZ: UTC
+          LC_ALL: C
+          GOMAXPROCS: 1
+        run: ./scripts/v130_release_stabilization_gate.ps1
+
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Current CI pipeline includes:
   - `scripts/v100_release_stabilization_gate.ps1`
   - `scripts/v110_release_stabilization_gate.ps1`
   - `scripts/v120_release_stabilization_gate.ps1`
+  - `scripts/v130_release_stabilization_gate.ps1`
 
 You can also scaffold CI templates quickly:
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -11,7 +11,7 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v1.0 | M3: v1.0 UX & Polish | Completed | RD-10001..RD-10005 merged to `dev` and released via `dev -> main` PR #250. |
 | v1.1+ | M4: v1.1+ Scale (Use-case gated) | Completed | RD-11001..RD-11003 merged to `dev` and released via `dev -> main` PR #254. |
 | v1.2 | M5: v1.2 Test Quality & Coverage | Completed | RD-12001..RD-12006 merged into `dev`; root/model/rules coverage hardening, parser fuzz/property determinism tests, and v1.2 gate pack activated. |
-| v1.3 | M6: v1.3 Observability | Planned | Issue chain RD-13001..RD-13005 prepared with boundary/purity controls for logging, metrics, and profiling. |
+| v1.3 | M6: v1.3 Observability | Completed | RD-13001..RD-13005 merged into `dev`; structured logging, safe profiling hooks, error taxonomy hardening, deterministic metrics export, and v1.3 gate pack activated. |
 | v1.4 | M7: v1.4 Performance Hardening | Planned | Issue chain RD-14001..RD-14004 prepared with determinism, race, benchmark, and memory budget gates. |
 | v1.5 | M8: v1.5 Developer Experience | Planned | Issue chain RD-15001..RD-15005 prepared with output-compatibility and release-distribution controls. |
 
@@ -57,6 +57,19 @@ Release path:
 - Feature PRs merged into `dev`: #282, #283, #284, #285, #286, #287
 - Release PR (`dev -> main`): pending (create after v1.2 gate PR merges and CI remains green)
 
+### v1.3 (M6: Observability)
+
+- **RD-13001**: structured logging boundaries (`internal/logger`) with default-off behavior
+- **RD-13002**: opt-in CPU/heap profiling hooks with root-bounded path safeguards
+- **RD-13003**: stable error taxonomy (class+code), wrapped-context preservation, debug-gated details
+- **RD-13004**: deterministic metrics export (`internal/metrics`) with default-off activation
+- **RD-13005**: v1.3 stabilization gate orchestration (`scripts/v130_release_stabilization_gate.ps1` + CI workflow wiring)
+
+Release path:
+
+- Feature PRs merged into `dev`: #289, #290, #291, #292, #293
+- Release PR (`dev -> main`): pending (create after v1.3 gate PR merges and CI remains green)
+
 ## Current Branch/Release State
 
 - Latest completed release line is synchronized on `main`; `dev` may temporarily run ahead with planning/docs-only deltas before the next release merge.
@@ -77,4 +90,4 @@ Release path:
    - merge
 4. After each milestone chain closes on `dev`, open release PR `dev -> main` and keep `dev` branch intact.
 
-Son güncelleme: 3 Nisan 2026
+Son güncelleme: 4 Nisan 2026

--- a/scripts/v130_release_stabilization_gate.ps1
+++ b/scripts/v130_release_stabilization_gate.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    Write-Host "==> $Name"
+    Invoke-Expression $Command
+}
+
+$determinismRegex = "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
+$observabilityRegex = "TestBuildProfilingRequest_.*|TestStartProfiling_.*|TestComposeAnalyzeRequest_ParsesAndNormalizesProfileFlags|TestResolveMetricsExportPath_.*|TestAnalysisService_Run_ExportsMetricsWhenEnabled|TestCLIError_.*|TestCategoryCode_.*"
+
+Invoke-Step -Name "build" -Command "go build ."
+Invoke-Step -Name "core test suite" -Command "go test ./..."
+Invoke-Step -Name "static analysis" -Command "go vet ./..."
+Invoke-Step -Name "observability regression pack" -Command "go test ./... -run '$observabilityRegex'"
+Invoke-Step -Name "architecture boundary pack" -Command "go test . -run 'TestArchitecture_'"
+Invoke-Step -Name "determinism confidence suite" -Command "go test ./... -run '$determinismRegex'"
+Invoke-Step -Name "self-analysis 100/100 gate" -Command "go run . analyze -path ."
+
+Write-Host "v1.3 release stabilization gate passed."


### PR DESCRIPTION
## Summary
- Adds `scripts/v130_release_stabilization_gate.ps1` to consolidate v1.3 observability/boundary checks.
- Wires the v1.3 stabilization gate into CI workflow so the new gate is enforced on PR/push to `dev/main`.
- Updates `docs/report.md` and `README.md` milestone gate inventory for v1.3 completion readiness.

## Validation
- `go test ./...`
- `go vet ./...`
- `go run . analyze -path .` (100/100)
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/v130_release_stabilization_gate.ps1`

Closes #267