### PR TITLE
RD-17003: add deterministic hotspot detection

### DIFF
--- a/analysis_service.go
+++ b/analysis_service.go
@@ -95,8 +95,6 @@ func (s *AnalysisService) RunWithReport(request AnalyzeRequest) (int, *Structura
 
 	report := generateRuleEngineReport(absPath, request.Format, request.Verbose, request.ColorEnabled, config, ruleSummary)
 	report.Language = collectLanguageEvidenceSummary(absPath, analysisResult.AdapterName)
-	report.Complexity = collectCyclomaticComplexitySummary(absPath)
-	report.Debt = estimateTechnicalDebt(report)
 	progress.SetProgress(progress.totalSteps)
 	progress.Complete()
 

--- a/colored_methods.go
+++ b/colored_methods.go
@@ -221,6 +221,38 @@ func writeGitChurnSummaryWithColor(sb *strings.Builder, report *StructuralReport
 	sb.WriteString("\n")
 }
 
+func writeHotspotSummaryWithColor(sb *strings.Builder, report *StructuralReport, formatter *ColorFormatter) {
+	if len(report.Hotspots) == 0 {
+		return
+	}
+
+	sb.WriteString(formatter.Color("┌───────────────────────────────────────────────────────────┐", ColorYellow))
+	sb.WriteString("\n")
+	sb.WriteString(formatter.Color("│  HOTSPOT RISK RANKING                                     │", ColorYellow))
+	sb.WriteString("\n")
+	sb.WriteString(formatter.Color("└───────────────────────────────────────────────────────────┘", ColorYellow))
+	sb.WriteString("\n")
+
+	hotspots := sortedHotspotEntries(report.Hotspots)
+	limit := 5
+	if len(hotspots) < limit {
+		limit = len(hotspots)
+	}
+	for i := 0; i < limit; i++ {
+		entry := hotspots[i]
+		sb.WriteString(formatter.Warn(fmt.Sprintf("[%d] %s | risk:%d complexity:%d churn:%d recent:%d\n",
+			i+1,
+			entry.File,
+			entry.RiskScore,
+			entry.Complexity,
+			entry.CommitTouches,
+			entry.RecentTouches,
+		)))
+		sb.WriteString(formatter.Info(fmt.Sprintf("    %s\n", entry.Explanation)))
+	}
+	sb.WriteString("\n")
+}
+
 func writeComplexityBandsWithColor(sb *strings.Builder, report *StructuralReport, formatter *ColorFormatter) {
 	sb.WriteString(formatter.Color("┌───────────────────────────────────────────────────────────┐", ColorCyan))
 	sb.WriteString("\n")

--- a/cyclomatic_complexity.go
+++ b/cyclomatic_complexity.go
@@ -17,7 +17,23 @@ type ComplexityBandSummary struct {
 	High   int `json:"high"`
 }
 
+type GoFileComplexity struct {
+	Path            string
+	TotalComplexity int
+	FunctionCount   int
+}
+
 func collectCyclomaticComplexitySummary(root string) ComplexityBandSummary {
+	summary, _ := collectCyclomaticComplexitySummaryWithFiles(root)
+	return summary
+}
+
+func collectGoFileComplexitySnapshot(root string) []GoFileComplexity {
+	_, files := collectCyclomaticComplexitySummaryWithFiles(root)
+	return files
+}
+
+func collectCyclomaticComplexitySummaryWithFiles(root string) (ComplexityBandSummary, []GoFileComplexity) {
 	paths := make([]string, 0)
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -40,6 +56,7 @@ func collectCyclomaticComplexitySummary(root string) ComplexityBandSummary {
 
 	sort.Strings(paths)
 	summary := ComplexityBandSummary{}
+	fileComplexities := make([]GoFileComplexity, 0, len(paths))
 	fset := token.NewFileSet()
 
 	for _, path := range paths {
@@ -52,6 +69,8 @@ func collectCyclomaticComplexitySummary(root string) ComplexityBandSummary {
 			continue
 		}
 
+		fileTotal := 0
+		functionCount := 0
 		for _, decl := range node.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
 			if !ok || fn.Body == nil {
@@ -70,6 +89,9 @@ func collectCyclomaticComplexitySummary(root string) ComplexityBandSummary {
 				return true
 			})
 
+			fileTotal += complexity
+			functionCount++
+
 			switch {
 			case complexity <= 10:
 				summary.Low++
@@ -79,7 +101,28 @@ func collectCyclomaticComplexitySummary(root string) ComplexityBandSummary {
 				summary.High++
 			}
 		}
+
+		relPath := normalizeComplexityPath(root, path)
+		if functionCount > 0 {
+			fileComplexities = append(fileComplexities, GoFileComplexity{
+				Path:            relPath,
+				TotalComplexity: fileTotal,
+				FunctionCount:   functionCount,
+			})
+		}
 	}
 
-	return summary
+	sort.SliceStable(fileComplexities, func(i, j int) bool {
+		return fileComplexities[i].Path < fileComplexities[j].Path
+	})
+
+	return summary, fileComplexities
+}
+
+func normalizeComplexityPath(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return filepath.ToSlash(filepath.Clean(path))
+	}
+	return filepath.ToSlash(filepath.Clean(rel))
 }

--- a/deterministic_ordering.go
+++ b/deterministic_ordering.go
@@ -99,6 +99,15 @@ func sortedGitChurnFiles(in []model.GitChurnFile) []model.GitChurnFile {
 	})
 }
 
