### PR TITLE
feat(rd-16001): add secret detection rule with entropy and fail-soft bounds

### DIFF
--- a/internal/rules/init.go
+++ b/internal/rules/init.go
@@ -8,6 +8,7 @@ func init() {
 	DefaultRegistry.MustRegister(NewGodObjectRule())
 	DefaultRegistry.MustRegister(NewSizeRule())
 	DefaultRegistry.MustRegister(NewLayerValidationRule())
+	DefaultRegistry.MustRegister(NewSecretDetectionRule())
 	// Note: CircularDependencyRule requires a graph parameter, so it's registered separately
 }
 

--- a/internal/rules/secret_detection_rule.go
+++ b/internal/rules/secret_detection_rule.go
@@ -1,0 +1,218 @@
+package rules
+
+import (
+	"math"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode"
+
+	"RepoDoctor/internal/model"
+)
+
+const (
+	defaultSecretEntropyThreshold = 3.5
+	defaultSecretMaxScanBytes     = 1_000_000
+)
+
+var (
+	secretLineRegex = regexp.MustCompile(`(?i)(api[_-]?key|secret|token|password|passwd|private[_-]?key)\s*[:=]\s*["']?([A-Za-z0-9_./+=-]{12,})["']?`)
+	awsKeyRegex     = regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`)
+	githubPATRegex  = regexp.MustCompile(`\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36}\b`)
+	privateKeyRegex = regexp.MustCompile(`-----BEGIN (?:RSA|EC|DSA|OPENSSH|PGP|PRIVATE) KEY-----`)
+)
+
+// SecretDetectionRule detects likely hardcoded secrets in repository files.
+// It uses bounded scanning and entropy checks to reduce false positives.
+type SecretDetectionRule struct {
+	EntropyThreshold float64
+	MaxScanBytes     int
+}
+
+func NewSecretDetectionRule() *SecretDetectionRule {
+	return &SecretDetectionRule{
+		EntropyThreshold: defaultSecretEntropyThreshold,
+		MaxScanBytes:     defaultSecretMaxScanBytes,
+	}
+}
+
+func (r *SecretDetectionRule) ID() string {
+	return "rule.secret-detection"
+}
+
+func (r *SecretDetectionRule) Category() string {
+	return string(CategoryMaintainability)
+}
+
+func (r *SecretDetectionRule) Severity() string {
+	return string(model.SeverityCritical)
+}
+
+func (r *SecretDetectionRule) Capabilities() RuleCapabilities {
+	return RuleCapabilities{SupportedLanguages: []string{"Go", "Python", "JavaScript", "TypeScript", "Java"}, SupportsMultipleLanguages: true}
+}
+
+func (r *SecretDetectionRule) Evaluate(context AnalysisContext) []model.Violation {
+	violations := make([]model.Violation, 0)
+	for _, file := range context.RepositoryFiles {
+		if !r.shouldScanFile(file.Path, file.Content) {
+			continue
+		}
+		violations = append(violations, r.scanFile(file)...)
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].File != violations[j].File {
+			return violations[i].File < violations[j].File
+		}
+		if violations[i].Line != violations[j].Line {
+			return violations[i].Line < violations[j].Line
+		}
+		return violations[i].Message < violations[j].Message
+	})
+
+	return violations
+}
+
+func (r *SecretDetectionRule) shouldScanFile(path, content string) bool {
+	lowerPath := strings.ToLower(path)
+	allowlistedPathTokens := []string{"/testdata/", "\\testdata\\", "/fixtures/", "\\fixtures\\", "/mocks/", "\\mocks\\", "/examples/", "\\examples\\", "/samples/", "\\samples\\", "/docs/", "\\docs\\"}
+	for _, token := range allowlistedPathTokens {
+		if strings.Contains(lowerPath, token) {
+			return false
+		}
+	}
+	if strings.HasSuffix(lowerPath, ".md") || strings.HasSuffix(lowerPath, ".txt") || strings.HasSuffix(lowerPath, ".svg") {
+		return false
+	}
+	if len(content) == 0 || len(content) > r.MaxScanBytes {
+		return false
+	}
+	if strings.IndexByte(content, 0) >= 0 {
+		return false
+	}
+	return true
+}
+
+func (r *SecretDetectionRule) scanFile(file RepositoryFile) []model.Violation {
+	lines := strings.Split(file.Content, "\n")
+	violations := make([]model.Violation, 0)
+
+	for idx, rawLine := range lines {
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if privateKeyRegex.MatchString(line) {
+			violations = append(violations, r.newViolation(file.Path, idx+1, "Private key material detected"))
+			continue
+		}
+
+		if match := awsKeyRegex.FindString(line); match != "" && !isAllowlistedSecretCandidate(line, match) {
+			violations = append(violations, r.newViolation(file.Path, idx+1, "AWS access key pattern detected"))
+			continue
+		}
+
+		if match := githubPATRegex.FindString(line); match != "" && !isAllowlistedSecretCandidate(line, match) {
+			violations = append(violations, r.newViolation(file.Path, idx+1, "GitHub token pattern detected"))
+			continue
+		}
+
+		captures := secretLineRegex.FindAllStringSubmatch(line, -1)
+		for _, capture := range captures {
+			if len(capture) < 3 {
+				continue
+			}
+			candidate := capture[2]
+			if isAllowlistedSecretCandidate(line, candidate) {
+				continue
+			}
+			if shannonEntropy(candidate) < r.EntropyThreshold {
+				continue
+			}
+			violations = append(violations, r.newViolation(file.Path, idx+1, "Possible hardcoded secret assigned to "+capture[1]))
+			break
+		}
+	}
+
+	return violations
+}
+
+func (r *SecretDetectionRule) newViolation(path string, line int, message string) model.Violation {
+	return model.Violation{
+		RuleID:      r.ID(),
+		Severity:    model.SeverityCritical,
+		Message:     message,
+		File:        path,
+		Line:        line,
+		ScoreImpact: -5.0,
+	}
+}
+
+func isAllowlistedSecretCandidate(line, candidate string) bool {
+	lowerLine := strings.ToLower(line)
+	lowerCandidate := strings.ToLower(strings.TrimSpace(candidate))
+	if strings.Contains(lowerLine, "repodoctor:allow-secret") {
+		return true
+	}
+	if strings.Contains(lowerLine, "example") || strings.Contains(lowerLine, "sample") || strings.Contains(lowerLine, "dummy") || strings.Contains(lowerLine, "placeholder") || strings.Contains(lowerLine, "test") {
+		return true
+	}
+	allowlistedValues := map[string]bool{
+		"changeme":     true,
+		"example":      true,
+		"example123":   true,
+		"dummy":        true,
+		"placeholder":  true,
+		"token":        true,
+		"not-a-secret": true,
+	}
+	if allowlistedValues[lowerCandidate] {
+		return true
+	}
+	if isRepeatedSingleRune(lowerCandidate) {
+		return true
+	}
+	return false
+}
+
+func isRepeatedSingleRune(value string) bool {
+	if len(value) < 8 {
+		return false
+	}
+	first := rune(value[0])
+	for _, ch := range value {
+		if ch != first {
+			return false
+		}
+	}
+	return true
+}
+
+func shannonEntropy(value string) float64 {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed) == 0 {
+		return 0
+	}
+
+	counts := map[rune]float64{}
+	total := 0.0
+	for _, ch := range trimmed {
+		if unicode.IsSpace(ch) {
+			continue
+		}
+		counts[ch]++
+		total++
+	}
+	if total == 0 {
+		return 0
+	}
+
+	entropy := 0.0
+	for _, count := range counts {
+		p := count / total
+		entropy -= p * math.Log2(p)
+	}
+	return entropy
+}

--- a/internal/rules/secret_detection_rule_test.go
+++ b/internal/rules/secret_detection_rule_test.go
@@ -1,0 +1,80 @@
+package rules
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSecretDetectionRule_DetectsHighRiskSecretPatterns(t *testing.T) {
+	rule := NewSecretDetectionRule()
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{{
+		Path:    "internal/config/secrets.go",
+		Content: "package config\nconst GitHubToken = \"ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"\n", //nolint:lll
+	}}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 1 {
+		t.Fatalf("expected one secret violation, got %d", len(violations))
+	}
+	if violations[0].Severity != "critical" {
+		t.Fatalf("expected critical severity, got %q", violations[0].Severity)
+	}
+	if violations[0].Line != 2 {
+		t.Fatalf("expected violation line 2, got %d", violations[0].Line)
+	}
+}
+
+func TestSecretDetectionRule_AllowlistAndEntropyReduceFalsePositives(t *testing.T) {
+	rule := NewSecretDetectionRule()
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{
+		{Path: "docs/examples.md", Content: "token = \"example123\"\n"},
+		{Path: "app/config.go", Content: "const apiKey = \"aaaaaaaaaaaaaaaaaaaaaaaaaaaa\" // repodoctor:allow-secret\n"},
+		{Path: "app/low_entropy.go", Content: "const password = \"aaaaabbbbbccccc\"\n"},
+	}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations for allowlisted/low-entropy examples, got %d", len(violations))
+	}
+}
+
+func TestSecretDetectionRule_SkipsOversizedAndBinaryFilesFailSoft(t *testing.T) {
+	rule := NewSecretDetectionRule()
+	content := make([]byte, defaultSecretMaxScanBytes+10)
+	for i := range content {
+		content[i] = 'A'
+	}
+
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{
+		{Path: "vendor/big_blob.go", Content: string(content)},
+		{Path: "assets/blob.bin", Content: "abc\x00defghijklmnopqrstuvwxyz"},
+	}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected fail-soft skip for oversized/binary content, got %d violations", len(violations))
+	}
+}
+
+func TestSecretDetectionRule_OutputOrderingDeterministic(t *testing.T) {
+	rule := NewSecretDetectionRule()
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{
+		{
+			Path:    "b.go",
+			Content: "const token = \"ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"\n",
+		},
+		{
+			Path:    "a.go",
+			Content: "const token = \"ghp_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\"\n",
+		},
+	}}
+
+	first := rule.Evaluate(ctx)
+	second := rule.Evaluate(ctx)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("expected deterministic output ordering\nfirst=%v\nsecond=%v", first, second)
+	}
+	if len(first) != 2 || first[0].File != "a.go" || first[1].File != "b.go" {
+		t.Fatalf("expected sorted violation order by file, got %+v", first)
+	}
+}

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -179,6 +179,8 @@ func buildReportFromRuleViolations(path string, version string, cfg *Config, vio
 			report.Circular = append(report.Circular, parseCircularViolation(v))
 		case "rule.layer-validation":
 			report.Layer = append(report.Layer, parseLayerViolation(v))
+		case "rule.secret-detection":
+			report.Layer = append(report.Layer, parseLayerViolation(v))
 		case "rule.size":
 			report.Size = append(report.Size, parseSizeViolation(v))
 		case "rule.god-object":
@@ -320,6 +322,8 @@ func remediationHintForViolation(v model.Violation) string {
 		return "Split oversized files/functions into focused units with one responsibility each."
 	case "rule.god-object":
 		return "Extract cohesive responsibilities into dedicated types and keep each object focused on one concern."
+	case "rule.secret-detection":
+		return "Move credentials to environment variables or secret stores and rotate any leaked keys immediately."
 	default:
 		return ""
 	}
@@ -334,6 +338,8 @@ func applyConfiguredSeverity(v model.Violation, cfg *Config) model.Violation {
 	case "rule.circular-dependency":
 		severity = cfg.Rules.CircularSeverity
 	case "rule.layer-validation":
+		severity = cfg.Rules.LayerSeverity
+	case "rule.secret-detection":
 		severity = cfg.Rules.LayerSeverity
 	case "rule.size":
 		severity = cfg.Rules.SizeSeverity

--- a/runtime_engine_remediation_test.go
+++ b/runtime_engine_remediation_test.go
@@ -9,6 +9,7 @@ import (
 func TestBuildReportFromRuleViolations_AttachesRemediationHints(t *testing.T) {
 	violations := []model.Violation{
 		{RuleID: "rule.layer-validation", File: "repo/repo.go", Severity: model.SeverityError, Message: "x"},
+		{RuleID: "rule.secret-detection", File: "repo/secrets.go", Severity: model.SeverityCritical, Message: "GitHub token pattern detected"},
 		{RuleID: "rule.size", File: "a.go", Severity: model.SeverityWarning, Message: "Function 'big' has 101 lines (threshold: 80)"},
 		{RuleID: "rule.god-object", File: "obj.go", Severity: model.SeverityWarning, Message: "Manager has 12 methods (threshold: 10)"},
 	}
@@ -16,6 +17,9 @@ func TestBuildReportFromRuleViolations_AttachesRemediationHints(t *testing.T) {
 	report := buildReportFromRuleViolations(".", "1.1.0", nil, violations)
 	if len(report.Layer) == 0 || report.Layer[0].Hint == "" {
 		t.Fatal("expected layer violation hint to be populated")
+	}
+	if len(report.Layer) < 2 || report.Layer[1].Hint == "" {
+		t.Fatal("expected secret-detection remediation hint to be populated")
 	}
 	if len(report.Size) == 0 || report.Size[0].Hint == "" {
 		t.Fatal("expected size violation hint to be populated")


### PR DESCRIPTION
## Summary
- add new internal rule `rule.secret-detection` with critical severity for likely hardcoded secrets
- reduce false positives using allowlist heuristics and Shannon entropy threshold checks
- enforce bounded scanning and fail-soft skips for oversized/binary files, while keeping deterministic violation ordering

## Integration
- register the new rule in default registry
- surface secret-detection findings through rule-engine report flow as critical layer-level violations
- add remediation hint mapping for secret findings

## Validation
- `go test ./...`
- `go vet ./...`
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`
- `go run . analyze -path .`

Closes #308