### PR TITLE
feat(rd-14002): add deterministic memory budget enforcement

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -93,6 +93,9 @@ jobs:
           GOMAXPROCS: 1
         run: ./scripts/v130_release_stabilization_gate.ps1
 
+      - name: Run memory budget guard tests
+        run: go test ./internal/analysis -run "TestOrchestrator_Analyze_AppliesMemoryFileBudget|TestOrchestrator_Analyze_InvalidMemoryBudgetFailSoft"
+
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text
 

--- a/analysis_service.go
+++ b/analysis_service.go
@@ -54,6 +54,9 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 
 	if request.Verbose {
 		fmt.Printf(ColorInfo("Selected adapter: ")+"%s\n", analysisResult.AdapterName)
+		for _, warning := range analysisResult.Warnings {
+			fmt.Printf("%s", ColorWarn(fmt.Sprintf("Warning: %s\n", warning)))
+		}
 	}
 
 	graph := s.reportAdapterGraph(progress, analysisResult, request.Verbose)

--- a/internal/analysis/orchestrator.go
+++ b/internal/analysis/orchestrator.go
@@ -2,12 +2,16 @@ package analysis
 
 import (
 	"fmt"
+	"os"
 	"sort"
+	"strconv"
 
 	"RepoDoctor/internal/languages"
 	"RepoDoctor/internal/logger"
 	"RepoDoctor/internal/model"
 )
+
+const memoryFileBudgetEnv = "REPODOCTOR_MEMORY_FILE_BUDGET"
 
 // Orchestrator coordinates language detection and adapter-driven analysis steps.
 type Orchestrator struct {
@@ -21,6 +25,7 @@ type Result struct {
 	Files       []string
 	Metrics     *model.RepositoryMetrics
 	Graph       *model.DependencyGraph
+	Warnings    []string
 }
 
 // NewOrchestrator creates a new analysis orchestrator.
@@ -65,6 +70,10 @@ func (o *Orchestrator) Analyze(repoPath string) (*Result, error) {
 		return nil, fmt.Errorf("file detection failed for %s: %w", adapter.Name(), err)
 	}
 	sort.Strings(files)
+	files, warnings := applyMemoryFileBudget(files)
+	for _, warning := range warnings {
+		o.logger.Warn("analysis.memory_budget", "warning", warning)
+	}
 	o.logger.Debug("analysis.files_detected", "adapter", adapter.Name(), "count", len(files))
 
 	metrics, err := adapter.CollectMetrics(files)
@@ -85,5 +94,25 @@ func (o *Orchestrator) Analyze(repoPath string) (*Result, error) {
 		Files:       files,
 		Metrics:     metrics,
 		Graph:       graph,
+		Warnings:    warnings,
 	}, nil
+}
+
+func applyMemoryFileBudget(files []string) ([]string, []string) {
+	rawBudget := os.Getenv(memoryFileBudgetEnv)
+	if rawBudget == "" {
+		return files, nil
+	}
+
+	budget, err := strconv.Atoi(rawBudget)
+	if err != nil || budget <= 0 {
+		return files, []string{fmt.Sprintf("invalid %s value %q; ignoring budget", memoryFileBudgetEnv, rawBudget)}
+	}
+
+	if len(files) <= budget {
+		return files, nil
+	}
+
+	warning := fmt.Sprintf("memory budget active: limiting file set from %d to %d", len(files), budget)
+	return files[:budget], []string{warning}
 }

--- a/internal/analysis/orchestrator_capability_test.go
+++ b/internal/analysis/orchestrator_capability_test.go
@@ -22,12 +22,18 @@ func (d fakeDetector) DetectLanguage(repoPath string) (languages.LanguageAdapter
 func (d fakeDetector) GetSupportedLanguages() []string { return []string{"fake"} }
 
 type fakeAdapter struct {
-	caps languages.AdapterCapabilities
+	caps  languages.AdapterCapabilities
+	files []string
 }
 
-func (a fakeAdapter) Name() string                                  { return "Fake" }
-func (a fakeAdapter) FileExtensions() []string                      { return []string{".fake"} }
-func (a fakeAdapter) DetectFiles(repoPath string) ([]string, error) { return []string{}, nil }
+func (a fakeAdapter) Name() string             { return "Fake" }
+func (a fakeAdapter) FileExtensions() []string { return []string{".fake"} }
+func (a fakeAdapter) DetectFiles(repoPath string) ([]string, error) {
+	if a.files == nil {
+		return []string{}, nil
+	}
+	return append([]string(nil), a.files...), nil
+}
 func (a fakeAdapter) CollectMetrics(files []string) (*model.RepositoryMetrics, error) {
 	return model.NewRepositoryMetrics(), nil
 }
@@ -42,5 +48,45 @@ func TestOrchestrator_Analyze_RejectsMissingCapabilities(t *testing.T) {
 	orchestrator := NewOrchestrator(fakeDetector{adapter: fakeAdapter{caps: languages.AdapterCapabilities{}}})
 	if _, err := orchestrator.Analyze(t.TempDir()); err == nil {
 		t.Fatal("expected orchestrator to reject missing capabilities")
+	}
+}
+
+func TestOrchestrator_Analyze_AppliesMemoryFileBudget(t *testing.T) {
+	t.Setenv(memoryFileBudgetEnv, "2")
+	orchestrator := NewOrchestrator(fakeDetector{adapter: fakeAdapter{
+		caps:  languages.AdapterCapabilities{SupportsDependencyGraph: true, SupportsMetrics: true},
+		files: []string{"c.go", "a.go", "b.go"},
+	}})
+
+	result, err := orchestrator.Analyze(t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected analyze error: %v", err)
+	}
+
+	if len(result.Files) != 2 {
+		t.Fatalf("expected bounded file count 2, got %d", len(result.Files))
+	}
+	if len(result.Warnings) == 0 {
+		t.Fatal("expected memory budget warning")
+	}
+}
+
+func TestOrchestrator_Analyze_InvalidMemoryBudgetFailSoft(t *testing.T) {
+	t.Setenv(memoryFileBudgetEnv, "not-a-number")
+	orchestrator := NewOrchestrator(fakeDetector{adapter: fakeAdapter{
+		caps:  languages.AdapterCapabilities{SupportsDependencyGraph: true, SupportsMetrics: true},
+		files: []string{"a.go"},
+	}})
+
+	result, err := orchestrator.Analyze(t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected analyze error: %v", err)
+	}
+
+	if len(result.Files) != 1 {
+		t.Fatalf("expected file set to remain unchanged, got %d", len(result.Files))
+	}
+	if len(result.Warnings) == 0 {
+		t.Fatal("expected invalid-budget warning for fail-soft behavior")
 	}
 }


### PR DESCRIPTION
## Summary
- Adds fail-soft memory budget control in orchestration via `REPODOCTOR_MEMORY_FILE_BUDGET` with deterministic file-set truncation.
- Surfaces budget warnings (including invalid budget values) without hard failures so default behavior stays unchanged when budget is unset.
- Adds CI guard step and dedicated tests to enforce memory budget handling semantics.

## Validation
- `go test ./internal/analysis -run "TestOrchestrator_Analyze_RejectsMissingCapabilities|TestOrchestrator_Analyze_AppliesMemoryFileBudget|TestOrchestrator_Analyze_InvalidMemoryBudgetFailSoft"`
- `go test ./...`
- `go vet ./...`
- `go run . analyze -path .` (100/100)
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns|TestGoAdapter_ParallelBuildDependencyGraph_Deterministic"`

Closes #269