### PR TITLE
feat(rd-16002): add deterministic code duplication rule

### DIFF
--- a/internal/rules/code_duplication_rule.go
+++ b/internal/rules/code_duplication_rule.go
@@ -1,0 +1,186 @@
+package rules
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+
+	"RepoDoctor/internal/model"
+)
+
+const (
+	defaultDuplicationWindowLines = 6
+	defaultDuplicationMaxWindows  = 50000
+)
+
+type CodeDuplicationRule struct {
+	WindowLines int
+	MaxWindows  int
+}
+
+func NewCodeDuplicationRule() *CodeDuplicationRule {
+	return &CodeDuplicationRule{WindowLines: defaultDuplicationWindowLines, MaxWindows: defaultDuplicationMaxWindows}
+}
+
+func (r *CodeDuplicationRule) ID() string { return "rule.code-duplication" }
+
+func (r *CodeDuplicationRule) Category() string { return string(CategoryMaintainability) }
+
+func (r *CodeDuplicationRule) Severity() string { return string(model.SeverityWarning) }
+
+func (r *CodeDuplicationRule) Capabilities() RuleCapabilities {
+	return RuleCapabilities{SupportedLanguages: []string{"Go", "Python", "JavaScript", "TypeScript", "Java"}, SupportsMultipleLanguages: true}
+}
+
+func (r *CodeDuplicationRule) Evaluate(context AnalysisContext) []model.Violation {
+	window := r.WindowLines
+	if window < 4 {
+		window = defaultDuplicationWindowLines
+	}
+	maxWindows := r.MaxWindows
+	if maxWindows <= 0 {
+		maxWindows = defaultDuplicationMaxWindows
+	}
+
+	type windowInstance struct {
+		file      string
+		startLine int
+		length    int
+	}
+
+	buckets := make(map[string][]windowInstance)
+	totalWindows := 0
+
+	for _, file := range context.RepositoryFiles {
+		if shouldSkipDuplicationScan(file.Path) {
+			continue
+		}
+		normalizedLines, sourceLines := normalizeContentForDuplication(file.Content)
+		if len(normalizedLines) < window {
+			continue
+		}
+		for idx := 0; idx+window <= len(normalizedLines); idx++ {
+			if totalWindows >= maxWindows {
+				break
+			}
+			signature := hashWindow(normalizedLines[idx : idx+window])
+			buckets[signature] = append(buckets[signature], windowInstance{
+				file:      file.Path,
+				startLine: sourceLines[idx],
+				length:    window,
+			})
+			totalWindows++
+		}
+		if totalWindows >= maxWindows {
+			break
+		}
+	}
+
+	violations := make([]model.Violation, 0)
+	seen := map[string]bool{}
+
+	for _, instances := range buckets {
+		if len(instances) < 2 {
+			continue
+		}
+		sort.Slice(instances, func(i, j int) bool {
+			if instances[i].file != instances[j].file {
+				return instances[i].file < instances[j].file
+			}
+			return instances[i].startLine < instances[j].startLine
+		})
+
+		for i := 0; i < len(instances)-1; i++ {
+			left := instances[i]
+			right := instances[i+1]
+			if left.file == right.file {
+				continue
+			}
+			fingerprint := left.file + ":" + fmt.Sprint(left.startLine) + "->" + right.file + ":" + fmt.Sprint(right.startLine)
+			if seen[fingerprint] {
+				continue
+			}
+			seen[fingerprint] = true
+
+			violations = append(violations,
+				model.Violation{
+					RuleID:      r.ID(),
+					Severity:    model.SeverityWarning,
+					Message:     fmt.Sprintf("File %s has %d lines (threshold: %d) duplicated with %s", left.file, left.length, window, right.file),
+					File:        left.file,
+					Line:        left.startLine,
+					ScoreImpact: -2.0,
+				},
+				model.Violation{
+					RuleID:      r.ID(),
+					Severity:    model.SeverityWarning,
+					Message:     fmt.Sprintf("File %s has %d lines (threshold: %d) duplicated with %s", right.file, right.length, window, left.file),
+					File:        right.file,
+					Line:        right.startLine,
+					ScoreImpact: -2.0,
+				},
+			)
+		}
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].File != violations[j].File {
+			return violations[i].File < violations[j].File
+		}
+		if violations[i].Line != violations[j].Line {
+			return violations[i].Line < violations[j].Line
+		}
+		return violations[i].Message < violations[j].Message
+	})
+
+	return violations
+}
+
+func shouldSkipDuplicationScan(path string) bool {
+	lower := strings.ToLower(path)
+	if strings.Contains(lower, "/testdata/") || strings.Contains(lower, "\\testdata\\") {
+		return true
+	}
+	if strings.Contains(lower, "/vendor/") || strings.Contains(lower, "\\vendor\\") {
+		return true
+	}
+	if strings.Contains(lower, "/fixtures/") || strings.Contains(lower, "\\fixtures\\") {
+		return true
+	}
+	if strings.Contains(lower, "/docs/") || strings.Contains(lower, "\\docs\\") {
+		return true
+	}
+	if strings.HasPrefix(lower, "docs/") || strings.HasPrefix(lower, "docs\\") {
+		return true
+	}
+	if strings.Contains(lower, ".min.") {
+		return true
+	}
+	return false
+}
+
+func normalizeContentForDuplication(content string) ([]string, []int) {
+	lines := strings.Split(content, "\n")
+	normalized := make([]string, 0, len(lines))
+	sourceLines := make([]int, 0, len(lines))
+
+	for idx, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		compact := strings.Join(strings.Fields(trimmed), " ")
+		normalized = append(normalized, compact)
+		sourceLines = append(sourceLines, idx+1)
+	}
+
+	return normalized, sourceLines
+}
+
+func hashWindow(lines []string) string {
+	joined := strings.Join(lines, "\n")
+	sum := sha1.Sum([]byte(joined))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/rules/code_duplication_rule_test.go
+++ b/internal/rules/code_duplication_rule_test.go
@@ -1,0 +1,61 @@
+package rules
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCodeDuplicationRule_DetectsDuplicateBlocksAcrossFiles(t *testing.T) {
+	rule := NewCodeDuplicationRule()
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{
+		{
+			Path:    "a.go",
+			Content: "package p\nfunc a() {\nvalue := 1\nvalue = value + 2\nvalue = value + 3\nvalue = value + 4\nvalue = value + 5\nvalue = value + 6\n}\n",
+		},
+		{
+			Path:    "b.go",
+			Content: "package p\nfunc b() {\nvalue := 1\nvalue = value + 2\nvalue = value + 3\nvalue = value + 4\nvalue = value + 5\nvalue = value + 6\n}\n",
+		},
+	}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) == 0 {
+		t.Fatal("expected duplication violations across two files")
+	}
+	if violations[0].RuleID != "rule.code-duplication" {
+		t.Fatalf("unexpected rule id %q", violations[0].RuleID)
+	}
+}
+
+func TestCodeDuplicationRule_SkipsAllowlistedPaths(t *testing.T) {
+	rule := NewCodeDuplicationRule()
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{
+		{Path: "docs/snippets.go", Content: "a\nb\nc\nd\ne\nf\n"},
+		{Path: "vendor/lib.go", Content: "a\nb\nc\nd\ne\nf\n"},
+	}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations for allowlisted paths, got %d", len(violations))
+	}
+}
+
+func TestCodeDuplicationRule_IsDeterministic(t *testing.T) {
+	rule := NewCodeDuplicationRule()
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{
+		{
+			Path:    "z.go",
+			Content: "package p\nfunc z() {\na\nb\nc\nd\ne\nf\n}\n",
+		},
+		{
+			Path:    "a.go",
+			Content: "package p\nfunc a() {\na\nb\nc\nd\ne\nf\n}\n",
+		},
+	}}
+
+	first := rule.Evaluate(ctx)
+	second := rule.Evaluate(ctx)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("expected deterministic output ordering\nfirst=%v\nsecond=%v", first, second)
+	}
+}

