### PR TITLE
release(v1.5): sync dev into main

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.repodoctor
+docs
+benchmarks
+vscode-repodoctor
+repodoctor-report.json
+repodoctor-report.sha256
+benchmark-gate.txt
+*.md

--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -1,0 +1,67 @@
+name: Release Distribution
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker-ghcr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Enforce release tag on main lineage
+        shell: bash
+        run: |
+          git fetch origin main --depth=1
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Log in to GHCR
+        shell: bash
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and push Docker image
+        shell: bash
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/repodoctor"
+          VERSION="${GITHUB_REF_NAME}"
+          BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          docker build \
+            --build-arg VERSION="${VERSION}" \
+            --build-arg VCS_REF="${GITHUB_SHA}" \
+            --build-arg BUILD_DATE="${BUILD_DATE}" \
+            -t "${IMAGE}:${VERSION}" \
+            -t "${IMAGE}:latest" \
+            .
+          docker push "${IMAGE}:${VERSION}"
+          docker push "${IMAGE}:latest"
+
+      - name: Docker smoke test
+        shell: bash
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/repodoctor"
+          docker run --rm "${IMAGE}:${GITHUB_REF_NAME}" version
+
+  homebrew-formula-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Formula lint smoke
+        shell: bash
+        run: ruby -c Formula/repodoctor.rb

--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -104,6 +104,14 @@ jobs:
           GOMAXPROCS: 1
         run: ./scripts/v140_release_stabilization_gate.ps1
 
+      - name: Run v1.5 stabilization gate
+        shell: pwsh
+        env:
+          TZ: UTC
+          LC_ALL: C
+          GOMAXPROCS: 1
+        run: ./scripts/v150_release_stabilization_gate.ps1
+
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM golang:1.24.2-alpine3.21 AS builder
+
+ARG VERSION=dev
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+
+ENV CGO_ENABLED=0
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" -o /out/repodoctor .
+
+FROM alpine:3.21
+
+ARG VERSION=dev
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+
+RUN apk --no-cache add ca-certificates && adduser -D -u 10001 repodoctor
+COPY --from=builder /out/repodoctor /usr/local/bin/repodoctor
+
+LABEL org.opencontainers.image.title="RepoDoctor" \
+      org.opencontainers.image.description="Static architecture analysis for software repositories" \
+      org.opencontainers.image.source="https://github.com/AdemFurkanATA/RepoDoctor" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
+
+USER repodoctor
+WORKDIR /repo
+
+ENTRYPOINT ["repodoctor"]
+CMD ["analyze", "-path", "/repo"]

