### PR TITLE
feat(rd-16008): add pre-commit hook installer

### DIFF
--- a/hook_installer.go
+++ b/hook_installer.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const preCommitMarker = "# repodoctor-managed:pre-commit"
+
+func handleInstallHookCommand(args []string) error {
+	hookType := "pre-commit"
+	repoPath := "."
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--type", "-type":
+			if i+1 >= len(args) {
+				return HandleCLIUsageError("Usage: repodoctor install-hook --type pre-commit [-path .]", nil)
+			}
+			hookType = strings.TrimSpace(args[i+1])
+			i++
+		case "--path", "-path":
+			if i+1 >= len(args) {
+				return HandleCLIUsageError("Usage: repodoctor install-hook --type pre-commit [-path .]", nil)
+			}
+			repoPath = strings.TrimSpace(args[i+1])
+			i++
+		default:
+			return HandleCLIUsageError("Usage: repodoctor install-hook --type pre-commit [-path .]", nil)
+		}
+	}
+
+	if hookType != "pre-commit" {
+		return NewCLIError(ErrorInvalidArgument, "unsupported hook type: "+hookType, "Only --type pre-commit is supported", nil)
+	}
+
+	abs, err := normalizeAnalyzePathInput(repoPath)
+	if err != nil {
+		return err
+	}
+
+	if err := installManagedPreCommitHook(abs); err != nil {
+		return err
+	}
+
+	fmt.Println("Pre-commit hook installed successfully.")
+	return nil
+}
+
+func installManagedPreCommitHook(repoRoot string) error {
+	hookPath := filepath.Join(repoRoot, ".git", "hooks", "pre-commit")
+	hookDir := filepath.Dir(hookPath)
+	if _, err := os.Stat(hookDir); err != nil {
+		return NewCLIError(ErrorInvalidArgument, "git hooks directory not found", "Run inside a git repository with a valid .git/hooks directory", err)
+	}
+
+	wanted := managedPreCommitHookScript()
+	current, readErr := os.ReadFile(hookPath)
+	if readErr == nil {
+		currentText := string(current)
+		if currentText == wanted {
+			return nil
+		}
+		if !strings.Contains(currentText, preCommitMarker) {
+			return NewCLIError(ErrorCLIUsage, "existing pre-commit hook is not managed by RepoDoctor", "Backup the existing hook, then re-run installation", errors.New("unmanaged pre-commit hook"))
+		}
+	}
+
+	return os.WriteFile(hookPath, []byte(wanted), 0o755)
+}
+
+func managedPreCommitHookScript() string {
+	return "#!/bin/sh\n" +
+		preCommitMarker + "\n" +
+		"set -e\n\n" +
+		"STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\\.(go|py|js|jsx|ts|tsx|java)$' || true)\n" +
+		"if [ -z \"$STAGED\" ]; then\n" +
+		"  exit 0\n" +
+		"fi\n\n" +
+		"if command -v repodoctor >/dev/null 2>&1; then\n" +
+		"  repodoctor analyze -path . -no-color\n" +
+		"else\n" +
+		"  go run . analyze -path . -no-color\n" +
+		"fi\n"
+}

--- a/hook_installer_test.go
+++ b/hook_installer_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallManagedPreCommitHook_Idempotent(t *testing.T) {
+	root := t.TempDir()
+	hookDir := filepath.Join(root, ".git", "hooks")
+	if err := os.MkdirAll(hookDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+
+	if err := installManagedPreCommitHook(root); err != nil {
+		t.Fatalf("first install failed: %v", err)
+	}
+	first, err := os.ReadFile(filepath.Join(hookDir, "pre-commit"))
+	if err != nil {
+		t.Fatalf("read hook after first install: %v", err)
+	}
+
+	if err := installManagedPreCommitHook(root); err != nil {
+		t.Fatalf("second install should be idempotent, got error: %v", err)
+	}
+	second, err := os.ReadFile(filepath.Join(hookDir, "pre-commit"))
+	if err != nil {
+		t.Fatalf("read hook after second install: %v", err)
+	}
+
+	if string(first) != string(second) {
+		t.Fatal("expected hook content to stay unchanged across repeated installs")
+	}
+	if !strings.Contains(string(second), preCommitMarker) {
+		t.Fatalf("expected managed marker in hook: %s", string(second))
+	}
+}
+
+func TestInstallManagedPreCommitHook_RejectsUnmanagedExistingHook(t *testing.T) {
+	root := t.TempDir()
+	hookDir := filepath.Join(root, ".git", "hooks")
+	if err := os.MkdirAll(hookDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+	hookPath := filepath.Join(hookDir, "pre-commit")
+	if err := os.WriteFile(hookPath, []byte("#!/bin/sh\necho custom\n"), 0o755); err != nil {
+		t.Fatalf("write unmanaged hook: %v", err)
+	}
+
+	err := installManagedPreCommitHook(root)
+	if err == nil {
+		t.Fatal("expected unmanaged hook installation to be rejected")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -46,6 +46,9 @@ func executeCommand(cmd string, args []string) error {
 	case "generate":
 		return handleGenerateCommand(args)
 
+	case "install-hook":
+		return handleInstallHookCommand(args)
+
 	case "version":
 		return handleVersionCommand()
 
@@ -268,7 +271,7 @@ func handleHelpCommand() error {
 }
 
 func getCommandSuggestion(cmd string) string {
-	commands := []string{"analyze", "extract", "report", "history", "interactive", "generate", "version", "help"}
+	commands := []string{"analyze", "extract", "report", "history", "interactive", "generate", "install-hook", "version", "help"}
 	closest := ""
 	for _, candidate := range commands {
 		if strings.HasPrefix(candidate, strings.ToLower(cmd[:min(1, len(cmd))])) || strings.Contains(candidate, strings.ToLower(cmd)) {
@@ -301,9 +304,10 @@ Commands:
   report       Display existing analysis report
   history      Show score trend history
   interactive  Start interactive mode for guided analysis
-  generate     Generate rule templates and other files
-  version      Show version information
-  help         Show this help message
+	generate     Generate rule templates and other files
+	install-hook Install git hook templates
+	version      Show version information
+	help         Show this help message
 
 Arguments:
   analyze [options]
@@ -324,8 +328,12 @@ Arguments:
     -path      Path to JSON report file (default: repodoctor-report.json)
     -format    Output format: text, json, json-v1 (default: text)
 
-  history [options]
-    -path      Path to repository (default: current directory)
+	history [options]
+	  -path      Path to repository (default: current directory)
+
+	install-hook [options]
+	  --type     Hook type (supported: pre-commit)
+	  -path      Repository path (default: current directory)
 
 Examples:
   repodoctor analyze .
@@ -333,9 +341,10 @@ Examples:
   repodoctor analyze -path . --json
   repodoctor extract .
   repodoctor extract -path ./src -module github.com/myorg/myrepo
-  repodoctor report -path ./report.json
-  repodoctor history -path .
-  repodoctor version`)
+	repodoctor report -path ./report.json
+	repodoctor history -path .
+	repodoctor install-hook --type pre-commit
+	repodoctor version`)
 }
 
 func runAnalyze(path, format string, verbose bool, colorEnabled bool, exitOnViolation bool, profiling profilingRequest) int {


### PR DESCRIPTION
## Summary
- add `repodoctor install-hook --type pre-commit` command
- generate idempotent RepoDoctor-managed pre-commit script with staged-file guard for fast/safe developer loop
- protect existing unmanaged hooks by failing closed instead of overwriting custom scripts

## Validation
- `go test ./...`
- `go vet ./...`
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`
- `go run . analyze -path .`

Closes #315