### PR TITLE
feat(rd-16005): add configurable interface bloat rule

### DIFF
--- a/internal/rules/init.go
+++ b/internal/rules/init.go
@@ -12,6 +12,7 @@ func init() {
 	DefaultRegistry.MustRegister(NewCodeDuplicationRule())
 	DefaultRegistry.MustRegister(NewDeadCodeRule())
 	DefaultRegistry.MustRegister(NewErrorHandlingConsistencyRule())
+	DefaultRegistry.MustRegister(NewInterfaceBloatRule())
 	// Note: CircularDependencyRule requires a graph parameter, so it's registered separately
 }
 

--- a/internal/rules/interface_bloat_rule.go
+++ b/internal/rules/interface_bloat_rule.go
@@ -1,0 +1,143 @@
+package rules
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strconv"
+	"strings"
+
+	"RepoDoctor/internal/model"
+)
+
+const defaultInterfaceBloatMaxMethods = 10
+
+type InterfaceBloatRule struct {
+	MaxMethods int
+}
+
+func NewInterfaceBloatRule() *InterfaceBloatRule {
+	return &InterfaceBloatRule{MaxMethods: defaultInterfaceBloatMaxMethods}
+}
+
+func (r *InterfaceBloatRule) ID() string { return "rule.interface-bloat" }
+
+func (r *InterfaceBloatRule) Category() string { return string(CategoryMaintainability) }
+
+func (r *InterfaceBloatRule) Severity() string { return string(model.SeverityWarning) }
+
+func (r *InterfaceBloatRule) Capabilities() RuleCapabilities {
+	return RuleCapabilities{SupportedLanguages: []string{"Go"}, SupportsMultipleLanguages: false}
+}
+
+func (r *InterfaceBloatRule) Evaluate(context AnalysisContext) []model.Violation {
+	maxMethods := r.resolveMaxMethods(context)
+	fset := token.NewFileSet()
+	violations := make([]model.Violation, 0)
+
+	for _, file := range context.RepositoryFiles {
+		if shouldSkipErrorHandlingFile(file.Path) {
+			continue
+		}
+
+		node, err := parser.ParseFile(fset, file.Path, file.Content, 0)
+		if err != nil {
+			continue
+		}
+
+		for _, decl := range node.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.TYPE {
+				continue
+			}
+
+			for _, spec := range gen.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				iface, ok := typeSpec.Type.(*ast.InterfaceType)
+				if !ok {
+					continue
+				}
+
+				methodCount := countInterfaceMethods(iface)
+				if methodCount <= maxMethods {
+					continue
+				}
+
+				line := fset.Position(typeSpec.Pos()).Line
+				violations = append(violations, model.Violation{
+					RuleID:      r.ID(),
+					Severity:    model.SeverityWarning,
+					Message:     "Function 'Interface " + typeSpec.Name.Name + "' has " + strconv.Itoa(methodCount) + " lines (threshold: " + strconv.Itoa(maxMethods) + ")",
+					File:        file.Path,
+					Line:        line,
+					ScoreImpact: -2.0,
+				})
+			}
+		}
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].File != violations[j].File {
+			return violations[i].File < violations[j].File
+		}
+		if violations[i].Line != violations[j].Line {
+			return violations[i].Line < violations[j].Line
+		}
+		return violations[i].Message < violations[j].Message
+	})
+
+	return violations
+}
+
+func (r *InterfaceBloatRule) resolveMaxMethods(context AnalysisContext) int {
+	maxMethods := r.MaxMethods
+	if maxMethods <= 0 {
+		maxMethods = defaultInterfaceBloatMaxMethods
+	}
+	if context.Configuration == nil {
+		return maxMethods
+	}
+	raw, ok := context.Configuration["interfaceBloatMaxMethods"]
+	if !ok {
+		return maxMethods
+	}
+
+	switch typed := raw.(type) {
+	case int:
+		if typed > 0 {
+			return typed
+		}
+	case int64:
+		if typed > 0 {
+			return int(typed)
+		}
+	case float64:
+		if typed > 0 {
+			return int(typed)
+		}
+	case string:
+		v, err := strconv.Atoi(strings.TrimSpace(typed))
+		if err == nil && v > 0 {
+			return v
+		}
+	}
+
+	return maxMethods
+}
+
+func countInterfaceMethods(iface *ast.InterfaceType) int {
+	if iface == nil || iface.Methods == nil {
+		return 0
+	}
+	count := 0
+	for _, method := range iface.Methods.List {
+		if len(method.Names) > 0 {
+			count += len(method.Names)
+		}
+	}
+	return count
+}

