### PR TITLE
feat(rd-14003): add bounded cache warmup filesystem safety

### DIFF
--- a/analysis_service.go
+++ b/analysis_service.go
@@ -26,6 +26,8 @@ func NewAnalysisService() *AnalysisService {
 func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	absPath := validatePath(request.Path)
 	InitColorFormatter(request.ColorEnabled)
+	reportCacheWarmup(absPath, request.Verbose)
+
 	profiler, profileErr := startProfiling(request.Profiling)
 	if profileErr != nil {
 		fmt.Fprintf(os.Stderr, "%s", ColorError(fmt.Sprintf("Error: profiling setup failed: %v\n", profileErr)))
@@ -54,9 +56,7 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 
 	if request.Verbose {
 		fmt.Printf(ColorInfo("Selected adapter: ")+"%s\n", analysisResult.AdapterName)
-		for _, warning := range analysisResult.Warnings {
-			fmt.Printf("%s", ColorWarn(fmt.Sprintf("Warning: %s\n", warning)))
-		}
+		reportAnalysisWarnings(analysisResult.Warnings)
 	}
 
 	graph := s.reportAdapterGraph(progress, analysisResult, request.Verbose)
@@ -95,6 +95,26 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 
 	exitCode := determineExitCode(report)
 	return exitCode
+}
+
+func reportCacheWarmup(absPath string, verbose bool) {
+	cacheWarmupWarnings, warmupErr := maybeWarmupIncrementalCache(absPath)
+	if warmupErr != nil {
+		fmt.Fprintf(os.Stderr, "%s", ColorWarn(fmt.Sprintf("Warning: cache warmup skipped: %v\n", warmupErr)))
+		return
+	}
+	if !verbose {
+		return
+	}
+	for _, warning := range cacheWarmupWarnings {
+		fmt.Printf("%s", ColorInfo(warning+"\n"))
+	}
+}
+
+func reportAnalysisWarnings(warnings []string) {
+	for _, warning := range warnings {
+		fmt.Printf("%s", ColorWarn(fmt.Sprintf("Warning: %s\n", warning)))
+	}
 }
 
 func exportMetricsSnapshot(absPath, outputFormat string, result *analysispkg.Result, report *StructuralReport) error {

--- a/cache_warmup.go
+++ b/cache_warmup.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	analysispkg "RepoDoctor/internal/analysis"
+)
+
+const (
+	cacheWarmupEnv      = "REPODOCTOR_CACHE_WARMUP"
+	cacheWarmupLimitEnv = "REPODOCTOR_CACHE_WARMUP_LIMIT"
+)
+
+func maybeWarmupIncrementalCache(absPath string) ([]string, error) {
+	if strings.TrimSpace(os.Getenv(cacheWarmupEnv)) != "1" {
+		return nil, nil
+	}
+
+	cacheDir := filepath.Join(absPath, ".repodoctor", "cache")
+	if _, err := os.Stat(cacheDir); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	store, err := analysispkg.NewFileIncrementalSnapshotStore(cacheDir)
+	if err != nil {
+		return nil, err
+	}
+
+	limit := 128
+	if raw := strings.TrimSpace(os.Getenv(cacheWarmupLimitEnv)); raw != "" {
+		if parsed, parseErr := strconv.Atoi(raw); parseErr == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+
+	warmed, warnings, err := store.WarmupFromFilesystem(limit)
+	if err != nil {
+		return nil, err
+	}
+
+	info := fmt.Sprintf("cache warmup loaded %d snapshot(s)", warmed)
+	return append([]string{info}, warnings...), nil
+}

--- a/cache_warmup_test.go
+++ b/cache_warmup_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	analysispkg "RepoDoctor/internal/analysis"
+)
+
+func TestMaybeWarmupIncrementalCache_DefaultOff(t *testing.T) {
+	warnings, err := maybeWarmupIncrementalCache(t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warmup warnings when disabled, got %v", warnings)
+	}
+}
+
+func TestMaybeWarmupIncrementalCache_FailSoftAndBounded(t *testing.T) {
+	repo := t.TempDir()
+	cacheDir := filepath.Join(repo, ".repodoctor", "cache")
+	store, err := analysispkg.NewFileIncrementalSnapshotStore(cacheDir)
+	if err != nil {
+		t.Fatalf("failed creating cache store: %v", err)
+	}
+
+	valid := analysispkg.NewIncrementalCacheSnapshot("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", map[string]string{
+		"a.go": "1111111111111111111111111111111111111111111111111111111111111111",
+	})
+	if err := store.Save(valid); err != nil {
+		t.Fatalf("failed saving valid snapshot: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(cacheDir, "bad.json"), []byte("not-json"), 0o644); err != nil {
+		t.Fatalf("failed writing malformed entry: %v", err)
+	}
+
+	t.Setenv(cacheWarmupEnv, "1")
+	t.Setenv(cacheWarmupLimitEnv, "1")
+	warnings, warmErr := maybeWarmupIncrementalCache(repo)
+	if warmErr != nil {
+		t.Fatalf("expected fail-soft warmup, got %v", warmErr)
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected warmup summary output")
+	}
+	if !strings.Contains(warnings[0], "loaded") {
+		t.Fatalf("expected summary warning, got %v", warnings)
+	}
+}

--- a/internal/analysis/incremental_store_file.go
+++ b/internal/analysis/incremental_store_file.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -92,4 +93,70 @@ func (s *FileIncrementalSnapshotStore) snapshotPath(cacheKey string) (string, er
 		return "", fmt.Errorf("cache key must be 64-char lowercase hex")
 	}
 	return filepath.Join(s.baseDir, normalized+".json"), nil
+}
+
+// WarmupFromFilesystem validates on-disk cache entries with fail-soft behavior.
+// It never executes repository code and only reads files from store base directory.
+func (s *FileIncrementalSnapshotStore) WarmupFromFilesystem(limit int) (int, []string, error) {
+	if s == nil {
+		return 0, nil, fmt.Errorf("snapshot store is required")
+	}
+	if limit <= 0 {
+		limit = 128
+	}
+
+	entries, err := os.ReadDir(s.baseDir)
+	if err != nil {
+		return 0, nil, fmt.Errorf("read incremental cache directory: %w", err)
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	warmed := 0
+	warnings := make([]string, 0)
+	for _, entry := range entries {
+		if warmed >= limit {
+			break
+		}
+		if entry.IsDir() {
+			continue
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			warnings = append(warnings, "skipped symlink cache entry: "+entry.Name())
+			continue
+		}
+
+		key, ok := parseSnapshotFileName(entry.Name())
+		if !ok {
+			continue
+		}
+
+		path := filepath.Join(s.baseDir, entry.Name())
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			warnings = append(warnings, "failed reading cache entry: "+entry.Name())
+			continue
+		}
+
+		snapshot, valid := UnmarshalIncrementalCacheSnapshotSafe(data)
+		if !valid || snapshot.CacheKey != key {
+			warnings = append(warnings, "skipped malformed cache entry: "+entry.Name())
+			continue
+		}
+
+		warmed++
+	}
+
+	return warmed, warnings, nil
+}
+
+func parseSnapshotFileName(name string) (string, bool) {
+	if !strings.HasSuffix(name, ".json") {
+		return "", false
+	}
+	key := strings.TrimSuffix(name, ".json")
+	if len(key) != 64 || !isLowerHex(key) {
+		return "", false
+	}
+	return key, true
 }

--- a/internal/analysis/incremental_warmup_test.go
+++ b/internal/analysis/incremental_warmup_test.go
@@ -1,0 +1,85 @@
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileIncrementalSnapshotStore_WarmupFromFilesystem_FailSoft(t *testing.T) {
+	baseDir := t.TempDir()
+	store, err := NewFileIncrementalSnapshotStore(baseDir)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	validKey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	valid := NewIncrementalCacheSnapshot(validKey, map[string]string{"a.go": "1111111111111111111111111111111111111111111111111111111111111111"})
+	if err := store.Save(valid); err != nil {
+		t.Fatalf("failed saving valid snapshot: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(baseDir, "not-cache.txt"), []byte("ignore"), 0o644); err != nil {
+		t.Fatalf("failed writing ignored file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed writing malformed json file: %v", err)
+	}
+
+	warmed, warnings, warmErr := store.WarmupFromFilesystem(10)
+	if warmErr != nil {
+		t.Fatalf("warmup should be fail-soft, got error: %v", warmErr)
+	}
+	if warmed != 1 {
+		t.Fatalf("expected one warmed snapshot, got %d", warmed)
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected warnings for malformed cache entries")
+	}
+}
+
+func TestFileIncrementalSnapshotStore_WarmupFromFilesystem_RespectsLimit(t *testing.T) {
+	baseDir := t.TempDir()
+	store, err := NewFileIncrementalSnapshotStore(baseDir)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	keys := []string{
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+	}
+	for i, key := range keys {
+		snapshot := NewIncrementalCacheSnapshot(key, map[string]string{"f.go": "1111111111111111111111111111111111111111111111111111111111111111"})
+		snapshot.Fingerprints["f.go"] = string('1'+rune(i)) + "111111111111111111111111111111111111111111111111111111111111111"
+		if err := store.Save(snapshot); err != nil {
+			t.Fatalf("failed saving snapshot %d: %v", i, err)
+		}
+	}
+
+	warmed, warnings, warmErr := store.WarmupFromFilesystem(2)
+	if warmErr != nil {
+		t.Fatalf("warmup failed: %v", warmErr)
+	}
+	if warmed != 2 {
+		t.Fatalf("expected warmup limit 2, got %d", warmed)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for valid snapshots, got %v", warnings)
+	}
+}
+
+func TestParseSnapshotFileName(t *testing.T) {
+	key, ok := parseSnapshotFileName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json")
+	if !ok || key == "" {
+		t.Fatal("expected valid snapshot filename to parse")
+	}
+
+	if _, ok := parseSnapshotFileName("../escape.json"); ok {
+		t.Fatal("expected invalid filename to be rejected")
+	}
+	if _, ok := parseSnapshotFileName("nothex.json"); ok {
+		t.Fatal("expected non-hex key to be rejected")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds default-off cache warmup hooks (`REPODOCTOR_CACHE_WARMUP=1`) that validate local incremental cache snapshots with bounded limits.
- Implements filesystem safety checks in warmup flow (fail-soft malformed entry handling, key filename validation, symlink skip behavior, no repo code execution/process spawn).
- Adds unit tests for warmup safety/limits and root-level integration tests for opt-in warmup behavior.

## Validation
- `go test ./internal/analysis -run "TestFileIncrementalSnapshotStore_WarmupFromFilesystem_|TestParseSnapshotFileName"`
- `go test . -run "TestMaybeWarmupIncrementalCache_"`
- `go test ./...`
- `go vet ./...`
- `go run . analyze -path .` (100/100)
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns|TestGoAdapter_ParallelBuildDependencyGraph_Deterministic"`

Closes #270