### PR TITLE
ci(rd-15003): add Homebrew and Docker distribution pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.repodoctor
+docs
+benchmarks
+vscode-repodoctor
+repodoctor-report.json
+repodoctor-report.sha256
+benchmark-gate.txt
+*.md

--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -1,0 +1,67 @@
+name: Release Distribution
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker-ghcr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Enforce release tag on main lineage
+        shell: bash
+        run: |
+          git fetch origin main --depth=1
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Log in to GHCR
+        shell: bash
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and push Docker image
+        shell: bash
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/repodoctor"
+          VERSION="${GITHUB_REF_NAME}"
+          BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          docker build \
+            --build-arg VERSION="${VERSION}" \
+            --build-arg VCS_REF="${GITHUB_SHA}" \
+            --build-arg BUILD_DATE="${BUILD_DATE}" \
+            -t "${IMAGE}:${VERSION}" \
+            -t "${IMAGE}:latest" \
+            .
+          docker push "${IMAGE}:${VERSION}"
+          docker push "${IMAGE}:latest"
+
+      - name: Docker smoke test
+        shell: bash
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/repodoctor"
+          docker run --rm "${IMAGE}:${GITHUB_REF_NAME}" version
+
+  homebrew-formula-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Formula lint smoke
+        shell: bash
+        run: ruby -c Formula/repodoctor.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM golang:1.24.2-alpine3.21 AS builder
+
+ARG VERSION=dev
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+
+ENV CGO_ENABLED=0
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" -o /out/repodoctor .
+
+FROM alpine:3.21
+
+ARG VERSION=dev
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+
+RUN apk --no-cache add ca-certificates && adduser -D -u 10001 repodoctor
+COPY --from=builder /out/repodoctor /usr/local/bin/repodoctor
+
+LABEL org.opencontainers.image.title="RepoDoctor" \
+      org.opencontainers.image.description="Static architecture analysis for software repositories" \
+      org.opencontainers.image.source="https://github.com/AdemFurkanATA/RepoDoctor" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
+
+USER repodoctor
+WORKDIR /repo
+
+ENTRYPOINT ["repodoctor"]
+CMD ["analyze", "-path", "/repo"]

