### PR TITLE
feat(rd-16006): add cyclomatic complexity band metrics

### DIFF
--- a/analysis_service.go
+++ b/analysis_service.go
@@ -90,6 +90,7 @@ func (s *AnalysisService) RunWithReport(request AnalyzeRequest) (int, *Structura
 
 	report := generateRuleEngineReport(absPath, request.Format, request.Verbose, request.ColorEnabled, config, ruleSummary)
 	report.Language = collectLanguageEvidenceSummary(absPath, analysisResult.AdapterName)
+	report.Complexity = collectCyclomaticComplexitySummary(absPath)
 	progress.SetProgress(progress.totalSteps)
 	progress.Complete()
 
@@ -129,17 +130,20 @@ func exportMetricsSnapshot(absPath, outputFormat string, result *analysispkg.Res
 	}
 
 	snapshot := metricsPkg.Snapshot{
-		Version:         version,
-		Adapter:         result.AdapterName,
-		OutputFormat:    outputFormat,
-		FilesDetected:   len(result.Files),
-		GraphNodes:      0,
-		GraphEdges:      0,
-		CircularCount:   len(report.Circular),
-		LayerCount:      len(report.Layer),
-		SizeCount:       len(report.Size),
-		GodObjectCount:  len(report.GodObject),
-		TotalViolations: len(report.Circular) + len(report.Layer) + len(report.Size) + len(report.GodObject),
+		Version:          version,
+		Adapter:          result.AdapterName,
+		OutputFormat:     outputFormat,
+		FilesDetected:    len(result.Files),
+		GraphNodes:       0,
+		GraphEdges:       0,
+		CircularCount:    len(report.Circular),
+		LayerCount:       len(report.Layer),
+		SizeCount:        len(report.Size),
+		GodObjectCount:   len(report.GodObject),
+		ComplexityLow:    report.Complexity.Low,
+		ComplexityMedium: report.Complexity.Medium,
+		ComplexityHigh:   report.Complexity.High,
+		TotalViolations:  len(report.Circular) + len(report.Layer) + len(report.Size) + len(report.GodObject),
 	}
 
 	if result.Graph != nil {

--- a/colored_methods.go
+++ b/colored_methods.go
@@ -160,6 +160,18 @@ func writeGodObjectViolationsWithColor(sb *strings.Builder, report *StructuralRe
 	sb.WriteString("\n")
 }
 
+func writeComplexityBandsWithColor(sb *strings.Builder, report *StructuralReport, formatter *ColorFormatter) {
+	sb.WriteString(formatter.Color("┌───────────────────────────────────────────────────────────┐", ColorCyan))
+	sb.WriteString("\n")
+	sb.WriteString(formatter.Color("│  CYCLOMATIC COMPLEXITY BANDS                              │", ColorCyan))
+	sb.WriteString("\n")
+	sb.WriteString(formatter.Color("└───────────────────────────────────────────────────────────┘", ColorCyan))
+	sb.WriteString("\n")
+	sb.WriteString(formatter.Info(fmt.Sprintf("Low (<=10): %d\n", report.Complexity.Low)))
+	sb.WriteString(formatter.Info(fmt.Sprintf("Medium (11-20): %d\n", report.Complexity.Medium)))
+	sb.WriteString(formatter.Info(fmt.Sprintf("High (>20): %d\n\n", report.Complexity.High)))
+}
+
 // writeScoreBreakdownWithColor writes the score breakdown with colors
 func writeScoreBreakdownWithColor(sb *strings.Builder, report *StructuralReport, formatter *ColorFormatter) {
 	if !report.HasViolations {

--- a/cyclomatic_complexity.go
+++ b/cyclomatic_complexity.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type ComplexityBandSummary struct {
+	Low    int `json:"low"`
+	Medium int `json:"medium"`
+	High   int `json:"high"`
+}
+
+func collectCyclomaticComplexitySummary(root string) ComplexityBandSummary {
+	paths := make([]string, 0)
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			name := strings.ToLower(d.Name())
+			if name == ".git" || name == "vendor" || name == "testdata" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		lower := strings.ToLower(path)
+		if !strings.HasSuffix(lower, ".go") || strings.HasSuffix(lower, "_test.go") {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	})
+
+	sort.Strings(paths)
+	summary := ComplexityBandSummary{}
+	fset := token.NewFileSet()
+
+	for _, path := range paths {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		node, err := parser.ParseFile(fset, path, content, 0)
+		if err != nil {
+			continue
+		}
+
+		for _, decl := range node.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			complexity := 1
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				switch typed := n.(type) {
+				case *ast.IfStmt, *ast.ForStmt, *ast.RangeStmt, *ast.CaseClause, *ast.CommClause:
+					complexity++
+				case *ast.BinaryExpr:
+					if typed.Op.String() == "&&" || typed.Op.String() == "||" {
+						complexity++
+					}
+				}
+				return true
+			})
+
+			switch {
+			case complexity <= 10:
+				summary.Low++
+			case complexity <= 20:
+				summary.Medium++
+			default:
+				summary.High++
+			}
+		}
+	}
+
+	return summary
+}

