### PR TITLE
release(v1.3): merge M6 observability hardening

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -85,6 +85,14 @@ jobs:
           GOMAXPROCS: 1
         run: ./scripts/v120_release_stabilization_gate.ps1
 
+      - name: Run v1.3 release stabilization gate
+        shell: pwsh
+        env:
+          TZ: UTC
+          LC_ALL: C
+          GOMAXPROCS: 1
+        run: ./scripts/v130_release_stabilization_gate.ps1
+
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Current CI pipeline includes:
   - `scripts/v100_release_stabilization_gate.ps1`
   - `scripts/v110_release_stabilization_gate.ps1`
   - `scripts/v120_release_stabilization_gate.ps1`
+  - `scripts/v130_release_stabilization_gate.ps1`
 
 You can also scaffold CI templates quickly:
 

--- a/analysis_service.go
+++ b/analysis_service.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	analysispkg "RepoDoctor/internal/analysis"
+	metricsPkg "RepoDoctor/internal/metrics"
 )
 
 type AnalyzeRequest struct {
@@ -85,9 +86,40 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	progress.Complete()
 
 	handleTrendAnalysis(absPath, report, request.Verbose)
+	if metricsErr := exportMetricsSnapshot(absPath, request.Format, analysisResult, report); metricsErr != nil {
+		fmt.Fprintf(os.Stderr, "%s", ColorWarn(fmt.Sprintf("Warning: metrics export skipped: %v\n", metricsErr)))
+	}
 
 	exitCode := determineExitCode(report)
 	return exitCode
+}
+
+func exportMetricsSnapshot(absPath, outputFormat string, result *analysispkg.Result, report *StructuralReport) error {
+	metricsPath, enabled, err := resolveMetricsExportPath(absPath)
+	if err != nil || !enabled {
+		return err
+	}
+
+	snapshot := metricsPkg.Snapshot{
+		Version:         version,
+		Adapter:         result.AdapterName,
+		OutputFormat:    outputFormat,
+		FilesDetected:   len(result.Files),
+		GraphNodes:      0,
+		GraphEdges:      0,
+		CircularCount:   len(report.Circular),
+		LayerCount:      len(report.Layer),
+		SizeCount:       len(report.Size),
+		GodObjectCount:  len(report.GodObject),
+		TotalViolations: len(report.Circular) + len(report.Layer) + len(report.Size) + len(report.GodObject),
+	}
+
+	if result.Graph != nil {
+		snapshot.GraphNodes = result.Graph.NodeCount()
+		snapshot.GraphEdges = result.Graph.EdgeCount()
+	}
+
+	return metricsPkg.Write(metricsPath, snapshot)
 }
 
 func (s *AnalysisService) reportAdapterGraph(progress *ProgressReporter, result *analysispkg.Result, verbose bool) Graph {

--- a/analysis_service.go
+++ b/analysis_service.go
@@ -13,6 +13,7 @@ type AnalyzeRequest struct {
 	Verbose         bool
 	ColorEnabled    bool
 	ExitOnViolation bool
+	Profiling       profilingRequest
 }
 
 type AnalysisService struct{}
@@ -24,6 +25,19 @@ func NewAnalysisService() *AnalysisService {
 func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	absPath := validatePath(request.Path)
 	InitColorFormatter(request.ColorEnabled)
+	profiler, profileErr := startProfiling(request.Profiling)
+	if profileErr != nil {
+		fmt.Fprintf(os.Stderr, "%s", ColorError(fmt.Sprintf("Error: profiling setup failed: %v\n", profileErr)))
+		return 1
+	}
+
+	if profiler != nil {
+		defer func() {
+			if stopErr := profiler.Stop(); stopErr != nil {
+				fmt.Fprintf(os.Stderr, "%s", ColorWarn(fmt.Sprintf("Warning: profiling finalization failed: %v\n", stopErr)))
+			}
+		}()
+	}
 
 	progress := NewProgressReporter(!request.Verbose)
 	progress.Start("Scanning repository", getStageCount("Scanning repository", absPath))
@@ -34,9 +48,6 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	analysisResult, err := runAdapterPipeline(absPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s", ColorError(fmt.Sprintf("Error: analysis pipeline failed: %v\n", err)))
-		if request.ExitOnViolation {
-			os.Exit(1)
-		}
 		return 1
 	}
 
@@ -76,10 +87,6 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	handleTrendAnalysis(absPath, report, request.Verbose)
 
 	exitCode := determineExitCode(report)
-	if request.ExitOnViolation && exitCode != 0 {
-		os.Exit(exitCode)
-	}
-
 	return exitCode
 }
 

--- a/analysis_service_test.go
+++ b/analysis_service_test.go
@@ -29,7 +29,7 @@ func TestAnalysisService_RunAndRunAnalyze_SuccessPath(t *testing.T) {
 		t.Fatalf("expected analysis service success code 0, got %d", code)
 	}
 
-	if code := runAnalyze(tmp, "text", false, false, false); code != 0 {
+	if code := runAnalyze(tmp, "text", false, false, false, profilingRequest{}); code != 0 {
 		t.Fatalf("expected runAnalyze wrapper success code 0, got %d", code)
 	}
 }

--- a/architecture_boundary_test.go
+++ b/architecture_boundary_test.go
@@ -79,10 +79,11 @@ func TestArchitecture_PurityBoundary_NoSideEffectImportsInSensitivePackages(t *t
 		modulePath + "/internal/rules",
 	}
 	bannedImports := map[string]struct{}{
-		"os/exec":                       {},
-		"syscall":                       {},
-		"unsafe":                        {},
-		modulePath + "/internal/logger": {},
+		"os/exec":                        {},
+		"syscall":                        {},
+		"unsafe":                         {},
+		modulePath + "/internal/logger":  {},
+		modulePath + "/internal/metrics": {},
 	}
 
 	fset := token.NewFileSet()
@@ -138,6 +139,7 @@ func boundaryViolation(fromPkg, toPkg, modulePath string) (string, bool) {
 	modelPkg := modulePath + "/internal/model"
 	domainPkg := modulePath + "/internal/domain"
 	loggerPkg := modulePath + "/internal/logger"
+	metricsPkg := modulePath + "/internal/metrics"
 
 	if !strings.HasPrefix(fromPkg, modulePath+"/internal/") {
 		return "", false
@@ -155,7 +157,7 @@ func boundaryViolation(fromPkg, toPkg, modulePath string) (string, bool) {
 	}
 
 	if fromPkg == analysisPkg {
-		if toPkg != languagesPkg && toPkg != modelPkg && toPkg != domainPkg && toPkg != loggerPkg {
+		if toPkg != languagesPkg && toPkg != modelPkg && toPkg != domainPkg && toPkg != loggerPkg && toPkg != metricsPkg {
 			return fmt.Sprintf("%s imports forbidden internal dependency %s", fromPkg, toPkg), true
 		}
 		return "", false

--- a/architecture_boundary_test.go
+++ b/architecture_boundary_test.go
@@ -79,9 +79,10 @@ func TestArchitecture_PurityBoundary_NoSideEffectImportsInSensitivePackages(t *t
 		modulePath + "/internal/rules",
 	}
 	bannedImports := map[string]struct{}{
-		"os/exec": {},
-		"syscall": {},
-		"unsafe":  {},
+		"os/exec":                       {},
+		"syscall":                       {},
+		"unsafe":                        {},
+		modulePath + "/internal/logger": {},
 	}
 
 	fset := token.NewFileSet()
@@ -136,6 +137,7 @@ func boundaryViolation(fromPkg, toPkg, modulePath string) (string, bool) {
 	enginePkg := modulePath + "/internal/engine"
 	modelPkg := modulePath + "/internal/model"
 	domainPkg := modulePath + "/internal/domain"
+	loggerPkg := modulePath + "/internal/logger"
 
 	if !strings.HasPrefix(fromPkg, modulePath+"/internal/") {
 		return "", false
@@ -153,7 +155,7 @@ func boundaryViolation(fromPkg, toPkg, modulePath string) (string, bool) {
 	}
 
 	if fromPkg == analysisPkg {
-		if toPkg != languagesPkg && toPkg != modelPkg && toPkg != domainPkg {
+		if toPkg != languagesPkg && toPkg != modelPkg && toPkg != domainPkg && toPkg != loggerPkg {
 			return fmt.Sprintf("%s imports forbidden internal dependency %s", fromPkg, toPkg), true
 		}
 		return "", false

--- a/docs/report.md
+++ b/docs/report.md
@@ -11,7 +11,7 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v1.0 | M3: v1.0 UX & Polish | Completed | RD-10001..RD-10005 merged to `dev` and released via `dev -> main` PR #250. |
 | v1.1+ | M4: v1.1+ Scale (Use-case gated) | Completed | RD-11001..RD-11003 merged to `dev` and released via `dev -> main` PR #254. |
 | v1.2 | M5: v1.2 Test Quality & Coverage | Completed | RD-12001..RD-12006 merged into `dev`; root/model/rules coverage hardening, parser fuzz/property determinism tests, and v1.2 gate pack activated. |
-| v1.3 | M6: v1.3 Observability | Planned | Issue chain RD-13001..RD-13005 prepared with boundary/purity controls for logging, metrics, and profiling. |
+| v1.3 | M6: v1.3 Observability | Completed | RD-13001..RD-13005 merged into `dev`; structured logging, safe profiling hooks, error taxonomy hardening, deterministic metrics export, and v1.3 gate pack activated. |
 | v1.4 | M7: v1.4 Performance Hardening | Planned | Issue chain RD-14001..RD-14004 prepared with determinism, race, benchmark, and memory budget gates. |
 | v1.5 | M8: v1.5 Developer Experience | Planned | Issue chain RD-15001..RD-15005 prepared with output-compatibility and release-distribution controls. |
 
@@ -57,6 +57,19 @@ Release path:
 - Feature PRs merged into `dev`: #282, #283, #284, #285, #286, #287
 - Release PR (`dev -> main`): pending (create after v1.2 gate PR merges and CI remains green)
 
+### v1.3 (M6: Observability)
+
+- **RD-13001**: structured logging boundaries (`internal/logger`) with default-off behavior
+- **RD-13002**: opt-in CPU/heap profiling hooks with root-bounded path safeguards
+- **RD-13003**: stable error taxonomy (class+code), wrapped-context preservation, debug-gated details
+- **RD-13004**: deterministic metrics export (`internal/metrics`) with default-off activation
+- **RD-13005**: v1.3 stabilization gate orchestration (`scripts/v130_release_stabilization_gate.ps1` + CI workflow wiring)
+
+Release path:
+
+- Feature PRs merged into `dev`: #289, #290, #291, #292, #293
+- Release PR (`dev -> main`): pending (create after v1.3 gate PR merges and CI remains green)
+
 ## Current Branch/Release State
 
 - Latest completed release line is synchronized on `main`; `dev` may temporarily run ahead with planning/docs-only deltas before the next release merge.
@@ -77,4 +90,4 @@ Release path:
    - merge
 4. After each milestone chain closes on `dev`, open release PR `dev -> main` and keep `dev` branch intact.
 
-Son güncelleme: 3 Nisan 2026
+Son güncelleme: 4 Nisan 2026

--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+const debugErrorsEnv = "REPODOCTOR_DEBUG_ERRORS"
+
 // ErrorCategory represents the category of an error
 type ErrorCategory string
 
@@ -27,6 +29,18 @@ type CLIError struct {
 	OriginalErr error
 }
 
+// ErrorClass provides a stable taxonomy for machine-readable error grouping.
+type ErrorClass string
+
+const (
+	ErrorClassUsage         ErrorClass = "usage"
+	ErrorClassConfiguration ErrorClass = "configuration"
+	ErrorClassAnalysis      ErrorClass = "analysis"
+	ErrorClassRuntime       ErrorClass = "runtime"
+	ErrorClassIO            ErrorClass = "io"
+	ErrorClassValidation    ErrorClass = "validation"
+)
+
 // Error implements the error interface
 func (e *CLIError) Error() string {
 	if e.OriginalErr != nil {
@@ -35,15 +49,40 @@ func (e *CLIError) Error() string {
 	return fmt.Sprintf("%s: %s", e.Category, e.Message)
 }
 
+// Unwrap enables errors.Is/errors.As interoperability.
+func (e *CLIError) Unwrap() error {
+	return e.OriginalErr
+}
+
+// Class returns the stable error class for taxonomy-level grouping.
+func (e *CLIError) Class() ErrorClass {
+	switch e.Category {
+	case ErrorCLIUsage:
+		return ErrorClassUsage
+	case ErrorConfiguration:
+		return ErrorClassConfiguration
+	case ErrorAnalysis:
+		return ErrorClassAnalysis
+	case ErrorRuntime:
+		return ErrorClassRuntime
+	case ErrorFileNotFound:
+		return ErrorClassIO
+	case ErrorInvalidArgument:
+		return ErrorClassValidation
+	default:
+		return ErrorClassRuntime
+	}
+}
+
 // Display prints the error with formatting and suggestions
 func (e *CLIError) Display() {
 	fmt.Fprintf(os.Stderr, "\n%s: %s\n", e.Category, e.Message)
-	
+
 	if e.Suggestion != "" {
 		fmt.Fprintf(os.Stderr, "\n💡 Suggestion: %s\n", e.Suggestion)
 	}
-	
-	if e.OriginalErr != nil {
+
+	if e.OriginalErr != nil && os.Getenv(debugErrorsEnv) == "1" {
 		fmt.Fprintf(os.Stderr, "\nDetails: %v\n", e.OriginalErr)
 	}
 	fmt.Fprintf(os.Stderr, "\n")
@@ -53,10 +92,30 @@ func (e *CLIError) Display() {
 func NewCLIError(category ErrorCategory, message, suggestion string, originalErr error) *CLIError {
 	return &CLIError{
 		Category:    category,
-		Code:        string(category),
+		Code:        CategoryCode(category),
 		Message:     message,
 		Suggestion:  suggestion,
 		OriginalErr: originalErr,
+	}
+}
+
+// CategoryCode returns stable machine-readable error codes.
+func CategoryCode(category ErrorCategory) string {
+	switch category {
+	case ErrorCLIUsage:
+		return "CLI_USAGE"
+	case ErrorConfiguration:
+		return "CONFIGURATION"
+	case ErrorAnalysis:
+		return "ANALYSIS"
+	case ErrorRuntime:
+		return "RUNTIME"
+	case ErrorFileNotFound:
+		return "FILE_NOT_FOUND"
+	case ErrorInvalidArgument:
+		return "INVALID_ARGUMENT"
+	default:
+		return "UNKNOWN"
 	}
 }
 
@@ -77,13 +136,13 @@ var errorSuggestions = map[string]string{
 // GetSuggestion returns a suggestion for a given error message
 func GetSuggestion(errMessage string) string {
 	errLower := strings.ToLower(errMessage)
-	
+
 	for key, suggestion := range errorSuggestions {
 		if strings.Contains(errLower, key) {
 			return suggestion
 		}
 	}
-	
+
 	return "Run 'repodoctor --help' for usage information"
 }
 
@@ -120,7 +179,7 @@ func HandleConfigNotFoundError(configPath string) *CLIError {
 // HandleUnknownRuleError creates an unknown rule error with suggestions
 func HandleUnknownRuleError(ruleName string, availableRules []string) *CLIError {
 	suggestion := "Available rules: " + strings.Join(availableRules, ", ")
-	
+
 	return NewCLIError(
 		ErrorInvalidArgument,
 		fmt.Sprintf("Unknown rule: %s", ruleName),

--- a/errors_test.go
+++ b/errors_test.go
@@ -20,6 +20,17 @@ func TestCLIError_ErrorAndDisplay(t *testing.T) {
 	if !strings.Contains(output, "Suggestion") || !strings.Contains(output, "runtime failed") {
 		t.Fatalf("expected display output with suggestion and message, got %q", output)
 	}
+	if strings.Contains(output, "boom") {
+		t.Fatalf("expected debug details to stay hidden by default, got %q", output)
+	}
+
+	t.Setenv(debugErrorsEnv, "1")
+	debugOutput := captureStderr(t, func() {
+		cliErr.Display()
+	})
+	if !strings.Contains(debugOutput, "Details: boom") {
+		t.Fatalf("expected debug details when %s=1, got %q", debugErrorsEnv, debugOutput)
+	}
 }
 
 func TestErrorHelpersAndSuggestionLookup(t *testing.T) {
@@ -48,6 +59,41 @@ func TestErrorHelpersAndSuggestionLookup(t *testing.T) {
 
 	if msg := FormatErrorMessage(ErrorRuntime, "x"); !strings.Contains(msg, "Runtime Error") {
 		t.Fatalf("unexpected formatted message: %q", msg)
+	}
+}
+
+func TestCLIError_CodeClassAndUnwrap(t *testing.T) {
+	original := errors.New("root-cause")
+	err := NewCLIError(ErrorInvalidArgument, "bad arg", "fix it", original)
+
+	if err.Code != "INVALID_ARGUMENT" {
+		t.Fatalf("expected stable code INVALID_ARGUMENT, got %q", err.Code)
+	}
+	if err.Class() != ErrorClassValidation {
+		t.Fatalf("expected validation class, got %q", err.Class())
+	}
+	if !errors.Is(err, original) {
+		t.Fatal("expected wrapped error to support errors.Is")
+	}
+}
+
+func TestCategoryCode_Mapping(t *testing.T) {
+	cases := []struct {
+		category ErrorCategory
+		code     string
+	}{
+		{ErrorCLIUsage, "CLI_USAGE"},
+		{ErrorConfiguration, "CONFIGURATION"},
+		{ErrorAnalysis, "ANALYSIS"},
+		{ErrorRuntime, "RUNTIME"},
+		{ErrorFileNotFound, "FILE_NOT_FOUND"},
+		{ErrorInvalidArgument, "INVALID_ARGUMENT"},
+	}
+
+	for _, tc := range cases {
+		if got := CategoryCode(tc.category); got != tc.code {
+			t.Fatalf("CategoryCode(%q) expected %q, got %q", tc.category, tc.code, got)
+		}
 	}
 }
 

--- a/interactive.go
+++ b/interactive.go
@@ -78,7 +78,7 @@ func (i *InteractiveMode) analyzeMenu() {
 	switch choice {
 	case 1:
 		fmt.Println("\nAnalyzing current repository...")
-		runAnalyze(".", "text", false, true, true)
+		runAnalyze(".", "text", false, true, true, profilingRequest{})
 	case 2:
 		path := i.io.readString("\nEnter path to analyze: ")
 		if path == "" {
@@ -86,7 +86,7 @@ func (i *InteractiveMode) analyzeMenu() {
 			return
 		}
 		fmt.Printf("\nAnalyzing repository: %s\n", path)
-		runAnalyze(path, "text", false, true, true)
+		runAnalyze(path, "text", false, true, true, profilingRequest{})
 	case 3:
 		return
 	default:

--- a/internal/analysis/orchestrator.go
+++ b/internal/analysis/orchestrator.go
@@ -5,12 +5,14 @@ import (
 	"sort"
 
 	"RepoDoctor/internal/languages"
+	"RepoDoctor/internal/logger"
 	"RepoDoctor/internal/model"
 )
 
 // Orchestrator coordinates language detection and adapter-driven analysis steps.
 type Orchestrator struct {
 	detector languages.LanguageDetector
+	logger   logger.Logger
 }
 
 // Result contains adapter-driven analysis output.
@@ -23,7 +25,15 @@ type Result struct {
 
 // NewOrchestrator creates a new analysis orchestrator.
 func NewOrchestrator(detector languages.LanguageDetector) *Orchestrator {
-	return &Orchestrator{detector: detector}
+	return NewOrchestratorWithLogger(detector, logger.NewNoop())
+}
+
+// NewOrchestratorWithLogger creates a new analysis orchestrator with structured logger wiring.
+func NewOrchestratorWithLogger(detector languages.LanguageDetector, log logger.Logger) *Orchestrator {
+	if log == nil {
+		log = logger.NewNoop()
+	}
+	return &Orchestrator{detector: detector, logger: log}
 }
 
 // Analyze executes the runtime pipeline: detect adapter -> detect files -> metrics -> graph.
@@ -32,10 +42,14 @@ func (o *Orchestrator) Analyze(repoPath string) (*Result, error) {
 		return nil, fmt.Errorf("language detector is required")
 	}
 
+	o.logger.Debug("analysis.start", "repo_path", repoPath)
+
 	adapter, err := o.detector.DetectLanguage(repoPath)
 	if err != nil {
+		o.logger.Error("analysis.language_detection_failed", "repo_path", repoPath, "error", err)
 		return nil, fmt.Errorf("language detection failed: %w", err)
 	}
+	o.logger.Info("analysis.language_detected", "adapter", adapter.Name())
 
 	capabilities := adapter.Capabilities()
 	if !capabilities.SupportsDependencyGraph {
@@ -47,19 +61,24 @@ func (o *Orchestrator) Analyze(repoPath string) (*Result, error) {
 
 	files, err := adapter.DetectFiles(repoPath)
 	if err != nil {
+		o.logger.Error("analysis.file_detection_failed", "adapter", adapter.Name(), "error", err)
 		return nil, fmt.Errorf("file detection failed for %s: %w", adapter.Name(), err)
 	}
 	sort.Strings(files)
+	o.logger.Debug("analysis.files_detected", "adapter", adapter.Name(), "count", len(files))
 
 	metrics, err := adapter.CollectMetrics(files)
 	if err != nil {
+		o.logger.Error("analysis.metrics_failed", "adapter", adapter.Name(), "error", err)
 		return nil, fmt.Errorf("metrics collection failed for %s: %w", adapter.Name(), err)
 	}
 
 	graph, err := adapter.BuildDependencyGraph(files)
 	if err != nil {
+		o.logger.Error("analysis.graph_failed", "adapter", adapter.Name(), "error", err)
 		return nil, fmt.Errorf("dependency graph build failed for %s: %w", adapter.Name(), err)
 	}
+	o.logger.Info("analysis.completed", "adapter", adapter.Name(), "file_count", len(files))
 
 	return &Result{
 		AdapterName: adapter.Name(),

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,80 @@
+package logger
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Logger defines a minimal structured logging contract for orchestration/CLI layers.
+type Logger interface {
+	Debug(msg string, attrs ...any)
+	Info(msg string, attrs ...any)
+	Warn(msg string, attrs ...any)
+	Error(msg string, attrs ...any)
+}
+
+type slogLogger struct {
+	delegate *slog.Logger
+}
+
+func (l *slogLogger) Debug(msg string, attrs ...any) { l.delegate.Debug(msg, attrs...) }
+func (l *slogLogger) Info(msg string, attrs ...any)  { l.delegate.Info(msg, attrs...) }
+func (l *slogLogger) Warn(msg string, attrs ...any)  { l.delegate.Warn(msg, attrs...) }
+func (l *slogLogger) Error(msg string, attrs ...any) { l.delegate.Error(msg, attrs...) }
+
+type noopLogger struct{}
+
+func (l *noopLogger) Debug(string, ...any) {}
+func (l *noopLogger) Info(string, ...any)  {}
+func (l *noopLogger) Warn(string, ...any)  {}
+func (l *noopLogger) Error(string, ...any) {}
+
+// NewNoop returns a logger implementation that never emits output.
+func NewNoop() Logger {
+	return &noopLogger{}
+}
+
+// NewSlog wraps a slog.Logger behind the repository logging abstraction.
+func NewSlog(delegate *slog.Logger) Logger {
+	if delegate == nil {
+		return NewNoop()
+	}
+	return &slogLogger{delegate: delegate}
+}
+
+// NewFromEnv returns a structured logger controlled by REPODOCTOR_LOG_LEVEL.
+// Default is disabled (no-op), preserving deterministic output behavior.
+func NewFromEnv() Logger {
+	levelText := strings.TrimSpace(strings.ToLower(os.Getenv("REPODOCTOR_LOG_LEVEL")))
+	level, enabled := parseLevel(levelText)
+	if !enabled {
+		return NewNoop()
+	}
+
+	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
+	return NewSlog(slog.New(handler))
+}
+
+func parseLevel(value string) (slog.Level, bool) {
+	switch value {
+	case "debug":
+		return slog.LevelDebug, true
+	case "info":
+		return slog.LevelInfo, true
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error":
+		return slog.LevelError, true
+	default:
+		return slog.LevelInfo, false
+	}
+}
+
+// NewTestLogger returns a structured logger writing to the provided writer.
+// Intended for deterministic unit tests.
+func NewTestLogger(writer io.Writer, level slog.Level) Logger {
+	handler := slog.NewTextHandler(writer, &slog.HandlerOptions{Level: level})
+	return NewSlog(slog.New(handler))
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,83 @@
+package logger
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestNewFromEnv_DefaultIsNoop(t *testing.T) {
+	t.Setenv("REPODOCTOR_LOG_LEVEL", "")
+
+	log := NewFromEnv()
+	log.Debug("debug", "k", "v")
+	log.Info("info", "k", "v")
+	log.Warn("warn", "k", "v")
+	log.Error("error", "k", "v")
+}
+
+func TestNewFromEnv_InvalidValueFallsBackToNoop(t *testing.T) {
+	t.Setenv("REPODOCTOR_LOG_LEVEL", "invalid")
+
+	log := NewFromEnv()
+	log.Info("ignored")
+}
+
+func TestNewTestLogger_EmitsStructuredOutput(t *testing.T) {
+	var buf bytes.Buffer
+	log := NewTestLogger(&buf, slog.LevelDebug)
+
+	log.Info("pipeline.start", "adapter", "Go", "files", 3)
+
+	out := buf.String()
+	if !strings.Contains(out, "pipeline.start") {
+		t.Fatalf("expected message in output, got %q", out)
+	}
+	if !strings.Contains(out, "adapter=Go") || !strings.Contains(out, "files=3") {
+		t.Fatalf("expected key-value attrs in output, got %q", out)
+	}
+}
+
+func TestParseLevel(t *testing.T) {
+	cases := []struct {
+		input   string
+		enabled bool
+	}{
+		{input: "debug", enabled: true},
+		{input: "info", enabled: true},
+		{input: "warn", enabled: true},
+		{input: "error", enabled: true},
+		{input: "", enabled: false},
+		{input: "off", enabled: false},
+	}
+
+	for _, tc := range cases {
+		_, enabled := parseLevel(tc.input)
+		if enabled != tc.enabled {
+			t.Fatalf("parseLevel(%q) enabled expected %v, got %v", tc.input, tc.enabled, enabled)
+		}
+	}
+}
+
+func TestNewSlog_NilDelegateReturnsNoop(t *testing.T) {
+	log := NewSlog(nil)
+	log.Info("safe")
+
+	if _, ok := log.(*noopLogger); !ok {
+		t.Fatal("expected noop logger when delegate is nil")
+	}
+}
+
+func TestNewFromEnv_RecognizesConfiguredLevels(t *testing.T) {
+	levels := []string{"debug", "info", "warn", "error"}
+	for _, level := range levels {
+		t.Run(level, func(t *testing.T) {
+			t.Setenv("REPODOCTOR_LOG_LEVEL", level)
+			log := NewFromEnv()
+			if _, ok := log.(*noopLogger); ok {
+				t.Fatalf("expected configured level %q to enable logger", level)
+			}
+		})
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,41 @@
+package metrics
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Snapshot is a deterministic metrics export payload for one analyze run.
+type Snapshot struct {
+	Version         string `json:"version"`
+	Adapter         string `json:"adapter"`
+	OutputFormat    string `json:"outputFormat"`
+	FilesDetected   int    `json:"filesDetected"`
+	GraphNodes      int    `json:"graphNodes"`
+	GraphEdges      int    `json:"graphEdges"`
+	CircularCount   int    `json:"circularCount"`
+	LayerCount      int    `json:"layerCount"`
+	SizeCount       int    `json:"sizeCount"`
+	GodObjectCount  int    `json:"godObjectCount"`
+	TotalViolations int    `json:"totalViolations"`
+}
+
+// Marshal serializes the snapshot in deterministic key order.
+func (s Snapshot) Marshal() ([]byte, error) {
+	return json.MarshalIndent(s, "", "  ")
+}
+
+// Write writes the snapshot to disk using deterministic JSON representation.
+func Write(path string, snapshot Snapshot) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	payload, err := snapshot.Marshal()
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, payload, 0o644)
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,44 @@
+package metrics
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSnapshotMarshal_Deterministic(t *testing.T) {
+	snapshot := Snapshot{
+		Version:         "1.1.0",
+		Adapter:         "Go",
+		OutputFormat:    "text",
+		FilesDetected:   3,
+		GraphNodes:      4,
+		GraphEdges:      2,
+		CircularCount:   0,
+		LayerCount:      1,
+		SizeCount:       2,
+		GodObjectCount:  0,
+		TotalViolations: 3,
+	}
+
+	first, err := snapshot.Marshal()
+	if err != nil {
+		t.Fatalf("first marshal failed: %v", err)
+	}
+	second, err := snapshot.Marshal()
+	if err != nil {
+		t.Fatalf("second marshal failed: %v", err)
+	}
+
+	if string(first) != string(second) {
+		t.Fatalf("expected deterministic serialization\nfirst=%s\nsecond=%s", string(first), string(second))
+	}
+}
+
+func TestWrite_CreatesSnapshotFile(t *testing.T) {
+	output := filepath.Join(t.TempDir(), ".repodoctor", "metrics", "snapshot.json")
+
+	err := Write(output, Snapshot{Version: "1.1.0", Adapter: "Go", OutputFormat: "json"})
+	if err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"RepoDoctor/internal/analysis"
 	"RepoDoctor/internal/domain"
 	"RepoDoctor/internal/languages"
+	"RepoDoctor/internal/logger"
 	"RepoDoctor/internal/model"
 	"flag"
 	"fmt"
@@ -406,7 +407,7 @@ func runAdapterPipeline(absPath string) (*analysis.Result, error) {
 	detector := languages.NewRepositoryLanguageDetectorWithPolicy(ignoreStrategy, policy)
 	registerCoreAdapters(detector, config)
 
-	orchestrator := analysis.NewOrchestrator(detector)
+	orchestrator := analysis.NewOrchestratorWithLogger(detector, logger.NewFromEnv())
 	return orchestrator.Analyze(absPath)
 }
 

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func handleAnalyzeCommand(args []string) error {
 		return nil
 	}
 
-	runAnalyze(req.path, req.format, req.verbose, req.colorEnabled, true)
+	runAnalyze(req.path, req.format, req.verbose, req.colorEnabled, true, req.profiling)
 	return nil
 }
 
@@ -85,6 +85,7 @@ type analyzeCommandRequest struct {
 	verbose      bool
 	colorEnabled bool
 	watch        bool
+	profiling    profilingRequest
 }
 
 func composeAnalyzeRequest(args []string) (*analyzeCommandRequest, error) {
@@ -99,12 +100,18 @@ func composeAnalyzeRequest(args []string) (*analyzeCommandRequest, error) {
 		return nil, normalizeErr
 	}
 
+	profiling, profilingErr := buildProfilingRequest(normalizedPath, parsed.cpuProfile, parsed.memProfile, parsed.watch)
+	if profilingErr != nil {
+		return nil, profilingErr
+	}
+
 	return &analyzeCommandRequest{
 		path:         normalizedPath,
 		format:       parsed.outputFormat,
 		verbose:      parsed.verbose,
 		colorEnabled: !parsed.noColor,
 		watch:        parsed.watch,
+		profiling:    profiling,
 	}, nil
 }
 
@@ -114,6 +121,8 @@ type analyzeFlagInput struct {
 	verbose      bool
 	watch        bool
 	noColor      bool
+	cpuProfile   string
+	memProfile   string
 	positional   []string
 }
 
@@ -127,6 +136,8 @@ func parseAnalyzeFlags(args []string) (*analyzeFlagInput, error) {
 	jsonOut := analyzeCmd.Bool("json", false, "Output in JSON format")
 	watch := analyzeCmd.Bool("watch", false, "Enable watch mode for continuous analysis")
 	noColor := analyzeCmd.Bool("no-color", false, "Disable colored output")
+	cpuProfile := analyzeCmd.String("cpu-profile", "", "Write CPU profile to a file under analyze path")
+	memProfile := analyzeCmd.String("mem-profile", "", "Write heap profile to a file under analyze path")
 
 	if err := analyzeCmd.Parse(args); err != nil {
 		return nil, NewCLIError(
@@ -148,6 +159,8 @@ func parseAnalyzeFlags(args []string) (*analyzeFlagInput, error) {
 		verbose:      *verbose,
 		watch:        *watch,
 		noColor:      *noColor,
+		cpuProfile:   *cpuProfile,
+		memProfile:   *memProfile,
 		positional:   analyzeCmd.Args(),
 	}, nil
 }
@@ -299,6 +312,8 @@ Arguments:
     -verbose   Enable verbose output
     -watch     Enable watch mode for continuous analysis
     -no-color  Disable colored output (default: enabled)
+    -cpu-profile  Write CPU profile under analyze path (opt-in)
+    -mem-profile  Write heap profile under analyze path (opt-in)
 
   extract [options]
     -path      Directory path to extract imports from (default: current directory)
@@ -323,15 +338,22 @@ Examples:
   repodoctor version`)
 }
 
-func runAnalyze(path, format string, verbose bool, colorEnabled bool, exitOnViolation bool) int {
+func runAnalyze(path, format string, verbose bool, colorEnabled bool, exitOnViolation bool, profiling profilingRequest) int {
 	service := NewAnalysisService()
-	return service.Run(AnalyzeRequest{
+	exitCode := service.Run(AnalyzeRequest{
 		Path:            path,
 		Format:          format,
 		Verbose:         verbose,
 		ColorEnabled:    colorEnabled,
 		ExitOnViolation: exitOnViolation,
+		Profiling:       profiling,
 	})
+
+	if exitOnViolation && exitCode != 0 {
+		os.Exit(exitCode)
+	}
+
+	return exitCode
 }
 
 // determineExitCode returns the appropriate exit code based on report

--- a/metrics_export.go
+++ b/metrics_export.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+const metricsPathEnv = "REPODOCTOR_METRICS_PATH"
+
+func resolveMetricsExportPath(analyzeRoot string) (string, bool, error) {
+	raw := strings.TrimSpace(os.Getenv(metricsPathEnv))
+	if raw == "" {
+		return "", false, nil
+	}
+
+	path, err := sanitizeProfilePath(analyzeRoot, raw)
+	if err != nil {
+		return "", false, err
+	}
+
+	return path, true, nil
+}

--- a/metrics_export_test.go
+++ b/metrics_export_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveMetricsExportPath_DefaultDisabled(t *testing.T) {
+	t.Setenv(metricsPathEnv, "")
+	path, enabled, err := resolveMetricsExportPath(t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enabled || path != "" {
+		t.Fatalf("expected metrics export disabled, got enabled=%v path=%q", enabled, path)
+	}
+}
+
+func TestResolveMetricsExportPath_RootBounded(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(metricsPathEnv, filepath.Join(".repodoctor", "metrics", "run.json"))
+
+	path, enabled, err := resolveMetricsExportPath(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected metrics export enabled")
+	}
+	if !pathWithinRoot(root, path) {
+		t.Fatalf("expected metrics path under root, got %s", path)
+	}
+}
+
+func TestResolveMetricsExportPath_RejectsEscape(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(metricsPathEnv, filepath.Join("..", "outside", "metrics.json"))
+
+	_, enabled, err := resolveMetricsExportPath(root)
+	if err == nil {
+		t.Fatal("expected path escape to fail")
+	}
+	if enabled {
+		t.Fatal("expected disabled result on invalid path")
+	}
+}
+
+func TestAnalysisService_Run_ExportsMetricsWhenEnabled(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/test\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("failed writing go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\nfunc main(){}\n"), 0o644); err != nil {
+		t.Fatalf("failed writing main.go: %v", err)
+	}
+
+	t.Setenv(metricsPathEnv, filepath.Join(".repodoctor", "metrics", "run.json"))
+
+	service := NewAnalysisService()
+	code := service.Run(AnalyzeRequest{Path: root, Format: "json-v1", ColorEnabled: false})
+	if code != 0 {
+		t.Fatalf("expected success code, got %d", code)
+	}
+
+	metricsPath := filepath.Join(root, ".repodoctor", "metrics", "run.json")
+	if info, err := os.Stat(metricsPath); err != nil || info.Size() == 0 {
+		t.Fatalf("expected non-empty metrics artifact at %s", metricsPath)
+	}
+}

--- a/profiling.go
+++ b/profiling.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"strings"
+)
+
+type profilingRequest struct {
+	cpuProfilePath string
+	memProfilePath string
+}
+
+func (r profilingRequest) enabled() bool {
+	return strings.TrimSpace(r.cpuProfilePath) != "" || strings.TrimSpace(r.memProfilePath) != ""
+}
+
+func buildProfilingRequest(analyzeRoot, cpuPath, memPath string, watch bool) (profilingRequest, error) {
+	request := profilingRequest{}
+	if watch && (strings.TrimSpace(cpuPath) != "" || strings.TrimSpace(memPath) != "") {
+		return request, NewCLIError(
+			ErrorInvalidArgument,
+			"Profiling cannot be enabled in watch mode",
+			"Use analyze without -watch when collecting profiles",
+			nil,
+		)
+	}
+
+	var err error
+	request.cpuProfilePath, err = sanitizeProfilePath(analyzeRoot, cpuPath)
+	if err != nil {
+		return profilingRequest{}, err
+	}
+
+	request.memProfilePath, err = sanitizeProfilePath(analyzeRoot, memPath)
+	if err != nil {
+		return profilingRequest{}, err
+	}
+
+	return request, nil
+}
+
+func sanitizeProfilePath(analyzeRoot, profilePath string) (string, error) {
+	trimmed := strings.TrimSpace(profilePath)
+	if trimmed == "" {
+		return "", nil
+	}
+
+	root := filepath.Clean(analyzeRoot)
+	if resolvedRoot, err := filepath.EvalSymlinks(root); err == nil {
+		root = filepath.Clean(resolvedRoot)
+	}
+
+	target := filepath.Clean(trimmed)
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(root, target)
+	}
+
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return "", HandleInvalidPathError(profilePath, err)
+	}
+	absTarget = filepath.Clean(absTarget)
+	if resolvedTarget, err := filepath.EvalSymlinks(absTarget); err == nil {
+		absTarget = filepath.Clean(resolvedTarget)
+	}
+
+	rel, err := filepath.Rel(root, absTarget)
+	if err != nil {
+		return "", NewCLIError(
+			ErrorInvalidArgument,
+			fmt.Sprintf("Invalid profile path: %s", profilePath),
+			"Use a path under the analyze root directory",
+			err,
+		)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", NewCLIError(
+			ErrorInvalidArgument,
+			fmt.Sprintf("Profile path escapes analyze root: %s", profilePath),
+			"Profile artifacts must stay under the analyze root directory",
+			nil,
+		)
+	}
+
+	return absTarget, nil
+}
+
+type profileSession struct {
+	cpuFile *os.File
+	memPath string
+}
+
+func startProfiling(request profilingRequest) (*profileSession, error) {
+	if !request.enabled() {
+		return nil, nil
+	}
+
+	session := &profileSession{memPath: request.memProfilePath}
+
+	if request.cpuProfilePath != "" {
+		if err := ensureProfileParentDir(request.cpuProfilePath); err != nil {
+			return nil, err
+		}
+		cpuFile, err := os.Create(request.cpuProfilePath)
+		if err != nil {
+			return nil, err
+		}
+		if err := pprof.StartCPUProfile(cpuFile); err != nil {
+			_ = cpuFile.Close()
+			return nil, err
+		}
+		session.cpuFile = cpuFile
+	}
+
+	return session, nil
+}
+
+func (s *profileSession) Stop() error {
+	if s == nil {
+		return nil
+	}
+
+	if s.cpuFile != nil {
+		pprof.StopCPUProfile()
+		if err := s.cpuFile.Close(); err != nil {
+			return err
+		}
+	}
+
+	if s.memPath != "" {
+		if err := ensureProfileParentDir(s.memPath); err != nil {
+			return err
+		}
+		memFile, err := os.Create(s.memPath)
+		if err != nil {
+			return err
+		}
+		runtime.GC()
+		if err := pprof.WriteHeapProfile(memFile); err != nil {
+			_ = memFile.Close()
+			return err
+		}
+		if err := memFile.Close(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ensureProfileParentDir(path string) error {
+	dir := filepath.Dir(path)
+	if dir == "" || dir == "." {
+		return nil
+	}
+	return os.MkdirAll(dir, 0o755)
+}

--- a/profiling_test.go
+++ b/profiling_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildProfilingRequest_DefaultOff(t *testing.T) {
+	root := t.TempDir()
+	request, err := buildProfilingRequest(root, "", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if request.enabled() {
+		t.Fatal("profiling should be disabled by default")
+	}
+}
+
+func TestBuildProfilingRequest_WatchModeRejected(t *testing.T) {
+	root := t.TempDir()
+	_, err := buildProfilingRequest(root, "cpu.pprof", "", true)
+	if err == nil {
+		t.Fatal("expected watch mode + profiling to be rejected")
+	}
+}
+
+func TestBuildProfilingRequest_ProfilePathRootBounded(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(root, "..", "escape", "cpu.pprof")
+
+	_, err := buildProfilingRequest(root, outside, "", false)
+	if err == nil {
+		t.Fatal("expected path outside root to be rejected")
+	}
+}
+
+func TestBuildProfilingRequest_ProfilePathSanitizedUnderRoot(t *testing.T) {
+	root := t.TempDir()
+	request, err := buildProfilingRequest(root, filepath.Join(".repodoctor", "profiles", "cpu.pprof"), "", false)
+	if err != nil {
+		t.Fatalf("unexpected sanitize error: %v", err)
+	}
+
+	if !pathWithinRoot(root, request.cpuProfilePath) {
+		t.Fatalf("expected cpu profile path under root, got %s", request.cpuProfilePath)
+	}
+}
+
+func TestStartProfiling_CreatesCpuAndMemArtifacts(t *testing.T) {
+	root := t.TempDir()
+	request, err := buildProfilingRequest(root, ".repodoctor/profiles/cpu.pprof", ".repodoctor/profiles/mem.pprof", false)
+	if err != nil {
+		t.Fatalf("unexpected request error: %v", err)
+	}
+
+	session, err := startProfiling(request)
+	if err != nil {
+		t.Fatalf("startProfiling failed: %v", err)
+	}
+
+	for i := 0; i < 100000; i++ {
+		_ = i * i
+	}
+
+	if err := session.Stop(); err != nil {
+		t.Fatalf("profile stop failed: %v", err)
+	}
+
+	if info, statErr := os.Stat(request.cpuProfilePath); statErr != nil || info.Size() == 0 {
+		t.Fatalf("expected non-empty cpu profile file at %s", request.cpuProfilePath)
+	}
+	if info, statErr := os.Stat(request.memProfilePath); statErr != nil || info.Size() == 0 {
+		t.Fatalf("expected non-empty mem profile file at %s", request.memProfilePath)
+	}
+}
+
+func TestComposeAnalyzeRequest_ParsesAndNormalizesProfileFlags(t *testing.T) {
+	root := t.TempDir()
+	req, err := composeAnalyzeRequest([]string{"-path", root, "-cpu-profile", "profiles/cpu.pprof", "-mem-profile", "profiles/mem.pprof"})
+	if err != nil {
+		t.Fatalf("unexpected compose error: %v", err)
+	}
+
+	if !req.profiling.enabled() {
+		t.Fatal("expected profiling to be enabled")
+	}
+	if !pathWithinRoot(root, req.profiling.cpuProfilePath) {
+		t.Fatalf("expected cpu profile under root, got %s", req.profiling.cpuProfilePath)
+	}
+	if !pathWithinRoot(root, req.profiling.memProfilePath) {
+		t.Fatalf("expected mem profile under root, got %s", req.profiling.memProfilePath)
+	}
+}
+
+func pathWithinRoot(root, target string) bool {
+	resolvedRoot, err := filepath.Abs(filepath.Clean(root))
+	if err != nil {
+		return false
+	}
+	if next, resolveErr := filepath.EvalSymlinks(resolvedRoot); resolveErr == nil {
+		resolvedRoot = filepath.Clean(next)
+	}
+
+	resolvedTarget, err := filepath.Abs(filepath.Clean(target))
+	if err != nil {
+		return false
+	}
+	if next, resolveErr := filepath.EvalSymlinks(resolvedTarget); resolveErr == nil {
+		resolvedTarget = filepath.Clean(next)
+	}
+
+	rel, relErr := filepath.Rel(resolvedRoot, resolvedTarget)
+	if relErr != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/scripts/v130_release_stabilization_gate.ps1
+++ b/scripts/v130_release_stabilization_gate.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    Write-Host "==> $Name"
+    Invoke-Expression $Command
+}
+
+$determinismRegex = "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
+$observabilityRegex = "TestBuildProfilingRequest_.*|TestStartProfiling_.*|TestComposeAnalyzeRequest_ParsesAndNormalizesProfileFlags|TestResolveMetricsExportPath_.*|TestAnalysisService_Run_ExportsMetricsWhenEnabled|TestCLIError_.*|TestCategoryCode_.*"
+
+Invoke-Step -Name "build" -Command "go build ."
+Invoke-Step -Name "core test suite" -Command "go test ./..."
+Invoke-Step -Name "static analysis" -Command "go vet ./..."
+Invoke-Step -Name "observability regression pack" -Command "go test ./... -run '$observabilityRegex'"
+Invoke-Step -Name "architecture boundary pack" -Command "go test . -run 'TestArchitecture_'"
+Invoke-Step -Name "determinism confidence suite" -Command "go test ./... -run '$determinismRegex'"
+Invoke-Step -Name "self-analysis 100/100 gate" -Command "go run . analyze -path ."
+
+Write-Host "v1.3 release stabilization gate passed."

--- a/watcher.go
+++ b/watcher.go
@@ -155,7 +155,7 @@ func (w *Watcher) runAnalysis(changedFile string) {
 	fmt.Println(strings.Repeat("=", 60))
 
 	// Run analysis
-	if code := runAnalyze(w.path, "text", false, true, false); code != 0 {
+	if code := runAnalyze(w.path, "text", false, true, false, profilingRequest{}); code != 0 {
 		fmt.Printf("Analysis finished with exit code %d (watch continues).\n", code)
 	}
 }
@@ -220,7 +220,7 @@ func WatchAndAnalyze(path string) error {
 	// Run initial analysis
 	fmt.Println("Running initial analysis...")
 	fmt.Println()
-	if code := runAnalyze(path, "text", false, true, false); code != 0 {
+	if code := runAnalyze(path, "text", false, true, false, profilingRequest{}); code != 0 {
 		fmt.Printf("Initial analysis finished with exit code %d (watch continues).\n", code)
 	}
 


### PR DESCRIPTION
## Summary
- Delivers M6 (v1.3) chain: RD-13001..RD-13005 on dev.
- Includes structured logging boundaries, safe opt-in profiling, stable error taxonomy, deterministic metrics export, and v1.3 stabilization gate automation.
- Keeps mandatory quality baseline and determinism/self-analysis gates green across Linux+Windows CI.

## Included PRs
- #289, #290, #291, #292, #293

## Release Validation
- go test ./...
- go vet ./...
- go run . analyze -path . (100/100)
- scripts/v130_release_stabilization_gate.ps1