--- a/internal/rules/interface_bloat_rule_test.go
+++ b/internal/rules/interface_bloat_rule_test.go
@@ -1,0 +1,35 @@
+package rules
+
+import "testing"
+
+func TestInterfaceBloatRule_FlagsLargeInterface(t *testing.T) {
+	rule := NewInterfaceBloatRule()
+	ctx := AnalysisContext{RepositoryFiles: []RepositoryFile{{
+		Path:    "pkg/api/contracts.go",
+		Content: "package api\ntype Gateway interface {\nA()\nB()\nC()\nD()\nE()\nF()\nG()\nH()\nI()\nJ()\nK()\n}\n",
+	}}}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 1 {
+		t.Fatalf("expected one interface-bloat violation, got %d", len(violations))
+	}
+	if violations[0].RuleID != "rule.interface-bloat" {
+		t.Fatalf("unexpected rule id: %q", violations[0].RuleID)
+	}
+}
+
+func TestInterfaceBloatRule_UsesConfigurableThreshold(t *testing.T) {
+	rule := NewInterfaceBloatRule()
+	ctx := AnalysisContext{
+		RepositoryFiles: []RepositoryFile{{
+			Path:    "pkg/api/contracts.go",
+			Content: "package api\ntype Gateway interface {\nA()\nB()\nC()\nD()\nE()\nF()\n}\n",
+		}},
+		Configuration: Configuration{"interfaceBloatMaxMethods": 6},
+	}
+
+	violations := rule.Evaluate(ctx)
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations when threshold=6 and methods=6, got %d", len(violations))
+	}
+}

--- a/runtime_context_builder.go
+++ b/runtime_context_builder.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"os"
+	"strconv"
+	"strings"
+
 	"RepoDoctor/internal/rules"
 )
 
@@ -31,6 +35,9 @@ func buildUnifiedRulesAnalysisContext(input runtimeAnalysisContextInput) rules.A
 		}
 		configuration["customLayerKeywords"] = copiedKeywords
 	}
+	if threshold, ok := resolveInterfaceBloatThreshold(); ok {
+		configuration["interfaceBloatMaxMethods"] = threshold
+	}
 
 	return rules.AnalysisContext{
 		RepositoryFiles: repositoryFiles,
@@ -38,6 +45,18 @@ func buildUnifiedRulesAnalysisContext(input runtimeAnalysisContextInput) rules.A
 		Configuration:   configuration,
 		Languages:       languages,
 	}
+}
+
+func resolveInterfaceBloatThreshold() (int, bool) {
+	raw := strings.TrimSpace(os.Getenv("REPODOCTOR_INTERFACE_BLOAT_MAX_METHODS"))
+	if raw == "" {
+		return 0, false
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return 0, false
+	}
+	return value, true
 }
 
 func buildContextRepositoryFiles(graph Graph) []rules.RepositoryFile {

--- a/runtime_context_builder_test.go
+++ b/runtime_context_builder_test.go
@@ -107,3 +107,25 @@ func TestResolveContextLanguages_DefaultIncludesJavaPilotLanguage(t *testing.T) 
 		t.Fatalf("expected Java in default language set tail, got %v", languages)
 	}
 }
+
+func TestBuildUnifiedRulesAnalysisContext_IncludesInterfaceBloatThresholdFromEnv(t *testing.T) {
+	t.Setenv("REPODOCTOR_INTERFACE_BLOAT_MAX_METHODS", "14")
+
+	graph := NewDependencyGraph()
+	graph.AddNode("a.go")
+
+	ctx := buildUnifiedRulesAnalysisContext(runtimeAnalysisContextInput{
+		RepositoryPath:  filepath.Clean("."),
+		Graph:           graph,
+		PrimaryLanguage: "Go",
+	})
+
+	raw, ok := ctx.Configuration["interfaceBloatMaxMethods"]
+	if !ok {
+		t.Fatalf("configuration key %q missing", "interfaceBloatMaxMethods")
+	}
+	v, ok := raw.(int)
+	if !ok || v != 14 {
+		t.Fatalf("unexpected interface bloat threshold in configuration: %v (%T)", raw, raw)
+	}
+}