--- a/cyclomatic_complexity_test.go
+++ b/cyclomatic_complexity_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCollectCyclomaticComplexitySummary_BandsDeterministic(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.go"), []byte("package demo\nfunc low(){if true {}}\nfunc med(){if true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\n}\n"), 0o644); err != nil {
+		t.Fatalf("write a.go: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "b.go"), []byte("package demo\nfunc high(){if true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\nif true {}\n}\n"), 0o644); err != nil {
+		t.Fatalf("write b.go: %v", err)
+	}
+
+	first := collectCyclomaticComplexitySummary(root)
+	second := collectCyclomaticComplexitySummary(root)
+	if first != second {
+		t.Fatalf("expected deterministic summary, got %v vs %v", first, second)
+	}
+	if first.Low == 0 || first.Medium == 0 || first.High == 0 {
+		t.Fatalf("expected all bands to be populated, got %+v", first)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -8,17 +8,20 @@ import (
 
 // Snapshot is a deterministic metrics export payload for one analyze run.
 type Snapshot struct {
-	Version         string `json:"version"`
-	Adapter         string `json:"adapter"`
-	OutputFormat    string `json:"outputFormat"`
-	FilesDetected   int    `json:"filesDetected"`
-	GraphNodes      int    `json:"graphNodes"`
-	GraphEdges      int    `json:"graphEdges"`
-	CircularCount   int    `json:"circularCount"`
-	LayerCount      int    `json:"layerCount"`
-	SizeCount       int    `json:"sizeCount"`
-	GodObjectCount  int    `json:"godObjectCount"`
-	TotalViolations int    `json:"totalViolations"`
+	Version          string `json:"version"`
+	Adapter          string `json:"adapter"`
+	OutputFormat     string `json:"outputFormat"`
+	FilesDetected    int    `json:"filesDetected"`
+	GraphNodes       int    `json:"graphNodes"`
+	GraphEdges       int    `json:"graphEdges"`
+	CircularCount    int    `json:"circularCount"`
+	LayerCount       int    `json:"layerCount"`
+	SizeCount        int    `json:"sizeCount"`
+	GodObjectCount   int    `json:"godObjectCount"`
+	ComplexityLow    int    `json:"complexityLow"`
+	ComplexityMedium int    `json:"complexityMedium"`
+	ComplexityHigh   int    `json:"complexityHigh"`
+	TotalViolations  int    `json:"totalViolations"`
 }
 
 // Marshal serializes the snapshot in deterministic key order.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -7,17 +7,20 @@ import (
 
 func TestSnapshotMarshal_Deterministic(t *testing.T) {
 	snapshot := Snapshot{
-		Version:         "1.1.0",
-		Adapter:         "Go",
-		OutputFormat:    "text",
-		FilesDetected:   3,
-		GraphNodes:      4,
-		GraphEdges:      2,
-		CircularCount:   0,
-		LayerCount:      1,
-		SizeCount:       2,
-		GodObjectCount:  0,
-		TotalViolations: 3,
+		Version:          "1.1.0",
+		Adapter:          "Go",
+		OutputFormat:     "text",
+		FilesDetected:    3,
+		GraphNodes:       4,
+		GraphEdges:       2,
+		CircularCount:    0,
+		LayerCount:       1,
+		SizeCount:        2,
+		GodObjectCount:   0,
+		ComplexityLow:    3,
+		ComplexityMedium: 1,
+		ComplexityHigh:   0,
+		TotalViolations:  3,
 	}
 
 	first, err := snapshot.Marshal()

--- a/main.go
+++ b/main.go
@@ -503,6 +503,7 @@ func generateReport(scorer *StructuralScorer, absPath, format string, verbose bo
 		writeLayerViolationsWithColor(&sb, report, reporter.formatter)
 		writeSizeViolationsWithColor(&sb, report, reporter.formatter)
 		writeGodObjectViolationsWithColor(&sb, report, reporter.formatter)
+		writeComplexityBandsWithColor(&sb, report, reporter.formatter)
 		writeScoreBreakdownWithColor(&sb, report, reporter.formatter)
 		fmt.Println(sb.String())
 	}
@@ -529,6 +530,7 @@ func generateRuleEngineReport(absPath, format string, verbose bool, colorEnabled
 		writeLayerViolationsWithColor(&sb, report, reporter.formatter)
 		writeSizeViolationsWithColor(&sb, report, reporter.formatter)
 		writeGodObjectViolationsWithColor(&sb, report, reporter.formatter)
+		writeComplexityBandsWithColor(&sb, report, reporter.formatter)
 		writeScoreBreakdownWithColor(&sb, report, reporter.formatter)
 		fmt.Println(sb.String())
 	}

--- a/reporter.go
+++ b/reporter.go
@@ -41,6 +41,7 @@ type StructuralReport struct {
 	GodObject     []GodObjectViolation
 	Summary       ReportSummary
 	Language      LanguageEvidenceSummary
+	Complexity    ComplexityBandSummary
 	HasViolations bool
 }
 
@@ -91,6 +92,7 @@ func (r *Reporter) GenerateReport(scorer *StructuralScorer, path, version string
 			GodObject:       len(violations.GodObject),
 		},
 		Language:      LanguageEvidenceSummary{DetectedLanguage: "unknown", Confidence: 0.0},
+		Complexity:    ComplexityBandSummary{},
 		HasViolations: len(violations.Circular) > 0 || len(violations.Layer) > 0 || len(violations.Size) > 0 || len(violations.GodObject) > 0,
 	}
 }
@@ -118,6 +120,7 @@ func (r *Reporter) formatText(report *StructuralReport) string {
 	writeLayerViolations(&sb, report)
 	writeSizeViolations(&sb, report)
 	writeGodObjectViolations(&sb, report)
+	writeComplexityBands(&sb, report)
 	writeScoreBreakdown(&sb, report)
 
 	return sb.String()
@@ -168,6 +171,11 @@ func (r *Reporter) formatJSON(report *StructuralReport) string {
 			"detectedLanguage": report.Language.DetectedLanguage,
 			"confidence":       report.Language.Confidence,
 			"reasonCodes":      append([]string(nil), report.Language.ReasonCodes...),
+		},
+		"complexity": map[string]interface{}{
+			"low":    report.Complexity.Low,
+			"medium": report.Complexity.Medium,
+			"high":   report.Complexity.High,
 		},
 		"circularViolations":  sortedCircularViolations(report.Circular),
 		"layerViolations":     sortedLayerViolations(report.Layer),

--- a/reporter_json_test.go
+++ b/reporter_json_test.go
@@ -30,6 +30,9 @@ func TestReporter_JSONV2_ContainsSchemaAndSummary(t *testing.T) {
 	if !strings.Contains(jsonOut, "\"language\"") {
 		t.Fatalf("expected language section in output: %s", jsonOut)
 	}
+	if !strings.Contains(jsonOut, "\"complexity\"") {
+		t.Fatalf("expected complexity section in output: %s", jsonOut)
+	}
 	if !strings.Contains(jsonOut, "\"reasonCodes\"") {
 		t.Fatalf("expected reasonCodes in output: %s", jsonOut)
 	}

--- a/reporter_methods.go
+++ b/reporter_methods.go
@@ -122,6 +122,15 @@ func writeGodObjectViolations(sb *strings.Builder, report *StructuralReport) {
 	sb.WriteString("\n")
 }
 
+func writeComplexityBands(sb *strings.Builder, report *StructuralReport) {
+	sb.WriteString("┌───────────────────────────────────────────────────────────┐\n")
+	sb.WriteString("│  CYCLOMATIC COMPLEXITY BANDS                              │\n")
+	sb.WriteString("└───────────────────────────────────────────────────────────┘\n")
+	sb.WriteString(fmt.Sprintf("Low (<=10): %d\n", report.Complexity.Low))
+	sb.WriteString(fmt.Sprintf("Medium (11-20): %d\n", report.Complexity.Medium))
+	sb.WriteString(fmt.Sprintf("High (>20): %d\n\n", report.Complexity.High))
+}
+
 func writeScoreBreakdown(sb *strings.Builder, report *StructuralReport) {
 	if !report.HasViolations {
 		sb.WriteString("✨ No structural violations detected! Your architecture is clean.\n\n")


### PR DESCRIPTION
## Summary
- add deterministic cyclomatic complexity band computation (low/medium/high) for Go functions
- integrate complexity bands into text/JSON reporting and metrics snapshot export
- keep scoring contract unchanged while surfacing management-friendly complexity distribution

## Validation
- `go test ./...`
- `go vet ./...`
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`
- `go run . analyze -path .`

Closes #313