### PR TITLE
ci(rd-16009): enforce v1.6 stabilization gate and CI split

### DIFF
--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "v*"
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/repodoctor-fast.yml
+++ b/.github/workflows/repodoctor-fast.yml
@@ -1,0 +1,35 @@
+name: RepoDoctor Fast Gate
+
+on:
+  pull_request:
+    branches: [dev, main]
+
+permissions:
+  contents: read
+
+jobs:
+  fast-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Fast test pack
+        run: go test ./...
+
+      - name: Fast static analysis
+        run: go vet ./...
+
+      - name: Fast determinism check
+        run: go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
+
+      - name: Fast self-analysis gate
+        run: go run . analyze -path .

--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -112,6 +112,14 @@ jobs:
           GOMAXPROCS: 1
         run: ./scripts/v150_release_stabilization_gate.ps1
 
+      - name: Run v1.6 stabilization gate
+        shell: pwsh
+        env:
+          TZ: UTC
+          LC_ALL: C
+          GOMAXPROCS: 1
+        run: ./scripts/v160_release_stabilization_gate.ps1
+
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Use `json-v1` only if an existing integration still depends on old schema.
 Current CI pipeline includes:
 
 - Linux + Windows matrix
+- PR fast gate (`.github/workflows/repodoctor-fast.yml`)
 - `go test ./...`
 - `go vet ./...`
 - deterministic confidence suites
@@ -282,6 +283,7 @@ Current CI pipeline includes:
   - `scripts/v130_release_stabilization_gate.ps1`
   - `scripts/v140_release_stabilization_gate.ps1`
   - `scripts/v150_release_stabilization_gate.ps1`
+  - `scripts/v160_release_stabilization_gate.ps1`
 
 You can also scaffold CI templates quickly:
 

--- a/scripts/v160_release_stabilization_gate.ps1
+++ b/scripts/v160_release_stabilization_gate.ps1
@@ -1,0 +1,27 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    Write-Host "==> $Name"
+    Invoke-Expression $Command
+    if (-not $? -or $LASTEXITCODE -ne 0) {
+        throw "step failed: $Name (exit code $LASTEXITCODE)"
+    }
+}
+
+$determinismRegex = "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
+$v16RulesRegex = "TestSecretDetectionRule_.*|TestCodeDuplicationRule_.*|TestDeadCodeRule_.*|TestErrorHandlingConsistencyRule_.*|TestInterfaceBloatRule_.*|TestCollectCyclomaticComplexitySummary_BandsDeterministic|TestEstimateTechnicalDebt_DeterministicBreakdown|TestInstallManagedPreCommitHook_.*"
+
+Invoke-Step -Name "build" -Command "go build ."
+Invoke-Step -Name "core test suite" -Command "go test ./..."
+Invoke-Step -Name "static analysis" -Command "go vet ./..."
+Invoke-Step -Name "v1.6 rule and dx pack" -Command "go test ./... -run '$v16RulesRegex'"
+Invoke-Step -Name "v1.5 stabilization inheritance gate" -Command "pwsh -File './scripts/v150_release_stabilization_gate.ps1'"
+Invoke-Step -Name "determinism confidence suite" -Command "go test ./... -run '$determinismRegex'"
+Invoke-Step -Name "self-analysis 100/100 gate" -Command "go run . analyze -path ."
+
+Write-Host "v1.6 release stabilization gate passed."


### PR DESCRIPTION
## Summary
- add `scripts/v160_release_stabilization_gate.ps1` to orchestrate v1.6 release readiness with deterministic rule packs and inherited gates
- split CI into fast PR gate (`repodoctor-fast.yml`) and full stabilization gate (`repodoctor.yml`) to address duplicate risk and throughput
- harden release distribution flow by removing manual dispatch trigger to keep tag/lineage path fail-closed

## Validation
- `pwsh -File scripts/v160_release_stabilization_gate.ps1`
- `go test ./...`
- `go vet ./...`
- `go test ./... -run "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"`
- `go run . analyze -path .`

Closes #316