### PR TITLE
feat(rd-15001): actionable remediation hints in violation output

### DIFF
--- a/colored_methods.go
+++ b/colored_methods.go
@@ -80,6 +80,9 @@ func writeCircularViolationsWithColor(sb *strings.Builder, report *StructuralRep
 		sb.WriteString(formatter.Error(fmt.Sprintf("[%d] ", i+1)))
 		sb.WriteString(formatter.Color(formatCyclePath(v.Path), ColorRed))
 		sb.WriteString("\n")
+		if v.Hint != "" {
+			sb.WriteString(formatter.Info(fmt.Sprintf("    Hint: %s\n", v.Hint)))
+		}
 	}
 	sb.WriteString("\n")
 }
@@ -99,6 +102,9 @@ func writeLayerViolationsWithColor(sb *strings.Builder, report *StructuralReport
 
 	for i, v := range report.Layer {
 		sb.WriteString(formatter.Warn(fmt.Sprintf("[%d] %s\n", i+1, v.Message)))
+		if v.Hint != "" {
+			sb.WriteString(formatter.Info(fmt.Sprintf("    Hint: %s\n", v.Hint)))
+		}
 	}
 	sb.WriteString("\n")
 }
@@ -124,6 +130,9 @@ func writeSizeViolationsWithColor(sb *strings.Builder, report *StructuralReport,
 			sb.WriteString(formatter.Info(fmt.Sprintf("[%d] File %s: %d lines (threshold: %d)\n",
 				i+1, v.File, v.Lines, v.Threshold)))
 		}
+		if v.Hint != "" {
+			sb.WriteString(formatter.Info(fmt.Sprintf("    Hint: %s\n", v.Hint)))
+		}
 	}
 	sb.WriteString("\n")
 }
@@ -144,6 +153,9 @@ func writeGodObjectViolationsWithColor(sb *strings.Builder, report *StructuralRe
 	for i, v := range report.GodObject {
 		sb.WriteString(formatter.Warn(fmt.Sprintf("[%d] Struct '%s' in %s: %d fields, %d methods\n",
 			i+1, v.StructName, v.File, v.FieldCount, v.MethodCount)))
+		if v.Hint != "" {
+			sb.WriteString(formatter.Info(fmt.Sprintf("    Hint: %s\n", v.Hint)))
+		}
 	}
 	sb.WriteString("\n")
 }
@@ -161,7 +173,7 @@ func writeScoreBreakdownWithColor(sb *strings.Builder, report *StructuralReport,
 	sb.WriteString("\n")
 	sb.WriteString(formatter.Color("└───────────────────────────────────────────────────────────┘", ColorCyan))
 	sb.WriteString("\n")
-	
+
 	sb.WriteString(fmt.Sprintf("Base Score:           100.0\n"))
 	sb.WriteString(fmt.Sprintf("Circular Penalty:     %s\n", formatter.Error(fmt.Sprintf("-%.1f (%d violations x 10.0)", report.Score.CircularPenalty, report.Score.CircularCount))))
 	sb.WriteString(fmt.Sprintf("Layer Penalty:        %s\n", formatter.Warn(fmt.Sprintf("-%.1f (%d violations x 5.0)", report.Score.LayerPenalty, report.Score.LayerCount))))

--- a/reporter_methods.go
+++ b/reporter_methods.go
@@ -54,6 +54,9 @@ func writeCircularViolations(sb *strings.Builder, report *StructuralReport) {
 		sb.WriteString(fmt.Sprintf("[%d] ", i+1))
 		sb.WriteString(formatCyclePath(v.Path))
 		sb.WriteString("\n")
+		if v.Hint != "" {
+			sb.WriteString(fmt.Sprintf("    Hint: %s\n", v.Hint))
+		}
 	}
 	sb.WriteString("\n")
 }
@@ -69,6 +72,9 @@ func writeLayerViolations(sb *strings.Builder, report *StructuralReport) {
 
 	for i, v := range report.Layer {
 		sb.WriteString(fmt.Sprintf("[%d] %s\n", i+1, v.Message))
+		if v.Hint != "" {
+			sb.WriteString(fmt.Sprintf("    Hint: %s\n", v.Hint))
+		}
 	}
 	sb.WriteString("\n")
 }
@@ -90,6 +96,9 @@ func writeSizeViolations(sb *strings.Builder, report *StructuralReport) {
 			sb.WriteString(fmt.Sprintf("[%d] File %s: %d lines (threshold: %d)\n",
 				i+1, v.File, v.Lines, v.Threshold))
 		}
+		if v.Hint != "" {
+			sb.WriteString(fmt.Sprintf("    Hint: %s\n", v.Hint))
+		}
 	}
 	sb.WriteString("\n")
 }
@@ -106,6 +115,9 @@ func writeGodObjectViolations(sb *strings.Builder, report *StructuralReport) {
 	for i, v := range report.GodObject {
 		sb.WriteString(fmt.Sprintf("[%d] Struct '%s' in %s: %d fields, %d methods\n",
 			i+1, v.StructName, v.File, v.FieldCount, v.MethodCount))
+		if v.Hint != "" {
+			sb.WriteString(fmt.Sprintf("    Hint: %s\n", v.Hint))
+		}
 	}
 	sb.WriteString("\n")
 }

--- a/reporter_methods_test.go
+++ b/reporter_methods_test.go
@@ -17,14 +17,15 @@ func TestReporterWriteSections_TextMethods(t *testing.T) {
 			SizePenalty:      0,
 			GodObjectPenalty: 0,
 		},
-		Circular: []CycleViolation{{Path: []string{"a", "b"}}},
-		Layer:    []LayerViolation{{From: "repo", To: "handler"}},
-		Size:     []SizeViolation{{File: "big.go", Lines: 800, Threshold: 500}},
+		Circular: []CycleViolation{{Path: []string{"a", "b"}, Hint: "Break the cycle by extracting shared contracts."}},
+		Layer:    []LayerViolation{{From: "repo", To: "handler", Hint: "Move dependency behind an interface boundary."}},
+		Size:     []SizeViolation{{File: "big.go", Lines: 800, Threshold: 500, Hint: "Split into smaller focused units."}},
 		GodObject: []GodObjectViolation{{
 			File:        "god.go",
 			StructName:  "God",
 			FieldCount:  20,
 			MethodCount: 12,
+			Hint:        "Extract cohesive collaborators from God.",
 		}},
 		HasViolations: true,
 	}
@@ -45,5 +46,8 @@ func TestReporterWriteSections_TextMethods(t *testing.T) {
 		if !strings.Contains(out, token) {
 			t.Fatalf("expected output to include %q, got %q", token, out)
 		}
+	}
+	if !strings.Contains(out, "Hint:") {
+		t.Fatalf("expected actionable hint lines in output, got %q", out)
 	}
 }


### PR DESCRIPTION
## Summary
- render remediation hints under each violation entry in standard text output and colored output
- preserve existing JSON contracts (`json-v1` and `json` schemas unchanged) while improving operator guidance in CLI output
- add coverage to ensure hint lines are present in report text rendering

## Validation
- `go test ./...`
- `go vet ./...`
- `go test ./... -run TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns`
- `go run . analyze -path .`

Closes #272