--- a/runtime_engine.go
+++ b/runtime_engine.go
@@ -187,6 +187,8 @@ func buildReportFromRuleViolations(path string, version string, cfg *Config, vio
 			report.Size = append(report.Size, parseSizeViolation(v))
 		case "rule.error-handling":
 			report.Size = append(report.Size, parseSizeViolation(v))
+		case "rule.interface-bloat":
+			report.Size = append(report.Size, parseSizeViolation(v))
 		case "rule.size":
 			report.Size = append(report.Size, parseSizeViolation(v))
 		case "rule.god-object":
@@ -336,6 +338,8 @@ func remediationHintForViolation(v model.Violation) string {
 		return "Remove unused private symbols or wire them explicitly where needed to keep the codebase lean and auditable."
 	case "rule.error-handling":
 		return "Handle returned errors explicitly and wrap propagated errors with context using %w when appropriate."
+	case "rule.interface-bloat":
+		return "Split broad interfaces into smaller role-focused contracts to reduce coupling and improve substitutability."
 	default:
 		return ""
 	}
@@ -358,6 +362,8 @@ func applyConfiguredSeverity(v model.Violation, cfg *Config) model.Violation {
 	case "rule.dead-code":
 		severity = cfg.Rules.SizeSeverity
 	case "rule.error-handling":
+		severity = cfg.Rules.SizeSeverity
+	case "rule.interface-bloat":
 		severity = cfg.Rules.SizeSeverity
 	case "rule.size":
 		severity = cfg.Rules.SizeSeverity

--- a/runtime_engine_remediation_test.go
+++ b/runtime_engine_remediation_test.go
@@ -13,6 +13,7 @@ func TestBuildReportFromRuleViolations_AttachesRemediationHints(t *testing.T) {
 		{RuleID: "rule.code-duplication", File: "repo/dup_a.go", Severity: model.SeverityWarning, Message: "File repo/dup_a.go has 8 lines (threshold: 6) duplicated with repo/dup_b.go"},
 		{RuleID: "rule.dead-code", File: "repo/dead.go", Severity: model.SeverityWarning, Message: "Function 'unusedThing' has 3 lines (threshold: 1) and appears unused"},
 		{RuleID: "rule.error-handling", File: "repo/err.go", Severity: model.SeverityWarning, Message: "Function 'wrapError' has 1 lines (threshold: 1) and formats error without %w wrapping"},
+		{RuleID: "rule.interface-bloat", File: "repo/contracts.go", Severity: model.SeverityWarning, Message: "Function 'Interface Gateway' has 12 lines (threshold: 10)"},
 		{RuleID: "rule.size", File: "a.go", Severity: model.SeverityWarning, Message: "Function 'big' has 101 lines (threshold: 80)"},
 		{RuleID: "rule.god-object", File: "obj.go", Severity: model.SeverityWarning, Message: "Manager has 12 methods (threshold: 10)"},
 	}

--- a/runtime_engine_violation_messages_test.go
+++ b/runtime_engine_violation_messages_test.go
@@ -58,6 +58,7 @@ func TestApplyConfiguredSeverity_UsesRuleOverrides(t *testing.T) {
 		{ruleID: "rule.code-duplication", want: model.SeverityError},
 		{ruleID: "rule.dead-code", want: model.SeverityError},
 		{ruleID: "rule.error-handling", want: model.SeverityError},
+		{ruleID: "rule.interface-bloat", want: model.SeverityError},
 		{ruleID: "rule.size", want: model.SeverityError},
 		{ruleID: "rule.god-object", want: model.SeverityInfo},
 	}


### PR DESCRIPTION
## Summary
- add `rule.interface-bloat` (Go safe-subset) to detect oversized interfaces by method count
- make threshold configurable via `REPODOCTOR_INTERFACE_BLOAT_MAX_METHODS` and propagate it through analysis context
- surface actionable suggestion through existing hint pipeline so report output includes remediation guidance

## Validation
- `go test ./...`
- `go vet ./...`
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`
- `go run . analyze -path .`

Closes #312