+func sortedHotspotEntries(in []HotspotEntry) []HotspotEntry {
+	return stableSortedCopy(in, func(left, right HotspotEntry) bool {
+		if left.RiskScore != right.RiskScore {
+			return left.RiskScore > right.RiskScore
+		}
+		return left.File < right.File
+	})
+}
+
 func sortModelViolationsDeterministic(violations []model.Violation) {
 	sort.SliceStable(violations, func(i, j int) bool {
 		if violations[i].RuleID != violations[j].RuleID {

--- a/hotspot_detection.go
+++ b/hotspot_detection.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"RepoDoctor/internal/model"
+)
+
+type HotspotEntry struct {
+	File          string `json:"file"`
+	RiskScore     int    `json:"riskScore"`
+	Complexity    int    `json:"complexity"`
+	CommitTouches int    `json:"commitTouches"`
+	RecentTouches int    `json:"recentTouches"`
+	Explanation   string `json:"explanation"`
+}
+
+// collectHotspotSummary computes deterministic hotspot rankings.
+// Risk score is intentionally explainable: complexity × commitTouches.
+func collectHotspotSummary(root string, churn model.GitChurnSummary) []HotspotEntry {
+	complexities := collectGoFileComplexitySnapshot(root)
+	if len(complexities) == 0 || len(churn.Files) == 0 {
+		return nil
+	}
+
+	churnByPath := make(map[string]model.GitChurnFile, len(churn.Files))
+	for _, file := range churn.Files {
+		churnByPath[file.Path] = file
+	}
+
+	hotspots := make([]HotspotEntry, 0)
+	for _, complexity := range complexities {
+		churnFile, ok := churnByPath[complexity.Path]
+		if !ok {
+			continue
+		}
+		riskScore := complexity.TotalComplexity * churnFile.CommitTouches
+		if riskScore <= 0 {
+			continue
+		}
+		hotspots = append(hotspots, HotspotEntry{
+			File:          complexity.Path,
+			RiskScore:     riskScore,
+			Complexity:    complexity.TotalComplexity,
+			CommitTouches: churnFile.CommitTouches,
+			RecentTouches: churnFile.RecentTouches,
+			Explanation:   fmt.Sprintf("risk=%d (complexity:%d × churnTouches:%d)", riskScore, complexity.TotalComplexity, churnFile.CommitTouches),
+		})
+	}
+
+	sort.SliceStable(hotspots, func(i, j int) bool {
+		if hotspots[i].RiskScore != hotspots[j].RiskScore {
+			return hotspots[i].RiskScore > hotspots[j].RiskScore
+		}
+		return hotspots[i].File < hotspots[j].File
+	})
+
+	return hotspots
+}

--- a/hotspot_detection_test.go
+++ b/hotspot_detection_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"RepoDoctor/internal/model"
+)
+
+func TestCollectHotspotSummary_DeterministicRiskOrdering(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.go"), []byte("package demo\nfunc A(){ if true {} }\n"), 0o644); err != nil {
+		t.Fatalf("write a.go: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "b.go"), []byte("package demo\nfunc B(){ if true {} }\n"), 0o644); err != nil {
+		t.Fatalf("write b.go: %v", err)
+	}
+
+	churn := model.GitChurnSummary{Files: []model.GitChurnFile{
+		{Path: "a.go", CommitTouches: 10, RecentTouches: 3},
+		{Path: "b.go", CommitTouches: 10, RecentTouches: 2},
+	}}
+
+	computed := collectHotspotSummary(root, churn)
+	if len(computed) != 2 {
+		t.Fatalf("expected two hotspot entries, got %d (%v)", len(computed), computed)
+	}
+	if computed[0].File != "a.go" || computed[1].File != "b.go" {
+		t.Fatalf("expected deterministic file asc tie-break ordering, got %v", computed)
+	}
+	if computed[0].RiskScore <= 0 || computed[0].Explanation == "" {
+		t.Fatalf("expected explainable positive risk score, got %+v", computed[0])
+	}
+}

--- a/main.go
+++ b/main.go
@@ -514,6 +514,7 @@ func generateReport(scorer *StructuralScorer, absPath, format string, verbose bo
 		writeGodObjectViolationsWithColor(&sb, report, reporter.formatter)
 		writeAPIViolationsWithColor(&sb, report, reporter.formatter)
 		writeGitChurnSummaryWithColor(&sb, report, reporter.formatter)
+		writeHotspotSummaryWithColor(&sb, report, reporter.formatter)
 		writeComplexityBandsWithColor(&sb, report, reporter.formatter)
 		writeTechnicalDebtSummaryWithColor(&sb, report, reporter.formatter)
 		writeScoreBreakdownWithColor(&sb, report, reporter.formatter)
@@ -526,6 +527,9 @@ func generateRuleEngineReport(absPath, format string, verbose bool, colorEnabled
 	report := buildReportFromRuleViolations(absPath, version, cfg, summary.result.Violations)
 	churnSummary, churnWarnings := analysis.ComputeGitChurnSummary(absPath)
 	report.GitChurn = churnSummary
+	report.Complexity = collectCyclomaticComplexitySummary(absPath)
+	report.Hotspots = collectHotspotSummary(absPath, report.GitChurn)
+	report.Debt = estimateTechnicalDebt(report)
 
 	if verbose {
 		fmt.Printf(ColorInfo("Rules in registry: ")+"%d\n", summary.rulesInScope)
@@ -549,6 +553,7 @@ func generateRuleEngineReport(absPath, format string, verbose bool, colorEnabled
 		writeGodObjectViolationsWithColor(&sb, report, reporter.formatter)
 		writeAPIViolationsWithColor(&sb, report, reporter.formatter)
 		writeGitChurnSummaryWithColor(&sb, report, reporter.formatter)
+		writeHotspotSummaryWithColor(&sb, report, reporter.formatter)
 		writeComplexityBandsWithColor(&sb, report, reporter.formatter)
 		writeTechnicalDebtSummaryWithColor(&sb, report, reporter.formatter)
 		writeScoreBreakdownWithColor(&sb, report, reporter.formatter)

--- a/reporter.go
+++ b/reporter.go
@@ -45,6 +45,7 @@ type StructuralReport struct {
 	Summary       ReportSummary
 	Language      LanguageEvidenceSummary
 	Complexity    ComplexityBandSummary
+	Hotspots      []HotspotEntry
 	Debt          TechnicalDebtEstimate
 	GitChurn      model.GitChurnSummary
 	HasViolations bool
@@ -105,6 +106,7 @@ func (r *Reporter) GenerateReport(scorer *StructuralScorer, path, version string
 		},
 		Language:      LanguageEvidenceSummary{DetectedLanguage: "unknown", Confidence: 0.0},
 		Complexity:    ComplexityBandSummary{},
+		Hotspots:      []HotspotEntry{},
 		Debt:          TechnicalDebtEstimate{},
 		GitChurn:      model.GitChurnSummary{Files: []model.GitChurnFile{}},
 		HasViolations: len(violations.Circular) > 0 || len(violations.Layer) > 0 || len(violations.Size) > 0 || len(violations.GodObject) > 0,
@@ -136,6 +138,7 @@ func (r *Reporter) formatText(report *StructuralReport) string {
 	writeGodObjectViolations(&sb, report)
 	writeAPIViolations(&sb, report)
 	writeGitChurnSummary(&sb, report)
+	writeHotspotSummary(&sb, report)
 	writeComplexityBands(&sb, report)
 	writeTechnicalDebtSummary(&sb, report)
 	writeScoreBreakdown(&sb, report)
@@ -208,6 +211,7 @@ func (r *Reporter) formatJSON(report *StructuralReport) string {
 			"distinctAuthors":     report.GitChurn.DistinctAuthors,
 			"files":               sortedGitChurnFiles(report.GitChurn.Files),
 		},
+		"hotspots":            sortedHotspotEntries(report.Hotspots),
 		"circularViolations":  sortedCircularViolations(report.Circular),
 		"layerViolations":     sortedLayerViolations(report.Layer),
 		"sizeViolations":      sortedSizeViolations(report.Size),

--- a/reporter_json_test.go
+++ b/reporter_json_test.go
@@ -39,6 +39,9 @@ func TestReporter_JSONV2_ContainsSchemaAndSummary(t *testing.T) {
 	if !strings.Contains(jsonOut, "\"gitChurn\"") {
 		t.Fatalf("expected gitChurn section in output: %s", jsonOut)
 	}
+	if !strings.Contains(jsonOut, "\"hotspots\"") {
+		t.Fatalf("expected hotspots section in output: %s", jsonOut)
+	}
 	if !strings.Contains(jsonOut, "\"apiStability\"") {
 		t.Fatalf("expected apiStability section in output: %s", jsonOut)
 	}

--- a/reporter_methods.go
+++ b/reporter_methods.go
@@ -176,6 +176,35 @@ func writeGitChurnSummary(sb *strings.Builder, report *StructuralReport) {
 	sb.WriteString("\n")
 }
 
+func writeHotspotSummary(sb *strings.Builder, report *StructuralReport) {
+	if len(report.Hotspots) == 0 {
+		return
+	}
+
+	sb.WriteString("┌───────────────────────────────────────────────────────────┐\n")
+	sb.WriteString("│  HOTSPOT RISK RANKING                                     │\n")
+	sb.WriteString("└───────────────────────────────────────────────────────────┘\n")
+
+	hotspots := sortedHotspotEntries(report.Hotspots)
+	limit := 5
+	if len(hotspots) < limit {
+		limit = len(hotspots)
+	}
+	for i := 0; i < limit; i++ {
+		entry := hotspots[i]
+		sb.WriteString(fmt.Sprintf("[%d] %s | risk:%d complexity:%d churn:%d recent:%d\n",
+			i+1,
+			entry.File,
+			entry.RiskScore,
+			entry.Complexity,
+			entry.CommitTouches,
+			entry.RecentTouches,
+		))
+		sb.WriteString(fmt.Sprintf("    %s\n", entry.Explanation))
+	}
+	sb.WriteString("\n")
+}
+
 func writeComplexityBands(sb *strings.Builder, report *StructuralReport) {
 	sb.WriteString("┌───────────────────────────────────────────────────────────┐\n")
 	sb.WriteString("│  CYCLOMATIC COMPLEXITY BANDS                              │\n")


### PR DESCRIPTION
## Summary
- add deterministic hotspot detection where risk score is `complexity × churn` with `risk desc, file asc` ordering
- expose hotspot ranking in text/color and JSON v2 outputs with explainable risk formulas
- keep churn + complexity integration deterministic and fail-soft, preserving analyzer score behavior

## Architecture impact
- keeps hotspot computation in orchestration/report composition layer
- avoids parser/network/process side effects in core model/domain/rules
- preserves deterministic output contracts via stable sorting helpers

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path . (100/100)

Closes #319