### PR TITLE
feat(rd-16003): add safe-subset dead code rule

### DIFF
--- a/internal/rules/dead_code_rule.go
+++ b/internal/rules/dead_code_rule.go
@@ -1,0 +1,186 @@
+package rules
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"RepoDoctor/internal/model"
+)
+
+type DeadCodeRule struct{}
+
+func NewDeadCodeRule() *DeadCodeRule {
+	return &DeadCodeRule{}
+}
+
+func (r *DeadCodeRule) ID() string { return "rule.dead-code" }
+
+func (r *DeadCodeRule) Category() string { return string(CategoryMaintainability) }
+
+func (r *DeadCodeRule) Severity() string { return string(model.SeverityWarning) }
+
+func (r *DeadCodeRule) Capabilities() RuleCapabilities {
+	return RuleCapabilities{SupportedLanguages: []string{"Go"}, SupportsMultipleLanguages: false}
+}
+
+type goPackageFacts struct {
+	filePaths    []string
+	declared     map[string]deadDecl
+	called       map[string]bool
+	skipAnalysis bool
+}
+
+type deadDecl struct {
+	file      string
+	line      int
+	funcLines int
+}
+
+func (r *DeadCodeRule) Evaluate(context AnalysisContext) []model.Violation {
+	fset := token.NewFileSet()
+	packages := map[string]*goPackageFacts{}
+
+	for _, file := range context.RepositoryFiles {
+		if shouldSkipDeadCodeFile(file.Path) {
+			continue
+		}
+		node, err := parser.ParseFile(fset, file.Path, file.Content, parser.ParseComments)
+		if err != nil {
+			continue
+		}
+
+		pkgKey := filepath.Dir(file.Path) + ":" + node.Name.Name
+		facts, ok := packages[pkgKey]
+		if !ok {
+			facts = &goPackageFacts{declared: map[string]deadDecl{}, called: map[string]bool{}}
+			packages[pkgKey] = facts
+		}
+		facts.filePaths = append(facts.filePaths, file.Path)
+
+		if importsReflect(node) || strings.Contains(file.Content, "reflect.") {
+			facts.skipAnalysis = true
+		}
+
+		ast.Inspect(node, func(n ast.Node) bool {
+			switch typed := n.(type) {
+			case *ast.FuncDecl:
+				if typed.Recv != nil {
+					return true
+				}
+				name := typed.Name.Name
+				if shouldSkipDeadCodeFunction(name, typed.Doc) {
+					return true
+				}
+				start := fset.Position(typed.Pos()).Line
+				end := fset.Position(typed.End()).Line
+				facts.declared[name] = deadDecl{file: file.Path, line: start, funcLines: end - start + 1}
+			case *ast.CallExpr:
+				switch fn := typed.Fun.(type) {
+				case *ast.Ident:
+					facts.called[fn.Name] = true
+				case *ast.SelectorExpr:
+					if fn.Sel != nil {
+						facts.called[fn.Sel.Name] = true
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	violations := make([]model.Violation, 0)
+	keys := make([]string, 0, len(packages))
+	for key := range packages {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		facts := packages[key]
+		if facts.skipAnalysis {
+			continue
+		}
+		names := make([]string, 0, len(facts.declared))
+		for name := range facts.declared {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		for _, name := range names {
+			if facts.called[name] {
+				continue
+			}
+			decl := facts.declared[name]
+			violations = append(violations, model.Violation{
+				RuleID:      r.ID(),
+				Severity:    model.SeverityWarning,
+				Message:     "Function '" + name + "' has " + strconv.Itoa(decl.funcLines) + " lines (threshold: 1) and appears unused",
+				File:        decl.file,
+				Line:        decl.line,
+				ScoreImpact: -2.0,
+			})
+		}
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].File != violations[j].File {
+			return violations[i].File < violations[j].File
+		}
+		if violations[i].Line != violations[j].Line {
+			return violations[i].Line < violations[j].Line
+		}
+		return violations[i].Message < violations[j].Message
+	})
+
+	return violations
+}
+
+func shouldSkipDeadCodeFile(path string) bool {
+	lower := strings.ToLower(path)
+	if !strings.HasSuffix(lower, ".go") || strings.HasSuffix(lower, "_test.go") {
+		return true
+	}
+	if strings.Contains(lower, "/vendor/") || strings.Contains(lower, "\\vendor\\") {
+		return true
+	}
+	if strings.Contains(lower, "/testdata/") || strings.Contains(lower, "\\testdata\\") {
+		return true
+	}
+	return false
+}
+
+func shouldSkipDeadCodeFunction(name string, doc *ast.CommentGroup) bool {
+	if name == "main" || name == "init" {
+		return true
+	}
+	if strings.HasPrefix(name, "Test") || strings.HasPrefix(name, "Benchmark") || strings.HasPrefix(name, "Example") {
+		return true
+	}
+	if len(name) > 0 && strings.ToUpper(name[:1]) == name[:1] {
+		return true
+	}
+	if doc == nil {
+		return false
+	}
+	for _, c := range doc.List {
+		if strings.Contains(strings.ToLower(c.Text), "repodoctor:keep") {
+			return true
+		}
+	}
+	return false
+}
+
+func importsReflect(node *ast.File) bool {
+	for _, imp := range node.Imports {
+		path := strings.Trim(imp.Path.Value, "\"")
+		if path == "reflect" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/dead_code_rule_test.go
+++ b/internal/rules/dead_code_rule_test.go
@@ -1,0 +1,45 @@
+package rules
+
+import "testing"
+
+func TestDeadCodeRule_FlagsUnusedPrivateFunction(t *testing.T) {
+	rule := NewDeadCodeRule()
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{{
+		Path:    "pkg/service/a.go",
+		Content: "package service\nfunc init() { used() }\nfunc used() { helper() }\nfunc helper() {}\nfunc unusedThing() {\nprintln(\"x\")\n}\n",
+	}}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 1 {
+		t.Fatalf("expected one dead-code violation, got %d", len(violations))
+	}
+	if violations[0].RuleID != "rule.dead-code" {
+		t.Fatalf("unexpected rule id %q", violations[0].RuleID)
+	}
+}
+
+func TestDeadCodeRule_DoesNotFlagPrivateFunctionCalledFromAnotherFile(t *testing.T) {
+	rule := NewDeadCodeRule()
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{
+		{Path: "pkg/service/a.go", Content: "package service\nfunc helper() {}\n"},
+		{Path: "pkg/service/b.go", Content: "package service\nfunc init() { helper() }\n"},
+	}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected no dead-code violations for cross-file call, got %d", len(violations))
+	}
+}
+
+func TestDeadCodeRule_RespectsKeepDirectiveAndReflectionException(t *testing.T) {
+	rule := NewDeadCodeRule()
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{
+		{Path: "pkg/service/keep.go", Content: "package service\n// repodoctor:keep\nfunc maybeUsedElsewhere() {}\n"},
+		{Path: "pkg/service/reflective.go", Content: "package service\nimport \"reflect\"\nfunc discoveredAtRuntime() {}\nfunc x() { _ = reflect.ValueOf(discoveredAtRuntime) }\n"},
+	}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations due to keep/reflection exceptions, got %d", len(violations))
+	}
+}

--- a/internal/rules/init.go
+++ b/internal/rules/init.go
@@ -10,6 +10,7 @@ func init() {
 	DefaultRegistry.MustRegister(NewLayerValidationRule())
 	DefaultRegistry.MustRegister(NewSecretDetectionRule())
 	DefaultRegistry.MustRegister(NewCodeDuplicationRule())
+	DefaultRegistry.MustRegister(NewDeadCodeRule())
 	// Note: CircularDependencyRule requires a graph parameter, so it's registered separately
 }
 

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -183,6 +183,8 @@ func buildReportFromRuleViolations(path string, version string, cfg *Config, vio
 			report.Layer = append(report.Layer, parseLayerViolation(v))
 		case "rule.code-duplication":
 			report.Size = append(report.Size, parseSizeViolation(v))
+		case "rule.dead-code":
+			report.Size = append(report.Size, parseSizeViolation(v))
 		case "rule.size":
 			report.Size = append(report.Size, parseSizeViolation(v))
 		case "rule.god-object":
@@ -328,6 +330,8 @@ func remediationHintForViolation(v model.Violation) string {
 		return "Move credentials to environment variables or secret stores and rotate any leaked keys immediately."
 	case "rule.code-duplication":
 		return "Extract shared logic into reusable helpers/components and keep one source of truth for duplicated blocks."
+	case "rule.dead-code":
+		return "Remove unused private symbols or wire them explicitly where needed to keep the codebase lean and auditable."
 	default:
 		return ""
 	}
@@ -346,6 +350,8 @@ func applyConfiguredSeverity(v model.Violation, cfg *Config) model.Violation {
 	case "rule.secret-detection":
 		severity = cfg.Rules.LayerSeverity
 	case "rule.code-duplication":
+		severity = cfg.Rules.SizeSeverity
+	case "rule.dead-code":
 		severity = cfg.Rules.SizeSeverity
 	case "rule.size":
 		severity = cfg.Rules.SizeSeverity

--- a/runtime_engine_remediation_test.go
+++ b/runtime_engine_remediation_test.go
@@ -11,6 +11,7 @@ func TestBuildReportFromRuleViolations_AttachesRemediationHints(t *testing.T) {
 		{RuleID: "rule.layer-validation", File: "repo/repo.go", Severity: model.SeverityError, Message: "x"},
 		{RuleID: "rule.secret-detection", File: "repo/secrets.go", Severity: model.SeverityCritical, Message: "GitHub token pattern detected"},
 		{RuleID: "rule.code-duplication", File: "repo/dup_a.go", Severity: model.SeverityWarning, Message: "File repo/dup_a.go has 8 lines (threshold: 6) duplicated with repo/dup_b.go"},
+		{RuleID: "rule.dead-code", File: "repo/dead.go", Severity: model.SeverityWarning, Message: "Function 'unusedThing' has 3 lines (threshold: 1) and appears unused"},
 		{RuleID: "rule.size", File: "a.go", Severity: model.SeverityWarning, Message: "Function 'big' has 101 lines (threshold: 80)"},
 		{RuleID: "rule.god-object", File: "obj.go", Severity: model.SeverityWarning, Message: "Manager has 12 methods (threshold: 10)"},
 	}

--- a/runtime_engine_violation_messages_test.go
+++ b/runtime_engine_violation_messages_test.go
@@ -56,6 +56,7 @@ func TestApplyConfiguredSeverity_UsesRuleOverrides(t *testing.T) {
 		{ruleID: "rule.circular-dependency", want: model.SeverityWarning},
 		{ruleID: "rule.layer-validation", want: model.SeverityCritical},
 		{ruleID: "rule.code-duplication", want: model.SeverityError},
+		{ruleID: "rule.dead-code", want: model.SeverityError},
 		{ruleID: "rule.size", want: model.SeverityError},
 		{ruleID: "rule.god-object", want: model.SeverityInfo},
 	}


### PR DESCRIPTION
## Summary
- add `rule.dead-code` as a safe-subset Go-only rule for unused private top-level functions
- reduce false positives by excluding exported symbols, `init/main`, keep directives (`repodoctor:keep`), and reflection-heavy packages
- keep deterministic output and integrate dead-code findings into existing report/severity/remediation flow

## Validation
- `go test ./...`
- `go vet ./...`
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`
- `go run . analyze -path .`

Closes #310