--- a/internal/rules/init.go
+++ b/internal/rules/init.go
@@ -9,6 +9,7 @@ func init() {
 	DefaultRegistry.MustRegister(NewSizeRule())
 	DefaultRegistry.MustRegister(NewLayerValidationRule())
 	DefaultRegistry.MustRegister(NewSecretDetectionRule())
+	DefaultRegistry.MustRegister(NewCodeDuplicationRule())
 	// Note: CircularDependencyRule requires a graph parameter, so it's registered separately
 }
 

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -181,6 +181,8 @@ func buildReportFromRuleViolations(path string, version string, cfg *Config, vio
 			report.Layer = append(report.Layer, parseLayerViolation(v))
 		case "rule.secret-detection":
 			report.Layer = append(report.Layer, parseLayerViolation(v))
+		case "rule.code-duplication":
+			report.Size = append(report.Size, parseSizeViolation(v))
 		case "rule.size":
 			report.Size = append(report.Size, parseSizeViolation(v))
 		case "rule.god-object":
@@ -324,6 +326,8 @@ func remediationHintForViolation(v model.Violation) string {
 		return "Extract cohesive responsibilities into dedicated types and keep each object focused on one concern."
 	case "rule.secret-detection":
 		return "Move credentials to environment variables or secret stores and rotate any leaked keys immediately."
+	case "rule.code-duplication":
+		return "Extract shared logic into reusable helpers/components and keep one source of truth for duplicated blocks."
 	default:
 		return ""
 	}
@@ -341,6 +345,8 @@ func applyConfiguredSeverity(v model.Violation, cfg *Config) model.Violation {
 		severity = cfg.Rules.LayerSeverity
 	case "rule.secret-detection":
 		severity = cfg.Rules.LayerSeverity
+	case "rule.code-duplication":
+		severity = cfg.Rules.SizeSeverity
 	case "rule.size":
 		severity = cfg.Rules.SizeSeverity
 	case "rule.god-object":

--- a/runtime_engine_remediation_test.go
+++ b/runtime_engine_remediation_test.go
@@ -10,6 +10,7 @@ func TestBuildReportFromRuleViolations_AttachesRemediationHints(t *testing.T) {
 	violations := []model.Violation{
 		{RuleID: "rule.layer-validation", File: "repo/repo.go", Severity: model.SeverityError, Message: "x"},
 		{RuleID: "rule.secret-detection", File: "repo/secrets.go", Severity: model.SeverityCritical, Message: "GitHub token pattern detected"},
+		{RuleID: "rule.code-duplication", File: "repo/dup_a.go", Severity: model.SeverityWarning, Message: "File repo/dup_a.go has 8 lines (threshold: 6) duplicated with repo/dup_b.go"},
 		{RuleID: "rule.size", File: "a.go", Severity: model.SeverityWarning, Message: "Function 'big' has 101 lines (threshold: 80)"},
 		{RuleID: "rule.god-object", File: "obj.go", Severity: model.SeverityWarning, Message: "Manager has 12 methods (threshold: 10)"},
 	}

--- a/runtime_engine_violation_messages_test.go
+++ b/runtime_engine_violation_messages_test.go
@@ -55,6 +55,7 @@ func TestApplyConfiguredSeverity_UsesRuleOverrides(t *testing.T) {
 	}{
 		{ruleID: "rule.circular-dependency", want: model.SeverityWarning},
 		{ruleID: "rule.layer-validation", want: model.SeverityCritical},
+		{ruleID: "rule.code-duplication", want: model.SeverityError},
 		{ruleID: "rule.size", want: model.SeverityError},
 		{ruleID: "rule.god-object", want: model.SeverityInfo},
 	}


### PR DESCRIPTION
## Summary
- add `rule.code-duplication` to detect duplicated code windows across files with deterministic ordering
- apply safe subset behavior with bounded scanning and allowlist path skips (`docs`, `vendor`, `fixtures`, `testdata`)
- integrate duplication findings into report/severity/remediation flow without changing JSON contract shape

## Validation
- `go test ./...`
- `go vet ./...`
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`
- `go run . analyze -path .`

Closes #309