### PR TITLE
feat(rd-15002): add opt-in interactive fix suggestions

### DIFF
--- a/analysis_service.go
+++ b/analysis_service.go
@@ -24,6 +24,11 @@ func NewAnalysisService() *AnalysisService {
 }
 
 func (s *AnalysisService) Run(request AnalyzeRequest) int {
+	exitCode, _ := s.RunWithReport(request)
+	return exitCode
+}
+
+func (s *AnalysisService) RunWithReport(request AnalyzeRequest) (int, *StructuralReport) {
 	absPath := validatePath(request.Path)
 	InitColorFormatter(request.ColorEnabled)
 	reportCacheWarmup(absPath, request.Verbose)
@@ -31,7 +36,7 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	profiler, profileErr := startProfiling(request.Profiling)
 	if profileErr != nil {
 		fmt.Fprintf(os.Stderr, "%s", ColorError(fmt.Sprintf("Error: profiling setup failed: %v\n", profileErr)))
-		return 1
+		return 1, nil
 	}
 
 	if profiler != nil {
@@ -51,7 +56,7 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	analysisResult, err := runAdapterPipeline(absPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s", ColorError(fmt.Sprintf("Error: analysis pipeline failed: %v\n", err)))
-		return 1
+		return 1, nil
 	}
 
 	if request.Verbose {
@@ -94,7 +99,7 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	}
 
 	exitCode := determineExitCode(report)
-	return exitCode
+	return exitCode, report
 }
 
 func reportCacheWarmup(absPath string, verbose bool) {

--- a/interactive.go
+++ b/interactive.go
@@ -16,6 +16,7 @@ type InteractiveMode struct {
 	io               *interactiveIO
 	configController *InteractiveConfigController
 	session          *InteractiveSession
+	fixSuggestions   *InteractiveFixSuggestionAdvisor
 }
 
 type interactiveIO struct {
@@ -35,6 +36,7 @@ func NewInteractiveMode() *InteractiveMode {
 		io:               io,
 		configController: NewInteractiveConfigController(io),
 		session:          nil,
+		fixSuggestions:   NewInteractiveFixSuggestionAdvisorFromEnv(io),
 	}
 }
 
@@ -78,7 +80,7 @@ func (i *InteractiveMode) analyzeMenu() {
 	switch choice {
 	case 1:
 		fmt.Println("\nAnalyzing current repository...")
-		runAnalyze(".", "text", false, true, true, profilingRequest{})
+		i.runInteractiveAnalysis(".")
 	case 2:
 		path := i.io.readString("\nEnter path to analyze: ")
 		if path == "" {
@@ -86,12 +88,30 @@ func (i *InteractiveMode) analyzeMenu() {
 			return
 		}
 		fmt.Printf("\nAnalyzing repository: %s\n", path)
-		runAnalyze(path, "text", false, true, true, profilingRequest{})
+		i.runInteractiveAnalysis(path)
 	case 3:
 		return
 	default:
 		fmt.Println("Invalid choice")
 	}
+}
+
+func (i *InteractiveMode) runInteractiveAnalysis(path string) {
+	if i.fixSuggestions == nil || !i.fixSuggestions.Enabled {
+		runAnalyze(path, "text", false, true, true, profilingRequest{})
+		return
+	}
+
+	service := NewAnalysisService()
+	_, report := service.RunWithReport(AnalyzeRequest{
+		Path:            path,
+		Format:          "text",
+		Verbose:         false,
+		ColorEnabled:    true,
+		ExitOnViolation: false,
+		Profiling:       profilingRequest{},
+	})
+	i.fixSuggestions.MaybePrint(report)
 }
 
 // viewHistory displays analysis history

--- a/interactive_fix_suggestions.go
+++ b/interactive_fix_suggestions.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const interactiveFixSuggestionsEnv = "REPODOCTOR_INTERACTIVE_FIX_SUGGESTIONS"
+
+type InteractiveFixSuggestionAdvisor struct {
+	Enabled bool
+	io      *interactiveIO
+}
+
+func NewInteractiveFixSuggestionAdvisorFromEnv(io *interactiveIO) *InteractiveFixSuggestionAdvisor {
+	return &InteractiveFixSuggestionAdvisor{
+		Enabled: parseBoolEnv(interactiveFixSuggestionsEnv),
+		io:      io,
+	}
+}
+
+func (a *InteractiveFixSuggestionAdvisor) MaybePrint(report *StructuralReport) {
+	if a == nil || !a.Enabled || report == nil || !report.HasViolations {
+		return
+	}
+
+	suggestions := buildInteractiveFixSuggestions(report)
+	if len(suggestions) == 0 {
+		return
+	}
+
+	fmt.Printf("\nInteractive fix suggestions are enabled via %s.\n", interactiveFixSuggestionsEnv)
+	fmt.Println("Suggestions are advisory only; no files are changed automatically.")
+	if !a.io.confirm("Show remediation suggestions") {
+		return
+	}
+
+	fmt.Println()
+	for idx, item := range suggestions {
+		fmt.Printf("  %d. %s\n", idx+1, item)
+	}
+	fmt.Println()
+}
+
+func buildInteractiveFixSuggestions(report *StructuralReport) []string {
+	items := make([]string, 0, 4)
+
+	if len(report.Circular) > 0 {
+		items = append(items, firstHintOrFallback(report.Circular[0].Hint,
+			"Break dependency cycles by extracting shared contracts into a lower layer and inverting dependencies."))
+	}
+	if len(report.Layer) > 0 {
+		items = append(items, firstHintOrFallback(report.Layer[0].Hint,
+			"Move upward imports behind an interface or toward a lower layer allowed by your profile."))
+	}
+	if len(report.Size) > 0 {
+		items = append(items, firstHintOrFallback(report.Size[0].Hint,
+			"Split oversized files/functions into smaller focused units and keep one responsibility per unit."))
+	}
+	if len(report.GodObject) > 0 {
+		items = append(items, firstHintOrFallback(report.GodObject[0].Hint,
+			"Extract cohesive collaborators and reduce broad structs into dedicated components."))
+	}
+
+	return items
+}
+
+func firstHintOrFallback(hint, fallback string) string {
+	trimmed := strings.TrimSpace(hint)
+	if trimmed != "" {
+		return trimmed
+	}
+	return fallback
+}
+
+func parseBoolEnv(key string) bool {
+	raw := strings.TrimSpace(strings.ToLower(os.Getenv(key)))
+	if raw == "" {
+		return false
+	}
+	if value, err := strconv.ParseBool(raw); err == nil {
+		return value
+	}
+	return raw == "1" || raw == "yes" || raw == "on" || raw == "enabled"
+}

--- a/interactive_fix_suggestions_test.go
+++ b/interactive_fix_suggestions_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func TestParseBoolEnv_DefaultOffAndTruthyValues(t *testing.T) {
+	t.Setenv(interactiveFixSuggestionsEnv, "")
+	if parseBoolEnv(interactiveFixSuggestionsEnv) {
+		t.Fatal("expected empty env to keep interactive suggestions disabled")
+	}
+
+	t.Setenv(interactiveFixSuggestionsEnv, "yes")
+	if !parseBoolEnv(interactiveFixSuggestionsEnv) {
+		t.Fatal("expected 'yes' to enable interactive suggestions")
+	}
+}
+
+func TestBuildInteractiveFixSuggestions_UsesHintsWithFallbacks(t *testing.T) {
+	report := &StructuralReport{
+		HasViolations: true,
+		Circular:      []CycleViolation{{Hint: "cycle hint"}},
+		Layer:         []LayerViolation{{Hint: ""}},
+		Size:          []SizeViolation{{Hint: "size hint"}},
+		GodObject:     []GodObjectViolation{{Hint: ""}},
+	}
+
+	got := buildInteractiveFixSuggestions(report)
+	if len(got) != 4 {
+		t.Fatalf("expected one suggestion per violation class, got %d", len(got))
+	}
+	if got[0] != "cycle hint" {
+		t.Fatalf("expected explicit circular hint first, got %q", got[0])
+	}
+	if !strings.Contains(got[1], "interface") {
+		t.Fatalf("expected layer fallback suggestion, got %q", got[1])
+	}
+}
+
+func TestInteractiveFixSuggestionAdvisor_MaybePrintAdvisoryOnly(t *testing.T) {
+	advisor := &InteractiveFixSuggestionAdvisor{
+		Enabled: true,
+		io:      &interactiveIO{reader: bufio.NewReader(strings.NewReader("yes\n"))},
+	}
+	report := &StructuralReport{
+		HasViolations: true,
+		Size:          []SizeViolation{{Hint: "split long function"}},
+	}
+
+	out := captureStdout(t, func() {
+		advisor.MaybePrint(report)
+	})
+	if !strings.Contains(out, "advisory only") {
+		t.Fatalf("expected advisory-only wording in output, got %q", out)
+	}
+	if !strings.Contains(out, "split long function") {
+		t.Fatalf("expected rendered suggestion in output, got %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add interactive remediation suggestions workflow gated by `REPODOCTOR_INTERACTIVE_FIX_SUGGESTIONS` (default-off)
- keep suggestions advisory-only and user-confirmed, with no autonomous file mutation
- preserve baseline behavior when disabled by using existing `runAnalyze` path unchanged

## Validation
- `go test ./...`
- `go vet ./...`
- `go test ./... -run TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns`
- `go run . analyze -path .`

Closes #273