### PR TITLE
feat(rd-16007): add technical debt estimation breakdown

### DIFF
--- a/analysis_service.go
+++ b/analysis_service.go
@@ -91,6 +91,7 @@ func (s *AnalysisService) RunWithReport(request AnalyzeRequest) (int, *Structura
 	report := generateRuleEngineReport(absPath, request.Format, request.Verbose, request.ColorEnabled, config, ruleSummary)
 	report.Language = collectLanguageEvidenceSummary(absPath, analysisResult.AdapterName)
 	report.Complexity = collectCyclomaticComplexitySummary(absPath)
+	report.Debt = estimateTechnicalDebt(report)
 	progress.SetProgress(progress.totalSteps)
 	progress.Complete()
 

--- a/colored_methods.go
+++ b/colored_methods.go
@@ -172,6 +172,21 @@ func writeComplexityBandsWithColor(sb *strings.Builder, report *StructuralReport
 	sb.WriteString(formatter.Info(fmt.Sprintf("High (>20): %d\n\n", report.Complexity.High)))
 }
 
+func writeTechnicalDebtSummaryWithColor(sb *strings.Builder, report *StructuralReport, formatter *ColorFormatter) {
+	sb.WriteString(formatter.Color("┌───────────────────────────────────────────────────────────┐", ColorCyan))
+	sb.WriteString("\n")
+	sb.WriteString(formatter.Color("│  TECHNICAL DEBT ESTIMATE                                  │", ColorCyan))
+	sb.WriteString("\n")
+	sb.WriteString(formatter.Color("└───────────────────────────────────────────────────────────┘", ColorCyan))
+	sb.WriteString("\n")
+	sb.WriteString(formatter.Info(fmt.Sprintf("Circular: %dh\n", report.Debt.CircularHours)))
+	sb.WriteString(formatter.Info(fmt.Sprintf("Layer: %dh\n", report.Debt.LayerHours)))
+	sb.WriteString(formatter.Info(fmt.Sprintf("Size: %dh\n", report.Debt.SizeHours)))
+	sb.WriteString(formatter.Info(fmt.Sprintf("God Object: %dh\n", report.Debt.GodObjectHours)))
+	sb.WriteString(formatter.Info(fmt.Sprintf("Complexity: %dh\n", report.Debt.ComplexityHours)))
+	sb.WriteString(formatter.Info(fmt.Sprintf("Total: %dh\n\n", report.Debt.TotalHours)))
+}
+
 // writeScoreBreakdownWithColor writes the score breakdown with colors
 func writeScoreBreakdownWithColor(sb *strings.Builder, report *StructuralReport, formatter *ColorFormatter) {
 	if !report.HasViolations {

--- a/main.go
+++ b/main.go
@@ -504,6 +504,7 @@ func generateReport(scorer *StructuralScorer, absPath, format string, verbose bo
 		writeSizeViolationsWithColor(&sb, report, reporter.formatter)
 		writeGodObjectViolationsWithColor(&sb, report, reporter.formatter)
 		writeComplexityBandsWithColor(&sb, report, reporter.formatter)
+		writeTechnicalDebtSummaryWithColor(&sb, report, reporter.formatter)
 		writeScoreBreakdownWithColor(&sb, report, reporter.formatter)
 		fmt.Println(sb.String())
 	}
@@ -531,6 +532,7 @@ func generateRuleEngineReport(absPath, format string, verbose bool, colorEnabled
 		writeSizeViolationsWithColor(&sb, report, reporter.formatter)
 		writeGodObjectViolationsWithColor(&sb, report, reporter.formatter)
 		writeComplexityBandsWithColor(&sb, report, reporter.formatter)
+		writeTechnicalDebtSummaryWithColor(&sb, report, reporter.formatter)
 		writeScoreBreakdownWithColor(&sb, report, reporter.formatter)
 		fmt.Println(sb.String())
 	}

--- a/reporter.go
+++ b/reporter.go
@@ -42,6 +42,7 @@ type StructuralReport struct {
 	Summary       ReportSummary
 	Language      LanguageEvidenceSummary
 	Complexity    ComplexityBandSummary
+	Debt          TechnicalDebtEstimate
 	HasViolations bool
 }
 
@@ -93,6 +94,7 @@ func (r *Reporter) GenerateReport(scorer *StructuralScorer, path, version string
 		},
 		Language:      LanguageEvidenceSummary{DetectedLanguage: "unknown", Confidence: 0.0},
 		Complexity:    ComplexityBandSummary{},
+		Debt:          TechnicalDebtEstimate{},
 		HasViolations: len(violations.Circular) > 0 || len(violations.Layer) > 0 || len(violations.Size) > 0 || len(violations.GodObject) > 0,
 	}
 }
@@ -121,6 +123,7 @@ func (r *Reporter) formatText(report *StructuralReport) string {
 	writeSizeViolations(&sb, report)
 	writeGodObjectViolations(&sb, report)
 	writeComplexityBands(&sb, report)
+	writeTechnicalDebtSummary(&sb, report)
 	writeScoreBreakdown(&sb, report)
 
 	return sb.String()
@@ -176,6 +179,14 @@ func (r *Reporter) formatJSON(report *StructuralReport) string {
 			"low":    report.Complexity.Low,
 			"medium": report.Complexity.Medium,
 			"high":   report.Complexity.High,
+		},
+		"technicalDebt": map[string]interface{}{
+			"circularHours":   report.Debt.CircularHours,
+			"layerHours":      report.Debt.LayerHours,
+			"sizeHours":       report.Debt.SizeHours,
+			"godObjectHours":  report.Debt.GodObjectHours,
+			"complexityHours": report.Debt.ComplexityHours,
+			"totalHours":      report.Debt.TotalHours,
 		},
 		"circularViolations":  sortedCircularViolations(report.Circular),
 		"layerViolations":     sortedLayerViolations(report.Layer),

--- a/reporter_json_test.go
+++ b/reporter_json_test.go
@@ -33,6 +33,9 @@ func TestReporter_JSONV2_ContainsSchemaAndSummary(t *testing.T) {
 	if !strings.Contains(jsonOut, "\"complexity\"") {
 		t.Fatalf("expected complexity section in output: %s", jsonOut)
 	}
+	if !strings.Contains(jsonOut, "\"technicalDebt\"") {
+		t.Fatalf("expected technicalDebt section in output: %s", jsonOut)
+	}
 	if !strings.Contains(jsonOut, "\"reasonCodes\"") {
 		t.Fatalf("expected reasonCodes in output: %s", jsonOut)
 	}

--- a/reporter_methods.go
+++ b/reporter_methods.go
@@ -131,6 +131,18 @@ func writeComplexityBands(sb *strings.Builder, report *StructuralReport) {
 	sb.WriteString(fmt.Sprintf("High (>20): %d\n\n", report.Complexity.High))
 }
 
+func writeTechnicalDebtSummary(sb *strings.Builder, report *StructuralReport) {
+	sb.WriteString("┌───────────────────────────────────────────────────────────┐\n")
+	sb.WriteString("│  TECHNICAL DEBT ESTIMATE                                  │\n")
+	sb.WriteString("└───────────────────────────────────────────────────────────┘\n")
+	sb.WriteString(fmt.Sprintf("Circular: %dh\n", report.Debt.CircularHours))
+	sb.WriteString(fmt.Sprintf("Layer: %dh\n", report.Debt.LayerHours))
+	sb.WriteString(fmt.Sprintf("Size: %dh\n", report.Debt.SizeHours))
+	sb.WriteString(fmt.Sprintf("God Object: %dh\n", report.Debt.GodObjectHours))
+	sb.WriteString(fmt.Sprintf("Complexity: %dh\n", report.Debt.ComplexityHours))
+	sb.WriteString(fmt.Sprintf("Total: %dh\n\n", report.Debt.TotalHours))
+}
+
 func writeScoreBreakdown(sb *strings.Builder, report *StructuralReport) {
 	if !report.HasViolations {
 		sb.WriteString("✨ No structural violations detected! Your architecture is clean.\n\n")

--- a/technical_debt.go
+++ b/technical_debt.go
@@ -1,0 +1,22 @@
+package main
+
+type TechnicalDebtEstimate struct {
+	CircularHours   int `json:"circularHours"`
+	LayerHours      int `json:"layerHours"`
+	SizeHours       int `json:"sizeHours"`
+	GodObjectHours  int `json:"godObjectHours"`
+	ComplexityHours int `json:"complexityHours"`
+	TotalHours      int `json:"totalHours"`
+}
+
+func estimateTechnicalDebt(report *StructuralReport) TechnicalDebtEstimate {
+	debt := TechnicalDebtEstimate{
+		CircularHours:  len(report.Circular) * 4,
+		LayerHours:     len(report.Layer) * 3,
+		SizeHours:      len(report.Size) * 1,
+		GodObjectHours: len(report.GodObject) * 2,
+	}
+	debt.ComplexityHours = (report.Complexity.Medium * 1) + (report.Complexity.High * 2)
+	debt.TotalHours = debt.CircularHours + debt.LayerHours + debt.SizeHours + debt.GodObjectHours + debt.ComplexityHours
+	return debt
+}

--- a/technical_debt_test.go
+++ b/technical_debt_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestEstimateTechnicalDebt_DeterministicBreakdown(t *testing.T) {
+	report := &StructuralReport{
+		Circular:  []CycleViolation{{}, {}},
+		Layer:     []LayerViolation{{}},
+		Size:      []SizeViolation{{}, {}, {}},
+		GodObject: []GodObjectViolation{{}},
+		Complexity: ComplexityBandSummary{
+			Medium: 2,
+			High:   1,
+		},
+	}
+
+	debt := estimateTechnicalDebt(report)
+	if debt.CircularHours != 8 || debt.LayerHours != 3 || debt.SizeHours != 3 || debt.GodObjectHours != 2 || debt.ComplexityHours != 4 {
+		t.Fatalf("unexpected debt breakdown: %+v", debt)
+	}
+	if debt.TotalHours != 20 {
+		t.Fatalf("expected total 20, got %d", debt.TotalHours)
+	}
+}


### PR DESCRIPTION
## Summary
- add deterministic technical debt estimation breakdown (hours) derived from violation categories and complexity bands
- integrate debt summary into text and JSON report outputs for managerial visibility
- keep scoring/exit-code semantics unchanged while exposing actionable planning metrics

## Validation
- `go test ./...`
- `go vet ./...`
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`
- `go run . analyze -path .`

Closes #314