### PR TITLE
feat(rd-15004): add isolated VS Code extension skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ docker build -t repodoctor:local .
 docker run --rm -v "$(pwd):/repo" repodoctor:local analyze -path /repo
 ```
 
+### VS Code extension skeleton
+
+```bash
+cd vscode-repodoctor
+npm install
+npm run compile
+```
+
+See `docs/v1.5-rd-15003-release-distribution.md` for release distribution details.
+
 Distribution pipeline details:
 
 - `Dockerfile`

--- a/docs/report.md
+++ b/docs/report.md
@@ -13,7 +13,7 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v1.2 | M5: v1.2 Test Quality & Coverage | Completed | RD-12001..RD-12006 merged into `dev`; root/model/rules coverage hardening, parser fuzz/property determinism tests, and v1.2 gate pack activated. |
 | v1.3 | M6: v1.3 Observability | Completed | RD-13001..RD-13005 merged into `dev`; structured logging, safe profiling hooks, error taxonomy hardening, deterministic metrics export, and v1.3 gate pack activated. |
 | v1.4 | M7: v1.4 Performance Hardening | Completed | RD-14001..RD-14004 merged into `dev`; parallel parsing tuning, memory budget fail-soft controls, filesystem-safe cache warmup, and benchmark/race gate automation activated. |
-| v1.5 | M8: v1.5 Developer Experience | In Progress | RD-15001..RD-15003 merged into `dev`; actionable hints, opt-in interactive suggestions, and distribution pipeline foundations are active. |
+| v1.5 | M8: v1.5 Developer Experience | In Progress | RD-15001..RD-15003 merged into `dev`; isolated VS Code skeleton work (RD-15004) is in review. |
 
 ---
 
@@ -84,14 +84,15 @@ Release path:
 
 ### v1.5 (M8: Developer Experience)
 
-- **RD-15001**: actionable remediation hints rendered in text/colored report output
-- **RD-15002**: interactive fix suggestions flow (default-off, confirmation-gated, advisory-only)
-- **RD-15003**: Homebrew formula + Docker multi-stage image + tag-triggered GHCR distribution workflow
+- **RD-15001**: actionable remediation hints in text/colored outputs
+- **RD-15002**: default-off interactive remediation suggestions (confirmation-gated, advisory-only)
+- **RD-15003**: Homebrew + Docker distribution foundation with tag-triggered GHCR workflow
+- **RD-15004**: isolated VS Code extension skeleton under `vscode-repodoctor/` consuming CLI JSON output only
 
 Release path:
 
-- Feature PRs merged into `dev`: #300, #301, pending RD-15003/15004/15005
-- Release PR (`dev -> main`): pending (after RD-15004 and RD-15005 merge)
+- Feature PRs merged into `dev`: #300, #301, #302, pending RD-15004/15005
+- Release PR (`dev -> main`): pending (after RD-15005 merge)
 
 ## Current Branch/Release State
 

--- a/docs/v1.5-rd-15004-architecture-impact.md
+++ b/docs/v1.5-rd-15004-architecture-impact.md
@@ -1,0 +1,15 @@
+# RD-15004 Architecture Impact Note
+
+## Boundary Statement
+
+`vscode-repodoctor/` is a standalone TypeScript extension package and does not participate in Go module dependency graph.
+
+## Coupling Policy
+
+- Extension integration is CLI-only (`repodoctor analyze -format json`).
+- No imports from Go internals.
+- No changes to core analysis layers (`internal/domain`, `internal/engine`, `internal/rules`).
+
+## Contract Authority
+
+Core CLI JSON output remains authoritative. Extension code adapts to output fields without forcing core architecture changes.

--- a/vscode-repodoctor/.gitignore
+++ b/vscode-repodoctor/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+out/
+.vscode-test/

--- a/vscode-repodoctor/README.md
+++ b/vscode-repodoctor/README.md
@@ -1,0 +1,25 @@
+# VS Code RepoDoctor Extension (Skeleton)
+
+This directory is an isolated extension skeleton for RD-15004.
+
+## Scope
+
+- Runs `repodoctor analyze -path <workspace> -format json`.
+- Parses JSON output and publishes diagnostics to Problems panel.
+- Shows install guidance when `repodoctor` binary is missing.
+
+## Architecture Boundary
+
+- The extension is a separate TypeScript project under `vscode-repodoctor/`.
+- No Go core module/runtime dependencies are introduced.
+- Core CLI output remains authoritative; extension consumes CLI JSON only.
+
+## Local Development
+
+```bash
+cd vscode-repodoctor
+npm install
+npm run compile
+```
+
+Then open this repository in VS Code and run Extension Host from the debugger.

--- a/vscode-repodoctor/package-lock.json
+++ b/vscode-repodoctor/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "vscode-repodoctor",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vscode-repodoctor",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^20.16.2",
+        "@types/vscode": "^1.92.0",
+        "typescript": "^5.6.2"
+      },
+      "engines": {
+        "vscode": "^1.92.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.110.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
+      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/vscode-repodoctor/package.json
+++ b/vscode-repodoctor/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "vscode-repodoctor",
+  "displayName": "RepoDoctor",
+  "description": "RepoDoctor CLI integration for VS Code diagnostics.",
+  "version": "0.0.1",
+  "publisher": "repodoctor",
+  "engines": {
+    "vscode": "^1.92.0"
+  },
+  "categories": [
+    "Linters",
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:repodoctor.analyzeWorkspace",
+    "workspaceContains:**/*"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "repodoctor.analyzeWorkspace",
+        "title": "RepoDoctor: Analyze Workspace"
+      }
+    ],
+    "configuration": {
+      "title": "RepoDoctor",
+      "properties": {
+        "repodoctor.runOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "Run RepoDoctor analysis on file save."
+        },
+        "repodoctor.binaryPath": {
+          "type": "string",
+          "default": "repodoctor",
+          "description": "Path to repodoctor binary."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.2",
+    "@types/vscode": "^1.92.0",
+    "typescript": "^5.6.2"
+  }
+}

--- a/vscode-repodoctor/src/analyzer.ts
+++ b/vscode-repodoctor/src/analyzer.ts
@@ -1,0 +1,36 @@
+import { execFile } from "node:child_process";
+
+export interface RepoDoctorReport {
+  circularViolations?: Array<{ path?: string[]; severity?: string; hint?: string }>;
+  layerViolations?: Array<{ from?: string; to?: string; message?: string; hint?: string }>;
+  sizeViolations?: Array<{ file?: string; function?: string; lines?: number; threshold?: number; hint?: string }>;
+  godObjectViolations?: Array<{ struct?: string; file?: string; fields?: number; methods?: number; hint?: string }>;
+}
+
+export class RepoDoctorAnalyzer {
+  public async run(binaryPath: string, workspacePath: string): Promise<RepoDoctorReport> {
+    const output = await this.exec(binaryPath, ["analyze", "-path", workspacePath, "-format", "json"]);
+    return this.parseReport(output);
+  }
+
+  private exec(binaryPath: string, args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+      execFile(binaryPath, args, { maxBuffer: 10 * 1024 * 1024 }, (error, stdout, stderr) => {
+        if (error) {
+          const details = stderr && stderr.trim() !== "" ? stderr.trim() : error.message;
+          reject(new Error(details));
+          return;
+        }
+        resolve(stdout);
+      });
+    });
+  }
+
+  private parseReport(raw: string): RepoDoctorReport {
+    const trimmed = raw.trim();
+    if (trimmed === "") {
+      throw new Error("repodoctor returned empty JSON output");
+    }
+    return JSON.parse(trimmed) as RepoDoctorReport;
+  }
+}

--- a/vscode-repodoctor/src/diagnostics.ts
+++ b/vscode-repodoctor/src/diagnostics.ts
@@ -1,0 +1,93 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+import type { RepoDoctorReport } from "./analyzer";
+
+export class RepoDoctorDiagnostics {
+  private readonly collection: vscode.DiagnosticCollection;
+
+  constructor() {
+    this.collection = vscode.languages.createDiagnosticCollection("repodoctor");
+  }
+
+  public dispose(): void {
+    this.collection.dispose();
+  }
+
+  public publish(workspacePath: string, report: RepoDoctorReport): void {
+    const grouped = new Map<string, vscode.Diagnostic[]>();
+
+    this.pushCircularDiagnostics(grouped, workspacePath, report.circularViolations ?? []);
+    this.pushLayerDiagnostics(grouped, workspacePath, report.layerViolations ?? []);
+    this.pushSizeDiagnostics(grouped, workspacePath, report.sizeViolations ?? []);
+    this.pushGodObjectDiagnostics(grouped, workspacePath, report.godObjectViolations ?? []);
+
+    this.collection.clear();
+    for (const [filePath, diagnostics] of grouped.entries()) {
+      this.collection.set(vscode.Uri.file(filePath), diagnostics);
+    }
+  }
+
+  private pushCircularDiagnostics(grouped: Map<string, vscode.Diagnostic[]>, workspacePath: string, violations: Array<{ path?: string[]; hint?: string }>): void {
+    for (const violation of violations) {
+      if (!violation.path || violation.path.length === 0) {
+        continue;
+      }
+      const cycle = violation.path.join(" -> ");
+      this.add(grouped, this.resolvePath(workspacePath, violation.path[0]), this.withHint(`Circular dependency: ${cycle}`, violation.hint), vscode.DiagnosticSeverity.Error);
+    }
+  }
+
+  private pushLayerDiagnostics(grouped: Map<string, vscode.Diagnostic[]>, workspacePath: string, violations: Array<{ from?: string; message?: string; hint?: string }>): void {
+    for (const violation of violations) {
+      if (!violation.from) {
+        continue;
+      }
+      const message = this.withHint(violation.message ?? "Layer violation", violation.hint);
+      this.add(grouped, this.resolvePath(workspacePath, violation.from), message, vscode.DiagnosticSeverity.Error);
+    }
+  }
+
+  private pushSizeDiagnostics(grouped: Map<string, vscode.Diagnostic[]>, workspacePath: string, violations: Array<{ file?: string; function?: string; lines?: number; threshold?: number; hint?: string }>): void {
+    for (const violation of violations) {
+      if (!violation.file) {
+        continue;
+      }
+      const base = violation.function
+        ? `Function '${violation.function}' has ${violation.lines ?? 0} lines (threshold: ${violation.threshold ?? 0})`
+        : `File has ${violation.lines ?? 0} lines (threshold: ${violation.threshold ?? 0})`;
+      this.add(grouped, this.resolvePath(workspacePath, violation.file), this.withHint(base, violation.hint), vscode.DiagnosticSeverity.Warning);
+    }
+  }
+
+  private pushGodObjectDiagnostics(grouped: Map<string, vscode.Diagnostic[]>, workspacePath: string, violations: Array<{ struct?: string; file?: string; fields?: number; methods?: number; hint?: string }>): void {
+    for (const violation of violations) {
+      if (!violation.file) {
+        continue;
+      }
+      const base = `Struct '${violation.struct ?? "unknown"}' has ${violation.fields ?? 0} fields and ${violation.methods ?? 0} methods`;
+      this.add(grouped, this.resolvePath(workspacePath, violation.file), this.withHint(base, violation.hint), vscode.DiagnosticSeverity.Warning);
+    }
+  }
+
+  private add(grouped: Map<string, vscode.Diagnostic[]>, filePath: string, message: string, severity: vscode.DiagnosticSeverity): void {
+    const diagnostics = grouped.get(filePath) ?? [];
+    const diagnostic = new vscode.Diagnostic(new vscode.Range(0, 0, 0, 1), message, severity);
+    diagnostic.source = "RepoDoctor";
+    diagnostics.push(diagnostic);
+    grouped.set(filePath, diagnostics);
+  }
+
+  private withHint(message: string, hint?: string): string {
+    if (!hint || hint.trim() === "") {
+      return message;
+    }
+    return `${message}. Hint: ${hint}`;
+  }
+
+  private resolvePath(workspacePath: string, candidate: string): string {
+    if (path.isAbsolute(candidate)) {
+      return candidate;
+    }
+    return path.join(workspacePath, candidate);
+  }
+}

--- a/vscode-repodoctor/src/extension.ts
+++ b/vscode-repodoctor/src/extension.ts
@@ -1,0 +1,46 @@
+import * as vscode from "vscode";
+import { RepoDoctorAnalyzer } from "./analyzer";
+import { RepoDoctorDiagnostics } from "./diagnostics";
+
+export function activate(context: vscode.ExtensionContext): void {
+  const analyzer = new RepoDoctorAnalyzer();
+  const diagnostics = new RepoDoctorDiagnostics();
+
+  const runAnalysis = async (): Promise<void> => {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+      vscode.window.showInformationMessage("RepoDoctor: open a workspace folder to run analysis.");
+      return;
+    }
+
+    const config = vscode.workspace.getConfiguration("repodoctor");
+    const binaryPath = config.get<string>("binaryPath", "repodoctor");
+
+    try {
+      const report = await analyzer.run(binaryPath, workspaceFolder.uri.fsPath);
+      diagnostics.publish(workspaceFolder.uri.fsPath, report);
+      vscode.window.setStatusBarMessage("RepoDoctor analysis completed", 2000);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      if (message.includes("ENOENT")) {
+        vscode.window.showErrorMessage("RepoDoctor binary not found. Install RepoDoctor and ensure it is available in PATH.");
+        return;
+      }
+      vscode.window.showErrorMessage(`RepoDoctor analysis failed: ${message}`);
+    }
+  };
+
+  context.subscriptions.push(diagnostics);
+  context.subscriptions.push(vscode.commands.registerCommand("repodoctor.analyzeWorkspace", runAnalysis));
+
+  context.subscriptions.push(
+    vscode.workspace.onDidSaveTextDocument(async () => {
+      const runOnSave = vscode.workspace.getConfiguration("repodoctor").get<boolean>("runOnSave", true);
+      if (runOnSave) {
+        await runAnalysis();
+      }
+    })
+  );
+}
+
+export function deactivate(): void {}

--- a/vscode-repodoctor/tsconfig.json
+++ b/vscode-repodoctor/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "lib": [
+      "ES2020"
+    ],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- add isolated TypeScript extension project under `vscode-repodoctor/` with dedicated package and build config
- run `repodoctor analyze -path <workspace> -format json` and publish parsed violations to VS Code Problems panel
- include architecture impact note proving CLI-only integration boundary with no core Go layer coupling

## Validation
- `npm install --prefix vscode-repodoctor`
- `npm run --prefix vscode-repodoctor compile`
- `go test ./...`
- `go vet ./...`
- `go test ./... -run TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns`
- `go run . analyze -path .`

Closes #275