### PR TITLE
perf(rd-14001): tune parallel parsing with deterministic merge

### DIFF
--- a/benchmarks/rd-14001.md
+++ b/benchmarks/rd-14001.md
@@ -1,0 +1,24 @@
+# RD-14001 Benchmark Evidence
+
+Date: 2026-04-04
+Environment: windows/amd64, Intel i7-12650H
+Command:
+
+`go test ./internal/languages -bench "BenchmarkGoAdapter_(Parallel|Serial)Parsing" -benchmem -run ^$ -count 5`
+
+Samples (`ns/op`):
+
+- Parallel: `6675704`, `6657137`, `6529080`, `6661668`, `15819497`
+- Serial: `50133908`, `45436889`, `48700643`, `46539188`, `49483627`
+
+Computed summary:
+
+- Parallel p50: `6661668 ns/op` (~6.66ms)
+- Parallel p95: `15819497 ns/op` (~15.82ms)
+- Serial p50: `48700643 ns/op` (~48.70ms)
+- Serial p95: `50133908 ns/op` (~50.13ms)
+
+Observation:
+
+- Parallel worker tuning shows materially better median throughput than serial baseline while determinism tests remain green.
+- One high parallel outlier is retained in the evidence set and reflected in p95.

--- a/internal/languages/go_adapter.go
+++ b/internal/languages/go_adapter.go
@@ -7,21 +7,50 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 
 	"RepoDoctor/internal/model"
 )
 
 // GoAdapter implements LanguageAdapter for Go programming language
 type GoAdapter struct {
-	fset *token.FileSet
+	parseWorkers int
 }
+
+const maxGoParseWorkers = 8
 
 // NewGoAdapter creates a new Go language adapter
 func NewGoAdapter() *GoAdapter {
 	return &GoAdapter{
-		fset: token.NewFileSet(),
+		parseWorkers: defaultGoParseWorkers(),
 	}
+}
+
+func defaultGoParseWorkers() int {
+	workers := runtime.GOMAXPROCS(0)
+	if workers < 1 {
+		workers = 1
+	}
+	if workers > maxGoParseWorkers {
+		workers = maxGoParseWorkers
+	}
+	return workers
+}
+
+func goWorkerCount(configuredWorkers, total int) int {
+	if total <= 1 {
+		return 1
+	}
+	workers := configuredWorkers
+	if workers < 1 {
+		workers = 1
+	}
+	if workers > total {
+		workers = total
+	}
+	return workers
 }
 
 // Name returns the language name