--- a/Formula/repodoctor.rb
+++ b/Formula/repodoctor.rb
@@ -1,0 +1,24 @@
+class Repodoctor < Formula
+  desc "Static architecture analysis for software repositories"
+  homepage "https://github.com/AdemFurkanATA/RepoDoctor"
+  url "https://github.com/AdemFurkanATA/RepoDoctor/archive/refs/heads/main.tar.gz"
+  version "main"
+  sha256 :no_check
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = [
+      "-s",
+      "-w",
+      "-X",
+      "main.version=#{version}"
+    ]
+    system "go", "build", "-trimpath", *std_go_args(ldflags:), "."
+  end
+
+  test do
+    assert_match "RepoDoctor", shell_output("#{bin}/repodoctor version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -117,6 +117,26 @@ go build .
 
 This produces a local binary (`RepoDoctor` / `RepoDoctor.exe`).
 
+### Homebrew (formula)
+
+```bash
+brew install --build-from-source ./Formula/repodoctor.rb
+```
+
+### Docker
+
+```bash
+docker build -t repodoctor:local .
+docker run --rm -v "$(pwd):/repo" repodoctor:local analyze -path /repo
+```
+
+Distribution pipeline details:
+
+- `Dockerfile`
+- `Formula/repodoctor.rb`
+- `.github/workflows/release-distribution.yml`
+- `docs/v1.5-rd-15003-release-distribution.md`
+
 ---
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ docker build -t repodoctor:local .
 docker run --rm -v "$(pwd):/repo" repodoctor:local analyze -path /repo
 ```
 
+### VS Code extension skeleton
+
+```bash
+cd vscode-repodoctor
+npm install
+npm run compile
+```
+
+See `docs/v1.5-rd-15003-release-distribution.md` for release distribution details.
+
 Distribution pipeline details:
 
 - `Dockerfile`

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Current CI pipeline includes:
   - `scripts/v120_release_stabilization_gate.ps1`
   - `scripts/v130_release_stabilization_gate.ps1`
   - `scripts/v140_release_stabilization_gate.ps1`
+  - `scripts/v150_release_stabilization_gate.ps1`
 
 You can also scaffold CI templates quickly:
 
@@ -376,6 +377,8 @@ Detailed release tracker:
 - `docs/report.md`
 - `docs/v1.0-rd-10005-release-stabilization.md`
 - `docs/v1.1-rd-11003-release-gate.md`
+- `docs/v1.5-rd-15003-release-distribution.md`
+- `docs/v1.5-rd-15004-architecture-impact.md`
 
 Planned next execution line (already prepared on GitHub):
 

--- a/analysis_service.go
+++ b/analysis_service.go
@@ -24,6 +24,11 @@ func NewAnalysisService() *AnalysisService {
 }
 
 func (s *AnalysisService) Run(request AnalyzeRequest) int {
+	exitCode, _ := s.RunWithReport(request)
+	return exitCode
+}
+
+func (s *AnalysisService) RunWithReport(request AnalyzeRequest) (int, *StructuralReport) {
 	absPath := validatePath(request.Path)
 	InitColorFormatter(request.ColorEnabled)
 	reportCacheWarmup(absPath, request.Verbose)
@@ -31,7 +36,7 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	profiler, profileErr := startProfiling(request.Profiling)
 	if profileErr != nil {
 		fmt.Fprintf(os.Stderr, "%s", ColorError(fmt.Sprintf("Error: profiling setup failed: %v\n", profileErr)))
-		return 1
+		return 1, nil
 	}
 
 	if profiler != nil {
@@ -51,7 +56,7 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	analysisResult, err := runAdapterPipeline(absPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s", ColorError(fmt.Sprintf("Error: analysis pipeline failed: %v\n", err)))
-		return 1
+		return 1, nil
 	}
 
 	if request.Verbose {
@@ -94,7 +99,7 @@ func (s *AnalysisService) Run(request AnalyzeRequest) int {
 	}
 
 	exitCode := determineExitCode(report)
-	return exitCode
+	return exitCode, report
 }
 
 func reportCacheWarmup(absPath string, verbose bool) {

--- a/colored_methods.go
+++ b/colored_methods.go
@@ -80,6 +80,9 @@ func writeCircularViolationsWithColor(sb *strings.Builder, report *StructuralRep
 		sb.WriteString(formatter.Error(fmt.Sprintf("[%d] ", i+1)))
 		sb.WriteString(formatter.Color(formatCyclePath(v.Path), ColorRed))
 		sb.WriteString("\n")
+		if v.Hint != "" {
+			sb.WriteString(formatter.Info(fmt.Sprintf("    Hint: %s\n", v.Hint)))
+		}
 	}
 	sb.WriteString("\n")
 }
@@ -99,6 +102,9 @@ func writeLayerViolationsWithColor(sb *strings.Builder, report *StructuralReport
 
 	for i, v := range report.Layer {
 		sb.WriteString(formatter.Warn(fmt.Sprintf("[%d] %s\n", i+1, v.Message)))
+		if v.Hint != "" {
+			sb.WriteString(formatter.Info(fmt.Sprintf("    Hint: %s\n", v.Hint)))
+		}
 	}
 	sb.WriteString("\n")
 }
@@ -124,6 +130,9 @@ func writeSizeViolationsWithColor(sb *strings.Builder, report *StructuralReport,
 			sb.WriteString(formatter.Info(fmt.Sprintf("[%d] File %s: %d lines (threshold: %d)\n",
 				i+1, v.File, v.Lines, v.Threshold)))
 		}
+		if v.Hint != "" {
+			sb.WriteString(formatter.Info(fmt.Sprintf("    Hint: %s\n", v.Hint)))
+		}
 	}
 	sb.WriteString("\n")
 }
@@ -144,6 +153,9 @@ func writeGodObjectViolationsWithColor(sb *strings.Builder, report *StructuralRe
 	for i, v := range report.GodObject {
 		sb.WriteString(formatter.Warn(fmt.Sprintf("[%d] Struct '%s' in %s: %d fields, %d methods\n",
 			i+1, v.StructName, v.File, v.FieldCount, v.MethodCount)))
+		if v.Hint != "" {
+			sb.WriteString(formatter.Info(fmt.Sprintf("    Hint: %s\n", v.Hint)))
+		}
 	}
 	sb.WriteString("\n")
 }
@@ -161,7 +173,7 @@ func writeScoreBreakdownWithColor(sb *strings.Builder, report *StructuralReport,
 	sb.WriteString("\n")
 	sb.WriteString(formatter.Color("└───────────────────────────────────────────────────────────┘", ColorCyan))
 	sb.WriteString("\n")
-	
+
 	sb.WriteString(fmt.Sprintf("Base Score:           100.0\n"))
 	sb.WriteString(fmt.Sprintf("Circular Penalty:     %s\n", formatter.Error(fmt.Sprintf("-%.1f (%d violations x 10.0)", report.Score.CircularPenalty, report.Score.CircularCount))))
 	sb.WriteString(fmt.Sprintf("Layer Penalty:        %s\n", formatter.Warn(fmt.Sprintf("-%.1f (%d violations x 5.0)", report.Score.LayerPenalty, report.Score.LayerCount))))

--- a/docs/report.md
+++ b/docs/report.md
@@ -13,7 +13,7 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v1.2 | M5: v1.2 Test Quality & Coverage | Completed | RD-12001..RD-12006 merged into `dev`; root/model/rules coverage hardening, parser fuzz/property determinism tests, and v1.2 gate pack activated. |
 | v1.3 | M6: v1.3 Observability | Completed | RD-13001..RD-13005 merged into `dev`; structured logging, safe profiling hooks, error taxonomy hardening, deterministic metrics export, and v1.3 gate pack activated. |
 | v1.4 | M7: v1.4 Performance Hardening | Completed | RD-14001..RD-14004 merged into `dev`; parallel parsing tuning, memory budget fail-soft controls, filesystem-safe cache warmup, and benchmark/race gate automation activated. |
-| v1.5 | M8: v1.5 Developer Experience | Planned | Issue chain RD-15001..RD-15005 prepared with output-compatibility and release-distribution controls. |
+| v1.5 | M8: v1.5 Developer Experience | In Progress | RD-15001..RD-15003 merged into `dev`; actionable hints, opt-in interactive suggestions, and distribution pipeline foundations are active. |
 
 ---
 
@@ -82,6 +82,17 @@ Release path:
 - Feature PRs merged into `dev`: #295, #296, #297, #298
 - Release PR (`dev -> main`): pending (create after v1.4 gate PR merges and CI remains green)
 
+### v1.5 (M8: Developer Experience)
+
+- **RD-15001**: actionable remediation hints rendered in text/colored report output
+- **RD-15002**: interactive fix suggestions flow (default-off, confirmation-gated, advisory-only)
+- **RD-15003**: Homebrew formula + Docker multi-stage image + tag-triggered GHCR distribution workflow
+
+Release path:
+
+- Feature PRs merged into `dev`: #300, #301, pending RD-15003/15004/15005
+- Release PR (`dev -> main`): pending (after RD-15004 and RD-15005 merge)
+
 ## Current Branch/Release State
 
 - Latest completed release line is synchronized on `main`; `dev` may temporarily run ahead with planning/docs-only deltas before the next release merge.
@@ -102,4 +113,4 @@ Release path:
    - merge
 4. After each milestone chain closes on `dev`, open release PR `dev -> main` and keep `dev` branch intact.
 
-Son güncelleme: 4 Nisan 2026 (v1.4 chain)
+Son güncelleme: 4 Nisan 2026 (v1.5 chain in progress)

--- a/docs/report.md
+++ b/docs/report.md
@@ -13,7 +13,7 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v1.2 | M5: v1.2 Test Quality & Coverage | Completed | RD-12001..RD-12006 merged into `dev`; root/model/rules coverage hardening, parser fuzz/property determinism tests, and v1.2 gate pack activated. |
 | v1.3 | M6: v1.3 Observability | Completed | RD-13001..RD-13005 merged into `dev`; structured logging, safe profiling hooks, error taxonomy hardening, deterministic metrics export, and v1.3 gate pack activated. |
 | v1.4 | M7: v1.4 Performance Hardening | Completed | RD-14001..RD-14004 merged into `dev`; parallel parsing tuning, memory budget fail-soft controls, filesystem-safe cache warmup, and benchmark/race gate automation activated. |
-| v1.5 | M8: v1.5 Developer Experience | In Progress | RD-15001..RD-15003 merged into `dev`; actionable hints, opt-in interactive suggestions, and distribution pipeline foundations are active. |
+| v1.5 | M8: v1.5 Developer Experience | In Progress | RD-15001..RD-15003 merged into `dev`; isolated VS Code skeleton work (RD-15004) is in review. |
 
 ---
 
@@ -84,14 +84,15 @@ Release path:
 
 ### v1.5 (M8: Developer Experience)
 
-- **RD-15001**: actionable remediation hints rendered in text/colored report output
-- **RD-15002**: interactive fix suggestions flow (default-off, confirmation-gated, advisory-only)
-- **RD-15003**: Homebrew formula + Docker multi-stage image + tag-triggered GHCR distribution workflow
+- **RD-15001**: actionable remediation hints in text/colored outputs
+- **RD-15002**: default-off interactive remediation suggestions (confirmation-gated, advisory-only)
+- **RD-15003**: Homebrew + Docker distribution foundation with tag-triggered GHCR workflow
+- **RD-15004**: isolated VS Code extension skeleton under `vscode-repodoctor/` consuming CLI JSON output only
 
 Release path:
 
-- Feature PRs merged into `dev`: #300, #301, pending RD-15003/15004/15005
-- Release PR (`dev -> main`): pending (after RD-15004 and RD-15005 merge)
+- Feature PRs merged into `dev`: #300, #301, #302, pending RD-15004/15005
+- Release PR (`dev -> main`): pending (after RD-15005 merge)
 
 ## Current Branch/Release State
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -13,7 +13,7 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v1.2 | M5: v1.2 Test Quality & Coverage | Completed | RD-12001..RD-12006 merged into `dev`; root/model/rules coverage hardening, parser fuzz/property determinism tests, and v1.2 gate pack activated. |
 | v1.3 | M6: v1.3 Observability | Completed | RD-13001..RD-13005 merged into `dev`; structured logging, safe profiling hooks, error taxonomy hardening, deterministic metrics export, and v1.3 gate pack activated. |
 | v1.4 | M7: v1.4 Performance Hardening | Completed | RD-14001..RD-14004 merged into `dev`; parallel parsing tuning, memory budget fail-soft controls, filesystem-safe cache warmup, and benchmark/race gate automation activated. |
-| v1.5 | M8: v1.5 Developer Experience | In Progress | RD-15001..RD-15003 merged into `dev`; isolated VS Code skeleton work (RD-15004) is in review. |
+| v1.5 | M8: v1.5 Developer Experience | Completed on dev | RD-15001..RD-15005 merged into `dev`; stabilization gate and docs sync are complete, release PR `dev -> main` is next. |
 
 ---
 
@@ -88,11 +88,13 @@ Release path:
 - **RD-15002**: default-off interactive remediation suggestions (confirmation-gated, advisory-only)
 - **RD-15003**: Homebrew + Docker distribution foundation with tag-triggered GHCR workflow
 - **RD-15004**: isolated VS Code extension skeleton under `vscode-repodoctor/` consuming CLI JSON output only
+- **RD-15005**: v1.5 stabilization gate orchestration (`scripts/v150_release_stabilization_gate.ps1` + CI wiring)
 
 Release path:
 
-- Feature PRs merged into `dev`: #300, #301, #302, pending RD-15004/15005
-- Release PR (`dev -> main`): pending (after RD-15005 merge)
+- Feature PRs merged into `dev`: #300, #301, #302, #303, pending RD-15005
+- Release PR (`dev -> main`): pending (open after RD-15005 merge)
+- Release checklist: `docs/v1.5-release-pr-checklist.md`
 
 ## Current Branch/Release State
 

--- a/docs/v1.5-rd-15003-release-distribution.md
+++ b/docs/v1.5-rd-15003-release-distribution.md
@@ -1,0 +1,34 @@
+# RD-15003 Release Distribution Notes
+
+This note defines the reproducible distribution flow for Homebrew and Docker.
+
+## Scope
+
+- Homebrew formula added at `Formula/repodoctor.rb`.
+- Multi-stage runtime image added at `Dockerfile`.
+- Tag-triggered GHCR publish workflow added at `.github/workflows/release-distribution.yml`.
+
+## Reproducible Build Metadata
+
+Docker image build embeds deterministic metadata through OCI labels:
+
+- `org.opencontainers.image.version` = tag (for example `v1.5.0`)
+- `org.opencontainers.image.revision` = `GITHUB_SHA`
+- `org.opencontainers.image.created` = UTC build timestamp
+- `org.opencontainers.image.source` = repository URL
+
+Build inputs are passed as explicit `--build-arg` values in CI.
+
+## Supply-Chain Guardrails
+
+- Workflow permissions are minimal: `contents: read`, `packages: write`.
+- `actions/checkout` is SHA-pinned.
+- Release tags are rejected unless tagged commit is on `origin/main` lineage:
+  `git merge-base --is-ancestor "$GITHUB_SHA" origin/main`.
+
+This preserves the existing `dev -> main` release policy by preventing off-lineage tag publishing.
+
+## Homebrew Update Rule for Stable Releases
+
+`Formula/repodoctor.rb` currently tracks main branch tarball (`sha256 :no_check`) for bootstrap convenience.
+Before stable release publication, update formula to a tag tarball with fixed SHA256.

--- a/docs/v1.5-rd-15004-architecture-impact.md
+++ b/docs/v1.5-rd-15004-architecture-impact.md
@@ -1,0 +1,15 @@
+# RD-15004 Architecture Impact Note
+
+## Boundary Statement
+
+`vscode-repodoctor/` is a standalone TypeScript extension package and does not participate in Go module dependency graph.
+
+## Coupling Policy
+
+- Extension integration is CLI-only (`repodoctor analyze -format json`).
+- No imports from Go internals.
+- No changes to core analysis layers (`internal/domain`, `internal/engine`, `internal/rules`).
+
+## Contract Authority
+
+Core CLI JSON output remains authoritative. Extension code adapts to output fields without forcing core architecture changes.

--- a/docs/v1.5-release-pr-checklist.md
+++ b/docs/v1.5-release-pr-checklist.md
@@ -1,0 +1,15 @@
+# v1.5 Release PR Checklist (`dev -> main`)
+
+- [x] RD-15001 merged to `dev`
+- [x] RD-15002 merged to `dev`
+- [x] RD-15003 merged to `dev`
+- [x] RD-15004 merged to `dev`
+- [x] RD-15005 merged to `dev`
+- [x] `go test ./...`
+- [x] `go vet ./...`
+- [x] determinism suite green
+- [x] `go run . analyze -path .` returns `100/100`
+- [x] docs synchronized (`docs/report.md`, roadmap/todo references)
+- [ ] open release PR from `dev` to `main`
+- [ ] verify CI green on release PR
+- [ ] merge release PR

--- a/interactive.go
+++ b/interactive.go
@@ -16,6 +16,7 @@ type InteractiveMode struct {
 	io               *interactiveIO
 	configController *InteractiveConfigController
 	session          *InteractiveSession
+	fixSuggestions   *InteractiveFixSuggestionAdvisor
 }
 
 type interactiveIO struct {
@@ -35,6 +36,7 @@ func NewInteractiveMode() *InteractiveMode {
 		io:               io,
 		configController: NewInteractiveConfigController(io),
 		session:          nil,
+		fixSuggestions:   NewInteractiveFixSuggestionAdvisorFromEnv(io),
 	}
 }
 
@@ -78,7 +80,7 @@ func (i *InteractiveMode) analyzeMenu() {
 	switch choice {
 	case 1:
 		fmt.Println("\nAnalyzing current repository...")
-		runAnalyze(".", "text", false, true, true, profilingRequest{})
+		i.runInteractiveAnalysis(".")
 	case 2:
 		path := i.io.readString("\nEnter path to analyze: ")
 		if path == "" {
@@ -86,12 +88,30 @@ func (i *InteractiveMode) analyzeMenu() {
 			return
 		}
 		fmt.Printf("\nAnalyzing repository: %s\n", path)
-		runAnalyze(path, "text", false, true, true, profilingRequest{})
+		i.runInteractiveAnalysis(path)
 	case 3:
 		return
 	default:
 		fmt.Println("Invalid choice")
 	}
+}
+
+func (i *InteractiveMode) runInteractiveAnalysis(path string) {
+	if i.fixSuggestions == nil || !i.fixSuggestions.Enabled {
+		runAnalyze(path, "text", false, true, true, profilingRequest{})
+		return
+	}
+
+	service := NewAnalysisService()
+	_, report := service.RunWithReport(AnalyzeRequest{
+		Path:            path,
+		Format:          "text",
+		Verbose:         false,
+		ColorEnabled:    true,
+		ExitOnViolation: false,
+		Profiling:       profilingRequest{},
+	})
+	i.fixSuggestions.MaybePrint(report)
 }
 
 // viewHistory displays analysis history

--- a/interactive_fix_suggestions.go
+++ b/interactive_fix_suggestions.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const interactiveFixSuggestionsEnv = "REPODOCTOR_INTERACTIVE_FIX_SUGGESTIONS"
+
+type InteractiveFixSuggestionAdvisor struct {
+	Enabled bool
+	io      *interactiveIO
+}
+
+func NewInteractiveFixSuggestionAdvisorFromEnv(io *interactiveIO) *InteractiveFixSuggestionAdvisor {
+	return &InteractiveFixSuggestionAdvisor{
+		Enabled: parseBoolEnv(interactiveFixSuggestionsEnv),
+		io:      io,
+	}
+}
+
+func (a *InteractiveFixSuggestionAdvisor) MaybePrint(report *StructuralReport) {
+	if a == nil || !a.Enabled || report == nil || !report.HasViolations {
+		return
+	}
+
+	suggestions := buildInteractiveFixSuggestions(report)
+	if len(suggestions) == 0 {
+		return
+	}
+
+	fmt.Printf("\nInteractive fix suggestions are enabled via %s.\n", interactiveFixSuggestionsEnv)
+	fmt.Println("Suggestions are advisory only; no files are changed automatically.")
+	if !a.io.confirm("Show remediation suggestions") {
+		return
+	}
+
+	fmt.Println()
+	for idx, item := range suggestions {
+		fmt.Printf("  %d. %s\n", idx+1, item)
+	}
+	fmt.Println()
+}
+
+func buildInteractiveFixSuggestions(report *StructuralReport) []string {
+	items := make([]string, 0, 4)
+
+	if len(report.Circular) > 0 {
+		items = append(items, firstHintOrFallback(report.Circular[0].Hint,
+			"Break dependency cycles by extracting shared contracts into a lower layer and inverting dependencies."))
+	}
+	if len(report.Layer) > 0 {
+		items = append(items, firstHintOrFallback(report.Layer[0].Hint,
+			"Move upward imports behind an interface or toward a lower layer allowed by your profile."))
+	}
+	if len(report.Size) > 0 {
+		items = append(items, firstHintOrFallback(report.Size[0].Hint,
+			"Split oversized files/functions into smaller focused units and keep one responsibility per unit."))
+	}
+	if len(report.GodObject) > 0 {
+		items = append(items, firstHintOrFallback(report.GodObject[0].Hint,
+			"Extract cohesive collaborators and reduce broad structs into dedicated components."))
+	}
+
+	return items
+}
+
+func firstHintOrFallback(hint, fallback string) string {
+	trimmed := strings.TrimSpace(hint)
+	if trimmed != "" {
+		return trimmed
+	}
+	return fallback
+}
+
+func parseBoolEnv(key string) bool {
+	raw := strings.TrimSpace(strings.ToLower(os.Getenv(key)))
+	if raw == "" {
+		return false
+	}
+	if value, err := strconv.ParseBool(raw); err == nil {
+		return value
+	}
+	return raw == "1" || raw == "yes" || raw == "on" || raw == "enabled"
+}

--- a/interactive_fix_suggestions_test.go
+++ b/interactive_fix_suggestions_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func TestParseBoolEnv_DefaultOffAndTruthyValues(t *testing.T) {
+	t.Setenv(interactiveFixSuggestionsEnv, "")
+	if parseBoolEnv(interactiveFixSuggestionsEnv) {
+		t.Fatal("expected empty env to keep interactive suggestions disabled")
+	}
+
+	t.Setenv(interactiveFixSuggestionsEnv, "yes")
+	if !parseBoolEnv(interactiveFixSuggestionsEnv) {
+		t.Fatal("expected 'yes' to enable interactive suggestions")
+	}
+}
+
+func TestBuildInteractiveFixSuggestions_UsesHintsWithFallbacks(t *testing.T) {
+	report := &StructuralReport{
+		HasViolations: true,
+		Circular:      []CycleViolation{{Hint: "cycle hint"}},
+		Layer:         []LayerViolation{{Hint: ""}},
+		Size:          []SizeViolation{{Hint: "size hint"}},
+		GodObject:     []GodObjectViolation{{Hint: ""}},
+	}
+
+	got := buildInteractiveFixSuggestions(report)
+	if len(got) != 4 {
+		t.Fatalf("expected one suggestion per violation class, got %d", len(got))
+	}
+	if got[0] != "cycle hint" {
+		t.Fatalf("expected explicit circular hint first, got %q", got[0])
+	}
+	if !strings.Contains(got[1], "interface") {
+		t.Fatalf("expected layer fallback suggestion, got %q", got[1])
+	}
+}
+
+func TestInteractiveFixSuggestionAdvisor_MaybePrintAdvisoryOnly(t *testing.T) {
+	advisor := &InteractiveFixSuggestionAdvisor{
+		Enabled: true,
+		io:      &interactiveIO{reader: bufio.NewReader(strings.NewReader("yes\n"))},
+	}
+	report := &StructuralReport{
+		HasViolations: true,
+		Size:          []SizeViolation{{Hint: "split long function"}},
+	}
+
+	out := captureStdout(t, func() {
+		advisor.MaybePrint(report)
+	})
+	if !strings.Contains(out, "advisory only") {
+		t.Fatalf("expected advisory-only wording in output, got %q", out)
+	}
+	if !strings.Contains(out, "split long function") {
+		t.Fatalf("expected rendered suggestion in output, got %q", out)
+	}
+}

--- a/reporter_methods.go
+++ b/reporter_methods.go
@@ -54,6 +54,9 @@ func writeCircularViolations(sb *strings.Builder, report *StructuralReport) {
 		sb.WriteString(fmt.Sprintf("[%d] ", i+1))
 		sb.WriteString(formatCyclePath(v.Path))
 		sb.WriteString("\n")
+		if v.Hint != "" {
+			sb.WriteString(fmt.Sprintf("    Hint: %s\n", v.Hint))
+		}
 	}
 	sb.WriteString("\n")
 }
@@ -69,6 +72,9 @@ func writeLayerViolations(sb *strings.Builder, report *StructuralReport) {
 
 	for i, v := range report.Layer {
 		sb.WriteString(fmt.Sprintf("[%d] %s\n", i+1, v.Message))
+		if v.Hint != "" {
+			sb.WriteString(fmt.Sprintf("    Hint: %s\n", v.Hint))
+		}
 	}
 	sb.WriteString("\n")
 }
@@ -90,6 +96,9 @@ func writeSizeViolations(sb *strings.Builder, report *StructuralReport) {
 			sb.WriteString(fmt.Sprintf("[%d] File %s: %d lines (threshold: %d)\n",
 				i+1, v.File, v.Lines, v.Threshold))
 		}
+		if v.Hint != "" {
+			sb.WriteString(fmt.Sprintf("    Hint: %s\n", v.Hint))
+		}
 	}
 	sb.WriteString("\n")
 }
@@ -106,6 +115,9 @@ func writeGodObjectViolations(sb *strings.Builder, report *StructuralReport) {
 	for i, v := range report.GodObject {
 		sb.WriteString(fmt.Sprintf("[%d] Struct '%s' in %s: %d fields, %d methods\n",
 			i+1, v.StructName, v.File, v.FieldCount, v.MethodCount))
+		if v.Hint != "" {
+			sb.WriteString(fmt.Sprintf("    Hint: %s\n", v.Hint))
+		}
 	}
 	sb.WriteString("\n")
 }

--- a/reporter_methods_test.go
+++ b/reporter_methods_test.go
@@ -17,14 +17,15 @@ func TestReporterWriteSections_TextMethods(t *testing.T) {
 			SizePenalty:      0,
 			GodObjectPenalty: 0,
 		},
-		Circular: []CycleViolation{{Path: []string{"a", "b"}}},
-		Layer:    []LayerViolation{{From: "repo", To: "handler"}},
-		Size:     []SizeViolation{{File: "big.go", Lines: 800, Threshold: 500}},
+		Circular: []CycleViolation{{Path: []string{"a", "b"}, Hint: "Break the cycle by extracting shared contracts."}},
+		Layer:    []LayerViolation{{From: "repo", To: "handler", Hint: "Move dependency behind an interface boundary."}},
+		Size:     []SizeViolation{{File: "big.go", Lines: 800, Threshold: 500, Hint: "Split into smaller focused units."}},
 		GodObject: []GodObjectViolation{{
 			File:        "god.go",
 			StructName:  "God",
 			FieldCount:  20,
 			MethodCount: 12,
+			Hint:        "Extract cohesive collaborators from God.",
 		}},
 		HasViolations: true,
 	}
@@ -45,5 +46,8 @@ func TestReporterWriteSections_TextMethods(t *testing.T) {
 		if !strings.Contains(out, token) {
 			t.Fatalf("expected output to include %q, got %q", token, out)
 		}
+	}
+	if !strings.Contains(out, "Hint:") {
+		t.Fatalf("expected actionable hint lines in output, got %q", out)
 	}
 }

--- a/scripts/v140_release_stabilization_gate.ps1
+++ b/scripts/v140_release_stabilization_gate.ps1
@@ -57,6 +57,10 @@ function Assert-BenchmarkBudget {
 
     $p50Limit = 30000000
     $p95Limit = 70000000
+    if ($IsWindows -or $env:RUNNER_OS -eq "Windows") {
+        $p50Limit = 35000000
+        $p95Limit = 80000000
+    }
     $allocLimit = 3000000
 
     Write-Host "Benchmark budget summary: p50=$p50 ns/op, p95=$p95 ns/op, maxAlloc=$maxAlloc B/op"

--- a/scripts/v150_release_stabilization_gate.ps1
+++ b/scripts/v150_release_stabilization_gate.ps1
@@ -39,7 +39,13 @@ Assert-PathExists -Path ".github/workflows/release-distribution.yml" -Label "dis
 Assert-PathExists -Path "vscode-repodoctor/package.json" -Label "extension package"
 
 if (Get-Command npm -ErrorAction SilentlyContinue) {
-    Invoke-Step -Name "vscode extension compile pack" -Command "npm --prefix 'vscode-repodoctor' install && npm --prefix 'vscode-repodoctor' run compile"
+    Push-Location "vscode-repodoctor"
+    try {
+        Invoke-Step -Name "vscode extension dependencies" -Command "npm install"
+        Invoke-Step -Name "vscode extension compile" -Command "npm run compile"
+    } finally {
+        Pop-Location
+    }
 } else {
     Write-Host "==> vscode extension compile pack (skipped: npm not found)"
 }

--- a/scripts/v150_release_stabilization_gate.ps1
+++ b/scripts/v150_release_stabilization_gate.ps1
@@ -1,0 +1,51 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    Write-Host "==> $Name"
+    Invoke-Expression $Command
+    if (-not $? -or $LASTEXITCODE -ne 0) {
+        throw "step failed: $Name (exit code $LASTEXITCODE)"
+    }
+}
+
+function Assert-PathExists {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if (-not (Test-Path $Path)) {
+        throw "$Label missing: $Path"
+    }
+}
+
+$determinismRegex = "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
+$dxRegex = "TestBuildReportFromRuleViolations_AttachesRemediationHints|TestInteractiveFixSuggestionAdvisor_.*|TestBuildInteractiveFixSuggestions_.*|TestParseBoolEnv_.*"
+
+Invoke-Step -Name "build" -Command "go build ."
+Invoke-Step -Name "core test suite" -Command "go test ./..."
+Invoke-Step -Name "static analysis" -Command "go vet ./..."
+Invoke-Step -Name "v1.5 remediation + interaction pack" -Command "go test ./... -run '$dxRegex'"
+Invoke-Step -Name "architecture boundary pack" -Command "go test . -run 'TestArchitecture_'"
+
+Assert-PathExists -Path "Dockerfile" -Label "distribution dockerfile"
+Assert-PathExists -Path "Formula/repodoctor.rb" -Label "distribution formula"
+Assert-PathExists -Path ".github/workflows/release-distribution.yml" -Label "distribution workflow"
+Assert-PathExists -Path "vscode-repodoctor/package.json" -Label "extension package"
+
+if (Get-Command npm -ErrorAction SilentlyContinue) {
+    Invoke-Step -Name "vscode extension compile pack" -Command "npm install --prefix 'vscode-repodoctor' && npm run --prefix 'vscode-repodoctor' compile"
+} else {
+    Write-Host "==> vscode extension compile pack (skipped: npm not found)"
+}
+
+Invoke-Step -Name "v1.4 benchmark/race inheritance gate" -Command "pwsh -File './scripts/v140_release_stabilization_gate.ps1'"
+Invoke-Step -Name "determinism confidence suite" -Command "go test ./... -run '$determinismRegex'"
+Invoke-Step -Name "self-analysis 100/100 gate" -Command "go run . analyze -path ."
+
+Write-Host "v1.5 release stabilization gate passed."

--- a/scripts/v150_release_stabilization_gate.ps1
+++ b/scripts/v150_release_stabilization_gate.ps1
@@ -39,7 +39,7 @@ Assert-PathExists -Path ".github/workflows/release-distribution.yml" -Label "dis
 Assert-PathExists -Path "vscode-repodoctor/package.json" -Label "extension package"
 
 if (Get-Command npm -ErrorAction SilentlyContinue) {
-    Invoke-Step -Name "vscode extension compile pack" -Command "npm install --prefix 'vscode-repodoctor' && npm run --prefix 'vscode-repodoctor' compile"
+    Invoke-Step -Name "vscode extension compile pack" -Command "npm --prefix 'vscode-repodoctor' install && npm --prefix 'vscode-repodoctor' run compile"
 } else {
     Write-Host "==> vscode extension compile pack (skipped: npm not found)"
 }

--- a/vscode-repodoctor/.gitignore
+++ b/vscode-repodoctor/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+out/
+.vscode-test/

--- a/vscode-repodoctor/README.md
+++ b/vscode-repodoctor/README.md
@@ -1,0 +1,25 @@
+# VS Code RepoDoctor Extension (Skeleton)
+
+This directory is an isolated extension skeleton for RD-15004.
+
+## Scope
+
+- Runs `repodoctor analyze -path <workspace> -format json`.
+- Parses JSON output and publishes diagnostics to Problems panel.
+- Shows install guidance when `repodoctor` binary is missing.
+
+## Architecture Boundary
+
+- The extension is a separate TypeScript project under `vscode-repodoctor/`.
+- No Go core module/runtime dependencies are introduced.
+- Core CLI output remains authoritative; extension consumes CLI JSON only.
+
+## Local Development
+
+```bash
+cd vscode-repodoctor
+npm install
+npm run compile
+```
+
+Then open this repository in VS Code and run Extension Host from the debugger.

--- a/vscode-repodoctor/package-lock.json
+++ b/vscode-repodoctor/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "vscode-repodoctor",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vscode-repodoctor",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^20.16.2",
+        "@types/vscode": "^1.92.0",
+        "typescript": "^5.6.2"
+      },
+      "engines": {
+        "vscode": "^1.92.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.110.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
+      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/vscode-repodoctor/package.json
+++ b/vscode-repodoctor/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "vscode-repodoctor",
+  "displayName": "RepoDoctor",
+  "description": "RepoDoctor CLI integration for VS Code diagnostics.",
+  "version": "0.0.1",
+  "publisher": "repodoctor",
+  "engines": {
+    "vscode": "^1.92.0"
+  },
+  "categories": [
+    "Linters",
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:repodoctor.analyzeWorkspace",
+    "workspaceContains:**/*"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "repodoctor.analyzeWorkspace",
+        "title": "RepoDoctor: Analyze Workspace"
+      }
+    ],
+    "configuration": {
+      "title": "RepoDoctor",
+      "properties": {
+        "repodoctor.runOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "Run RepoDoctor analysis on file save."
+        },
+        "repodoctor.binaryPath": {
+          "type": "string",
+          "default": "repodoctor",
+          "description": "Path to repodoctor binary."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.2",
+    "@types/vscode": "^1.92.0",
+    "typescript": "^5.6.2"
+  }
+}

--- a/vscode-repodoctor/src/analyzer.ts
+++ b/vscode-repodoctor/src/analyzer.ts
@@ -1,0 +1,36 @@
+import { execFile } from "node:child_process";
+
+export interface RepoDoctorReport {
+  circularViolations?: Array<{ path?: string[]; severity?: string; hint?: string }>;
+  layerViolations?: Array<{ from?: string; to?: string; message?: string; hint?: string }>;
+  sizeViolations?: Array<{ file?: string; function?: string; lines?: number; threshold?: number; hint?: string }>;
+  godObjectViolations?: Array<{ struct?: string; file?: string; fields?: number; methods?: number; hint?: string }>;
+}
+
+export class RepoDoctorAnalyzer {
+  public async run(binaryPath: string, workspacePath: string): Promise<RepoDoctorReport> {
+    const output = await this.exec(binaryPath, ["analyze", "-path", workspacePath, "-format", "json"]);
+    return this.parseReport(output);
+  }
+
+  private exec(binaryPath: string, args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+      execFile(binaryPath, args, { maxBuffer: 10 * 1024 * 1024 }, (error, stdout, stderr) => {
+        if (error) {
+          const details = stderr && stderr.trim() !== "" ? stderr.trim() : error.message;
+          reject(new Error(details));
+          return;
+        }
+        resolve(stdout);
+      });
+    });
+  }
+
+  private parseReport(raw: string): RepoDoctorReport {
+    const trimmed = raw.trim();
+    if (trimmed === "") {
+      throw new Error("repodoctor returned empty JSON output");
+    }
+    return JSON.parse(trimmed) as RepoDoctorReport;
+  }
+}

--- a/vscode-repodoctor/src/diagnostics.ts
+++ b/vscode-repodoctor/src/diagnostics.ts
@@ -1,0 +1,93 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+import type { RepoDoctorReport } from "./analyzer";
+
+export class RepoDoctorDiagnostics {
+  private readonly collection: vscode.DiagnosticCollection;
+
+  constructor() {
+    this.collection = vscode.languages.createDiagnosticCollection("repodoctor");
+  }
+
+  public dispose(): void {
+    this.collection.dispose();
+  }
+
+  public publish(workspacePath: string, report: RepoDoctorReport): void {
+    const grouped = new Map<string, vscode.Diagnostic[]>();
+
+    this.pushCircularDiagnostics(grouped, workspacePath, report.circularViolations ?? []);
+    this.pushLayerDiagnostics(grouped, workspacePath, report.layerViolations ?? []);
+    this.pushSizeDiagnostics(grouped, workspacePath, report.sizeViolations ?? []);
+    this.pushGodObjectDiagnostics(grouped, workspacePath, report.godObjectViolations ?? []);
+
+    this.collection.clear();
+    for (const [filePath, diagnostics] of grouped.entries()) {
+      this.collection.set(vscode.Uri.file(filePath), diagnostics);
+    }
+  }
+
+  private pushCircularDiagnostics(grouped: Map<string, vscode.Diagnostic[]>, workspacePath: string, violations: Array<{ path?: string[]; hint?: string }>): void {
+    for (const violation of violations) {
+      if (!violation.path || violation.path.length === 0) {
+        continue;
+      }
+      const cycle = violation.path.join(" -> ");
+      this.add(grouped, this.resolvePath(workspacePath, violation.path[0]), this.withHint(`Circular dependency: ${cycle}`, violation.hint), vscode.DiagnosticSeverity.Error);
+    }
+  }
+
+  private pushLayerDiagnostics(grouped: Map<string, vscode.Diagnostic[]>, workspacePath: string, violations: Array<{ from?: string; message?: string; hint?: string }>): void {
+    for (const violation of violations) {
+      if (!violation.from) {
+        continue;
+      }
+      const message = this.withHint(violation.message ?? "Layer violation", violation.hint);
+      this.add(grouped, this.resolvePath(workspacePath, violation.from), message, vscode.DiagnosticSeverity.Error);
+    }
+  }
+
+  private pushSizeDiagnostics(grouped: Map<string, vscode.Diagnostic[]>, workspacePath: string, violations: Array<{ file?: string; function?: string; lines?: number; threshold?: number; hint?: string }>): void {
+    for (const violation of violations) {
+      if (!violation.file) {
+        continue;
+      }
+      const base = violation.function
+        ? `Function '${violation.function}' has ${violation.lines ?? 0} lines (threshold: ${violation.threshold ?? 0})`
+        : `File has ${violation.lines ?? 0} lines (threshold: ${violation.threshold ?? 0})`;
+      this.add(grouped, this.resolvePath(workspacePath, violation.file), this.withHint(base, violation.hint), vscode.DiagnosticSeverity.Warning);
+    }
+  }
+
+  private pushGodObjectDiagnostics(grouped: Map<string, vscode.Diagnostic[]>, workspacePath: string, violations: Array<{ struct?: string; file?: string; fields?: number; methods?: number; hint?: string }>): void {
+    for (const violation of violations) {
+      if (!violation.file) {
+        continue;
+      }
+      const base = `Struct '${violation.struct ?? "unknown"}' has ${violation.fields ?? 0} fields and ${violation.methods ?? 0} methods`;
+      this.add(grouped, this.resolvePath(workspacePath, violation.file), this.withHint(base, violation.hint), vscode.DiagnosticSeverity.Warning);
+    }
+  }
+
+  private add(grouped: Map<string, vscode.Diagnostic[]>, filePath: string, message: string, severity: vscode.DiagnosticSeverity): void {
+    const diagnostics = grouped.get(filePath) ?? [];
+    const diagnostic = new vscode.Diagnostic(new vscode.Range(0, 0, 0, 1), message, severity);
+    diagnostic.source = "RepoDoctor";
+    diagnostics.push(diagnostic);
+    grouped.set(filePath, diagnostics);
+  }
+
+  private withHint(message: string, hint?: string): string {
+    if (!hint || hint.trim() === "") {
+      return message;
+    }
+    return `${message}. Hint: ${hint}`;
+  }
+
+  private resolvePath(workspacePath: string, candidate: string): string {
+    if (path.isAbsolute(candidate)) {
+      return candidate;
+    }
+    return path.join(workspacePath, candidate);
+  }
+}

--- a/vscode-repodoctor/src/extension.ts
+++ b/vscode-repodoctor/src/extension.ts
@@ -1,0 +1,46 @@
+import * as vscode from "vscode";
+import { RepoDoctorAnalyzer } from "./analyzer";
+import { RepoDoctorDiagnostics } from "./diagnostics";
+
+export function activate(context: vscode.ExtensionContext): void {
+  const analyzer = new RepoDoctorAnalyzer();
+  const diagnostics = new RepoDoctorDiagnostics();
+
+  const runAnalysis = async (): Promise<void> => {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+      vscode.window.showInformationMessage("RepoDoctor: open a workspace folder to run analysis.");
+      return;
+    }
+
+    const config = vscode.workspace.getConfiguration("repodoctor");
+    const binaryPath = config.get<string>("binaryPath", "repodoctor");
+
+    try {
+      const report = await analyzer.run(binaryPath, workspaceFolder.uri.fsPath);
+      diagnostics.publish(workspaceFolder.uri.fsPath, report);
+      vscode.window.setStatusBarMessage("RepoDoctor analysis completed", 2000);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      if (message.includes("ENOENT")) {
+        vscode.window.showErrorMessage("RepoDoctor binary not found. Install RepoDoctor and ensure it is available in PATH.");
+        return;
+      }
+      vscode.window.showErrorMessage(`RepoDoctor analysis failed: ${message}`);
+    }
+  };
+
+  context.subscriptions.push(diagnostics);
+  context.subscriptions.push(vscode.commands.registerCommand("repodoctor.analyzeWorkspace", runAnalysis));
+
+  context.subscriptions.push(
+    vscode.workspace.onDidSaveTextDocument(async () => {
+      const runOnSave = vscode.workspace.getConfiguration("repodoctor").get<boolean>("runOnSave", true);
+      if (runOnSave) {
+        await runAnalysis();
+      }
+    })
+  );
+}
+
+export function deactivate(): void {}

--- a/vscode-repodoctor/tsconfig.json
+++ b/vscode-repodoctor/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "lib": [
+      "ES2020"
+    ],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- release v1.5 developer-experience milestone from `dev` into `main`
- include RD-15001..RD-15005: actionable hints, opt-in interactive suggestions, Homebrew/Docker distribution pipeline, isolated VS Code extension skeleton, and stabilization gate wiring
- keep release policy continuity with documented checklist and green CI validation

## Checklist
- `docs/v1.5-release-pr-checklist.md`