--- a/Formula/repodoctor.rb
+++ b/Formula/repodoctor.rb
@@ -1,0 +1,24 @@
+class Repodoctor < Formula
+  desc "Static architecture analysis for software repositories"
+  homepage "https://github.com/AdemFurkanATA/RepoDoctor"
+  url "https://github.com/AdemFurkanATA/RepoDoctor/archive/refs/heads/main.tar.gz"
+  version "main"
+  sha256 :no_check
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = [
+      "-s",
+      "-w",
+      "-X",
+      "main.version=#{version}"
+    ]
+    system "go", "build", "-trimpath", *std_go_args(ldflags:), "."
+  end
+
+  test do
+    assert_match "RepoDoctor", shell_output("#{bin}/repodoctor version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -117,6 +117,26 @@ go build .
 
 This produces a local binary (`RepoDoctor` / `RepoDoctor.exe`).
 
+### Homebrew (formula)
+
+```bash
+brew install --build-from-source ./Formula/repodoctor.rb
+```
+
+### Docker
+
+```bash
+docker build -t repodoctor:local .
+docker run --rm -v "$(pwd):/repo" repodoctor:local analyze -path /repo
+```
+
+Distribution pipeline details:
+
+- `Dockerfile`
+- `Formula/repodoctor.rb`
+- `.github/workflows/release-distribution.yml`
+- `docs/v1.5-rd-15003-release-distribution.md`
+
 ---
 
 ## Usage

--- a/docs/report.md
+++ b/docs/report.md
@@ -13,7 +13,7 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v1.2 | M5: v1.2 Test Quality & Coverage | Completed | RD-12001..RD-12006 merged into `dev`; root/model/rules coverage hardening, parser fuzz/property determinism tests, and v1.2 gate pack activated. |
 | v1.3 | M6: v1.3 Observability | Completed | RD-13001..RD-13005 merged into `dev`; structured logging, safe profiling hooks, error taxonomy hardening, deterministic metrics export, and v1.3 gate pack activated. |
 | v1.4 | M7: v1.4 Performance Hardening | Completed | RD-14001..RD-14004 merged into `dev`; parallel parsing tuning, memory budget fail-soft controls, filesystem-safe cache warmup, and benchmark/race gate automation activated. |
-| v1.5 | M8: v1.5 Developer Experience | Planned | Issue chain RD-15001..RD-15005 prepared with output-compatibility and release-distribution controls. |
+| v1.5 | M8: v1.5 Developer Experience | In Progress | RD-15001..RD-15003 merged into `dev`; actionable hints, opt-in interactive suggestions, and distribution pipeline foundations are active. |
 
 ---
 
@@ -82,6 +82,17 @@ Release path:
 - Feature PRs merged into `dev`: #295, #296, #297, #298
 - Release PR (`dev -> main`): pending (create after v1.4 gate PR merges and CI remains green)
 
+### v1.5 (M8: Developer Experience)
+
+- **RD-15001**: actionable remediation hints rendered in text/colored report output
+- **RD-15002**: interactive fix suggestions flow (default-off, confirmation-gated, advisory-only)
+- **RD-15003**: Homebrew formula + Docker multi-stage image + tag-triggered GHCR distribution workflow
+
+Release path:
+
+- Feature PRs merged into `dev`: #300, #301, pending RD-15003/15004/15005
+- Release PR (`dev -> main`): pending (after RD-15004 and RD-15005 merge)
+
 ## Current Branch/Release State
 
 - Latest completed release line is synchronized on `main`; `dev` may temporarily run ahead with planning/docs-only deltas before the next release merge.
@@ -102,4 +113,4 @@ Release path:
    - merge
 4. After each milestone chain closes on `dev`, open release PR `dev -> main` and keep `dev` branch intact.
 
-Son güncelleme: 4 Nisan 2026 (v1.4 chain)
+Son güncelleme: 4 Nisan 2026 (v1.5 chain in progress)

--- a/docs/v1.5-rd-15003-release-distribution.md
+++ b/docs/v1.5-rd-15003-release-distribution.md
@@ -1,0 +1,34 @@
+# RD-15003 Release Distribution Notes
+
+This note defines the reproducible distribution flow for Homebrew and Docker.
+
+## Scope
+
+- Homebrew formula added at `Formula/repodoctor.rb`.
+- Multi-stage runtime image added at `Dockerfile`.
+- Tag-triggered GHCR publish workflow added at `.github/workflows/release-distribution.yml`.
+
+## Reproducible Build Metadata
+
+Docker image build embeds deterministic metadata through OCI labels:
+
+- `org.opencontainers.image.version` = tag (for example `v1.5.0`)
+- `org.opencontainers.image.revision` = `GITHUB_SHA`
+- `org.opencontainers.image.created` = UTC build timestamp
+- `org.opencontainers.image.source` = repository URL
+
+Build inputs are passed as explicit `--build-arg` values in CI.
+
+## Supply-Chain Guardrails
+
+- Workflow permissions are minimal: `contents: read`, `packages: write`.
+- `actions/checkout` is SHA-pinned.
+- Release tags are rejected unless tagged commit is on `origin/main` lineage:
+  `git merge-base --is-ancestor "$GITHUB_SHA" origin/main`.
+
+This preserves the existing `dev -> main` release policy by preventing off-lineage tag publishing.
+
+## Homebrew Update Rule for Stable Releases
+
+`Formula/repodoctor.rb` currently tracks main branch tarball (`sha256 :no_check`) for bootstrap convenience.
+Before stable release publication, update formula to a tag tarball with fixed SHA256.


### PR DESCRIPTION
## Summary
- add release distribution artifacts: `Dockerfile`, `.dockerignore`, and `Formula/repodoctor.rb`
- add tag-triggered GHCR publish workflow with pinned checkout, least-privilege permissions, and main-lineage enforcement
- document reproducible build metadata and supply-chain controls in release docs and README

## Validation
- `go test ./...`
- `go vet ./...`
- `go test ./... -run TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns`
- `go run . analyze -path .`
- local docker/ruby smoke checks attempted but unavailable in this runner (`docker` daemon off, `ruby` missing)

Closes #274