@@ -70,14 +99,40 @@ func (a *GoAdapter) DetectFiles(repoPath string) ([]string, error) {
 // CollectMetrics extracts Go-specific metrics from source files
 func (a *GoAdapter) CollectMetrics(files []string) (*model.RepositoryMetrics, error) {
 	metrics := model.NewRepositoryMetrics()
+	if len(files) == 0 {
+		return metrics, nil
+	}
 
-	for _, file := range files {
-		fileMetrics, err := a.collectFileMetrics(file)
-		if err != nil {
+	type result struct {
+		fm  *model.FileMetrics
+		err error
+	}
+	results := make([]result, len(files))
+
+	jobs := make(chan int, len(files))
+	for idx := range files {
+		jobs <- idx
+	}
+	close(jobs)
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < goWorkerCount(a.parseWorkers, len(files)); worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for idx := range jobs {
+				fm, err := a.collectFileMetrics(files[idx])
+				results[idx] = result{fm: fm, err: err}
+			}
+		}()
+	}
+	wg.Wait()
+
+	for _, r := range results {
+		if r.err != nil || r.fm == nil {
 			continue // Skip files that can't be parsed
 		}
-
-		metrics.AddFileMetrics(*fileMetrics)
+		metrics.AddFileMetrics(*r.fm)
 	}
 
 	return metrics, nil
@@ -85,7 +140,8 @@ func (a *GoAdapter) CollectMetrics(files []string) (*model.RepositoryMetrics, er
 
 // collectFileMetrics extracts metrics from a single Go file
 func (a *GoAdapter) collectFileMetrics(path string) (*model.FileMetrics, error) {
-	node, err := parser.ParseFile(a.fset, path, nil, parser.ParseComments)
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +153,7 @@ func (a *GoAdapter) collectFileMetrics(path string) (*model.FileMetrics, error) 
 	}
 
 	// Count lines
-	file := a.fset.File(node.Pos())
+	file := fset.File(node.Pos())
 	if file != nil {
 		fm.Lines = file.LineCount()
 	}
@@ -110,12 +166,12 @@ func (a *GoAdapter) collectFileMetrics(path string) (*model.FileMetrics, error) 
 		switch x := n.(type) {
 		case *ast.FuncDecl:
 			fm.Functions++
-			funcMetrics := goExtractFunctionMetrics(a.fset, x, path)
+			funcMetrics := goExtractFunctionMetrics(fset, x, path)
 			metrics.AddFunctionMetrics(*funcMetrics)
 
 		case *ast.TypeSpec:
 			if structType, ok := x.Type.(*ast.StructType); ok {
-				structMetrics := goExtractStructMetrics(a.fset, x, structType, path)
+				structMetrics := goExtractStructMetrics(fset, x, structType, path)
 				metrics.AddStructMetrics(*structMetrics)
 			}
 		}
@@ -167,53 +223,78 @@ func goExtractStructMetrics(fset *token.FileSet, typeSpec *ast.TypeSpec, structT
 func (a *GoAdapter) BuildDependencyGraph(files []string) (*model.DependencyGraph, error) {
 	graph := model.NewDependencyGraph()
 	modulePath := resolveGoModulePath(files)
+	entries := parseGoImportEntriesParallel(files, a.parseWorkers)
 
-	for _, file := range files {
-		node, err := goParseFileAndAddToGraph(a.fset, file, modulePath, graph)
-		if err != nil {
+	for idx, file := range files {
+		entry := entries[idx]
+		if entry == nil {
 			continue
 		}
 
-		// Add edges for imports
-		if node != nil {
-			for _, imp := range node.Imports {
-				graph.AddEdge(node.ID, imp)
+		node := graph.AddNode(file, file, entry.packageName)
+		for _, imp := range entry.imports {
+			node.Imports = append(node.Imports, imp)
+			if node.Metadata == nil {
+				node.Metadata = make(map[string]string)
 			}
+			node.Metadata["import_class:"+imp] = string(classifyGoImportWithModule(imp, modulePath))
+		}
+		for _, imp := range entry.imports {
+			graph.AddEdge(node.ID, imp)
 		}
 	}
 
 	return graph, nil
 }
 
-// goParseFileAndAddToGraph parses a Go file and adds it to the dependency graph.
-// Package-level helper to keep GoAdapter method count within SRP bounds.
-func goParseFileAndAddToGraph(fset *token.FileSet, path, modulePath string, graph *model.DependencyGraph) (*model.Node, error) {
+type goImportEntry struct {
+	packageName string
+	imports     []string
+}
+
+func parseGoImportEntriesParallel(files []string, configuredWorkers int) []*goImportEntry {
+	entries := make([]*goImportEntry, len(files))
+	if len(files) == 0 {
+		return entries
+	}
+
+	jobs := make(chan int, len(files))
+	for idx := range files {
+		jobs <- idx
+	}
+	close(jobs)
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < goWorkerCount(configuredWorkers, len(files)); worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for idx := range jobs {
+				entries[idx] = parseGoImportEntry(files[idx])
+			}
+		}()
+	}
+	wg.Wait()
+
+	return entries
+}
+
+func parseGoImportEntry(path string) *goImportEntry {
+	fset := token.NewFileSet()
 	node, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
 	if err != nil {
-		return nil, err
+		return nil
 	}
 
-	fileInfo := fset.File(node.Pos())
-	if fileInfo == nil {
-		return nil, nil
-	}
-
-	pkgName := node.Name.Name
-	nodeID := path
-
-	graphNode := graph.AddNode(nodeID, path, pkgName)
-
-	// Extract imports
+	imports := make([]string, 0, len(node.Imports))
 	for _, imp := range node.Imports {
-		importPath := strings.Trim(imp.Path.Value, "\"")
-		graphNode.Imports = append(graphNode.Imports, importPath)
-		if graphNode.Metadata == nil {
-			graphNode.Metadata = make(map[string]string)
-		}
-		graphNode.Metadata["import_class:"+importPath] = string(classifyGoImportWithModule(importPath, modulePath))
+		imports = append(imports, strings.Trim(imp.Path.Value, "\""))
 	}
 
-	return graphNode, nil
+	return &goImportEntry{
+		packageName: node.Name.Name,
+		imports:     imports,
+	}
 }
 
 func resolveGoModulePath(files []string) string {

--- a/internal/languages/go_adapter_parallel_test.go
+++ b/internal/languages/go_adapter_parallel_test.go
@@ -1,0 +1,112 @@
+package languages
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"RepoDoctor/internal/model"
+)
+
+func TestGoAdapter_ParallelBuildDependencyGraph_Deterministic(t *testing.T) {
+	repo := t.TempDir()
+	writeGoFixture(t, repo, "go.mod", "module example.com/parallel\n\ngo 1.21\n")
+	writeGoFixture(t, repo, "a.go", "package main\nimport \"example.com/parallel/pkg\"\nfunc a(){}\n")
+	writeGoFixture(t, repo, "pkg/p.go", "package pkg\nimport \"fmt\"\nfunc p(){}\n")
+	writeGoFixture(t, repo, "pkg/q.go", "package pkg\nimport \"example.com/parallel/internal/x\"\nfunc q(){}\n")
+	writeGoFixture(t, repo, "internal/x/x.go", "package x\nfunc X(){}\n")
+
+	adapter := NewGoAdapter()
+	adapter.parseWorkers = 4
+
+	files, err := adapter.DetectFiles(repo)
+	if err != nil {
+		t.Fatalf("DetectFiles failed: %v", err)
+	}
+	sort.Strings(files)
+
+	first, err := adapter.BuildDependencyGraph(files)
+	if err != nil {
+		t.Fatalf("BuildDependencyGraph failed: %v", err)
+	}
+	baseline := canonicalGraphSnapshot(first)
+
+	for i := 0; i < 20; i++ {
+		next, nextErr := adapter.BuildDependencyGraph(files)
+		if nextErr != nil {
+			t.Fatalf("BuildDependencyGraph iteration %d failed: %v", i, nextErr)
+		}
+		if got := canonicalGraphSnapshot(next); got != baseline {
+			t.Fatalf("non-deterministic graph output on iteration %d\nwant=%s\ngot=%s", i, baseline, got)
+		}
+	}
+}
+
+func BenchmarkGoAdapter_ParallelParsing(b *testing.B) {
+	benchmarkGoAdapterParsing(b, 4)
+}
+
+func BenchmarkGoAdapter_SerialParsing(b *testing.B) {
+	benchmarkGoAdapterParsing(b, 1)
+}
+
+func benchmarkGoAdapterParsing(b *testing.B, workers int) {
+	repo := b.TempDir()
+	writeGoFixture(b, repo, "go.mod", "module example.com/bench\n\ngo 1.21\n")
+
+	for i := 0; i < 250; i++ {
+		content := "package bench\n"
+		if i > 0 {
+			content += "import \"fmt\"\n"
+		}
+		content += fmt.Sprintf("func F%d(){}\n", i)
+		writeGoFixture(b, repo, filepath.Join("pkg", fmt.Sprintf("f_%03d.go", i)), content)
+	}
+
+	adapter := NewGoAdapter()
+	adapter.parseWorkers = workers
+
+	files, err := adapter.DetectFiles(repo)
+	if err != nil {
+		b.Fatalf("DetectFiles failed: %v", err)
+	}
+	sort.Strings(files)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := adapter.CollectMetrics(files); err != nil {
+			b.Fatalf("CollectMetrics failed: %v", err)
+		}
+		if _, err := adapter.BuildDependencyGraph(files); err != nil {
+			b.Fatalf("BuildDependencyGraph failed: %v", err)
+		}
+	}
+}
+
+func canonicalGraphSnapshot(graph *model.DependencyGraph) string {
+	nodes := graph.GetNodes()
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].ID < nodes[j].ID })
+
+	parts := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		deps := append([]string(nil), graph.GetDependencies(node.ID)...)
+		sort.Strings(deps)
+		parts = append(parts, node.ID+"=>"+strings.Join(deps, ","))
+	}
+
+	return strings.Join(parts, "|")
+}
+
+func writeGoFixture(tb testing.TB, root, relPath, content string) {
+	tb.Helper()
+	fullPath := filepath.Join(root, relPath)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		tb.Fatalf("failed creating fixture dir: %v", err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+		tb.Fatalf("failed writing fixture file %s: %v", relPath, err)
+	}
+}


### PR DESCRIPTION
## Summary
- Tunes Go adapter parsing throughput with bounded worker parallelism and deterministic merge ordering.
- Adds deterministic concurrency regression tests plus serial-vs-parallel benchmark harnesses for evidence.
- Records benchmark evidence with p50/p95 summaries in `benchmarks/rd-14001.md`.

## Validation
- `go test ./internal/languages -run "TestGoAdapter_ParallelBuildDependencyGraph_Deterministic"`
- `go test ./internal/languages -bench "BenchmarkGoAdapter_(Parallel|Serial)Parsing" -benchmem -run ^$ -count 5`
- `go test ./...`
- `go vet ./...`
- `go run . analyze -path .` (100/100)
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns|TestGoAdapter_ParallelBuildDependencyGraph_Deterministic"`
- Conditional race check attempted: `go test -race ./...` (blocked in this environment due missing `gcc`/cgo toolchain)

Closes #268