### PR TITLE
RD-17004: add default-off dependency vulnerability check

### DIFF
--- a/analysis_service.go
+++ b/analysis_service.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	analysispkg "RepoDoctor/internal/analysis"
 	metricsPkg "RepoDoctor/internal/metrics"
@@ -15,6 +16,13 @@ type AnalyzeRequest struct {
 	ColorEnabled    bool
 	ExitOnViolation bool
 	Profiling       profilingRequest
+	Vulnerability   vulnerabilityCheckRequest
+}
+
+type vulnerabilityCheckRequest struct {
+	Enabled         bool
+	TimeoutSeconds  int
+	MaxDependencies int
 }
 
 type AnalysisService struct{}
@@ -92,9 +100,17 @@ func (s *AnalysisService) RunWithReport(request AnalyzeRequest) (int, *Structura
 	}
 	ruleSummary := runInternalRulePipelineWithProfileAndAPI(absPath, graph, analysisResult.AdapterName, architecture, apiBreakingChanges)
 	progress.SetProgress(progress.totalSteps / 2)
+	vulnSummary, vulnWarnings := analysispkg.ComputeDependencyVulnerabilities(absPath, analysispkg.VulnerabilityOptions{
+		Enabled:         request.Vulnerability.Enabled,
+		Timeout:         time.Duration(request.Vulnerability.TimeoutSeconds) * time.Second,
+		MaxDependencies: request.Vulnerability.MaxDependencies,
+	})
 
-	report := generateRuleEngineReport(absPath, request.Format, request.Verbose, request.ColorEnabled, config, ruleSummary)
+	report := generateRuleEngineReport(absPath, request.Format, request.Verbose, request.ColorEnabled, config, ruleSummary, vulnSummary, vulnWarnings)
 	report.Language = collectLanguageEvidenceSummary(absPath, analysisResult.AdapterName)
+	if len(vulnWarnings) > 0 {
+		analysisResult.Warnings = append(analysisResult.Warnings, vulnWarnings...)
+	}
 	progress.SetProgress(progress.totalSteps)
 	progress.Complete()
 

--- a/analysis_service_test.go
+++ b/analysis_service_test.go
@@ -29,7 +29,7 @@ func TestAnalysisService_RunAndRunAnalyze_SuccessPath(t *testing.T) {
 		t.Fatalf("expected analysis service success code 0, got %d", code)
 	}
 
-	if code := runAnalyze(tmp, "text", false, false, false, profilingRequest{}); code != 0 {
+	if code := runAnalyze(tmp, "text", false, false, false, profilingRequest{}, vulnerabilityCheckRequest{}); code != 0 {
 		t.Fatalf("expected runAnalyze wrapper success code 0, got %d", code)
 	}
 }

--- a/colored_methods.go
+++ b/colored_methods.go
@@ -253,6 +253,36 @@ func writeHotspotSummaryWithColor(sb *strings.Builder, report *StructuralReport,
 	sb.WriteString("\n")
 }
 
+func writeVulnerabilitySummaryWithColor(sb *strings.Builder, report *StructuralReport, formatter *ColorFormatter) {
+	if !report.Vulnerability.Enabled {
+		return
+	}
+
+	sb.WriteString(formatter.Color("┌───────────────────────────────────────────────────────────┐", ColorRed))
+	sb.WriteString("\n")
+	sb.WriteString(formatter.Color("│  DEPENDENCY VULNERABILITY CHECK                           │", ColorRed))
+	sb.WriteString("\n")
+	sb.WriteString(formatter.Color("└───────────────────────────────────────────────────────────┘", ColorRed))
+	sb.WriteString("\n")
+
+	sb.WriteString(formatter.Info(fmt.Sprintf("Checked packages: %d\n", report.Vulnerability.CheckedPackages)))
+	sb.WriteString(formatter.Info(fmt.Sprintf("Findings: %d\n", len(report.Vulnerability.Findings))))
+
+	findings := sortedVulnerabilityFindings(report.Vulnerability.Findings)
+	limit := 5
+	if len(findings) < limit {
+		limit = len(findings)
+	}
+	for i := 0; i < limit; i++ {
+		finding := findings[i]
+		sb.WriteString(formatter.Error(fmt.Sprintf("[%d] %s@%s %s\n", i+1, finding.Package, finding.Version, finding.ID)))
+		if finding.Summary != "" {
+			sb.WriteString(formatter.Info(fmt.Sprintf("    %s\n", finding.Summary)))
+		}
+	}
+	sb.WriteString("\n")
+}
+
 func writeComplexityBandsWithColor(sb *strings.Builder, report *StructuralReport, formatter *ColorFormatter) {
 	sb.WriteString(formatter.Color("┌───────────────────────────────────────────────────────────┐", ColorCyan))
 	sb.WriteString("\n")

--- a/deterministic_ordering.go
+++ b/deterministic_ordering.go
@@ -108,6 +108,18 @@ func sortedHotspotEntries(in []HotspotEntry) []HotspotEntry {
 	})
 }
 
+func sortedVulnerabilityFindings(in []model.VulnerabilityFinding) []model.VulnerabilityFinding {
+	return stableSortedCopy(in, func(left, right model.VulnerabilityFinding) bool {
+		if left.Package != right.Package {
+			return left.Package < right.Package
+		}
+		if left.Version != right.Version {
+			return left.Version < right.Version
+		}
+		return left.ID < right.ID
+	})
+}
+
 func sortModelViolationsDeterministic(violations []model.Violation) {
 	sort.SliceStable(violations, func(i, j int) bool {
 		if violations[i].RuleID != violations[j].RuleID {

--- a/interactive.go
+++ b/interactive.go
@@ -98,7 +98,7 @@ func (i *InteractiveMode) analyzeMenu() {
 
 func (i *InteractiveMode) runInteractiveAnalysis(path string) {
 	if i.fixSuggestions == nil || !i.fixSuggestions.Enabled {
-		runAnalyze(path, "text", false, true, true, profilingRequest{})
+		runAnalyze(path, "text", false, true, true, profilingRequest{}, vulnerabilityCheckRequest{})
 		return
 	}
 

--- a/internal/analysis/vulnerability_check.go
+++ b/internal/analysis/vulnerability_check.go
@@ -1,0 +1,197 @@
+package analysis
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"RepoDoctor/internal/model"
+	"golang.org/x/mod/modfile"
+)
+
+const (
+	defaultVulnAPIURL           = "https://api.osv.dev/v1/query"
+	defaultVulnerabilityTimeout = 8 * time.Second
+	defaultVulnerabilityMaxDeps = 30
+)
+
+type VulnerabilityOptions struct {
+	Enabled         bool
+	Timeout         time.Duration
+	MaxDependencies int
+	APIURL          string
+}
+
+type osvQueryRequest struct {
+	Package struct {
+		Name      string `json:"name"`
+		Ecosystem string `json:"ecosystem"`
+	} `json:"package"`
+	Version string `json:"version,omitempty"`
+}
+
+type osvQueryResponse struct {
+	Vulns []struct {
+		ID      string `json:"id"`
+		Summary string `json:"summary"`
+		Details string `json:"details"`
+	} `json:"vulns"`
+}
+
+type moduleDependency struct {
+	Path    string
+	Version string
+}
+
+// ComputeDependencyVulnerabilities checks dependencies against OSV with timeout and fail-soft behavior.
+// It is deterministic and does nothing unless explicitly enabled.
+func ComputeDependencyVulnerabilities(repoPath string, options VulnerabilityOptions) (model.VulnerabilitySummary, []string) {
+	summary := model.VulnerabilitySummary{Enabled: options.Enabled, Findings: []model.VulnerabilityFinding{}}
+	if !options.Enabled {
+		return summary, nil
+	}
+
+	deps, depWarnings := parseModuleDependencies(repoPath)
+	if len(deps) == 0 {
+		warnings := append([]string{}, depWarnings...)
+		warnings = append(warnings, "vulnerability check skipped: no module dependencies detected")
+		return summary, warnings
+	}
+
+	maxDeps := options.MaxDependencies
+	if maxDeps <= 0 {
+		maxDeps = defaultVulnerabilityMaxDeps
+	}
+	if len(deps) > maxDeps {
+		deps = deps[:maxDeps]
+	}
+
+	timeout := options.Timeout
+	if timeout <= 0 {
+		timeout = defaultVulnerabilityTimeout
+	}
+
+	apiURL := strings.TrimSpace(options.APIURL)
+	if apiURL == "" {
+		apiURL = strings.TrimSpace(os.Getenv("REPODOCTOR_VULN_API_URL"))
+	}
+	if apiURL == "" {
+		apiURL = defaultVulnAPIURL
+	}
+
+	client := &http.Client{Timeout: timeout}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	warnings := append([]string{}, depWarnings...)
+	findings := make([]model.VulnerabilityFinding, 0)
+
+	for _, dep := range deps {
+		depFindings, err := queryOSVForDependency(ctx, client, apiURL, dep)
+		if err != nil {
+			warnings = append(warnings, "vulnerability check fail-soft for "+dep.Path+": "+err.Error())
+			continue
+		}
+		findings = append(findings, depFindings...)
+	}
+
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Package != findings[j].Package {
+			return findings[i].Package < findings[j].Package
+		}
+		if findings[i].Version != findings[j].Version {
+			return findings[i].Version < findings[j].Version
+		}
+		return findings[i].ID < findings[j].ID
+	})
+
+	summary.CheckedPackages = len(deps)
+	summary.Findings = findings
+	return summary, warnings
+}
+
+func parseModuleDependencies(repoPath string) ([]moduleDependency, []string) {
+	goModPath := filepath.Join(repoPath, "go.mod")
+	data, err := os.ReadFile(goModPath)
+	if err != nil {
+		return nil, []string{"vulnerability check skipped: go.mod not readable"}
+	}
+
+	parsed, err := modfile.Parse("go.mod", data, nil)
+	if err != nil {
+		return nil, []string{"vulnerability check skipped: go.mod parse failed"}
+	}
+
+	deps := make([]moduleDependency, 0, len(parsed.Require))
+	for _, req := range parsed.Require {
+		if req == nil || req.Mod.Path == "" {
+			continue
+		}
+		deps = append(deps, moduleDependency{Path: req.Mod.Path, Version: req.Mod.Version})
+	}
+
+	sort.SliceStable(deps, func(i, j int) bool {
+		if deps[i].Path != deps[j].Path {
+			return deps[i].Path < deps[j].Path
+		}
+		return deps[i].Version < deps[j].Version
+	})
+
+	return deps, nil
+}
+
+func queryOSVForDependency(ctx context.Context, client *http.Client, apiURL string, dep moduleDependency) ([]model.VulnerabilityFinding, error) {
+	requestPayload := osvQueryRequest{}
+	requestPayload.Package.Name = dep.Path
+	requestPayload.Package.Ecosystem = "Go"
+	requestPayload.Version = dep.Version
+
+	body, err := json.Marshal(requestPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("unexpected advisory status code: %d", resp.StatusCode)
+	}
+
+	var parsed osvQueryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, err
+	}
+
+	findings := make([]model.VulnerabilityFinding, 0, len(parsed.Vulns))
+	for _, vuln := range parsed.Vulns {
+		if strings.TrimSpace(vuln.ID) == "" {
+			continue
+		}
+		findings = append(findings, model.VulnerabilityFinding{
+			Package: dep.Path,
+			Version: dep.Version,
+			ID:      strings.TrimSpace(vuln.ID),
+			Summary: strings.TrimSpace(vuln.Summary),
+			Details: strings.TrimSpace(vuln.Details),
+		})
+	}
+
+	return findings, nil
+}

--- a/internal/analysis/vulnerability_check_test.go
+++ b/internal/analysis/vulnerability_check_test.go
@@ -1,0 +1,64 @@
+package analysis
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestComputeDependencyVulnerabilities_DefaultOff(t *testing.T) {
+	summary, warnings := ComputeDependencyVulnerabilities(t.TempDir(), VulnerabilityOptions{Enabled: false})
+	if summary.Enabled {
+		t.Fatal("expected vulnerability summary disabled by default")
+	}
+	if len(summary.Findings) != 0 {
+		t.Fatalf("expected no findings, got %v", summary.Findings)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings when disabled, got %v", warnings)
+	}
+}
+
+func TestComputeDependencyVulnerabilities_FailSoftAndDeterministic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		pkg := payload["package"].(map[string]interface{})["name"].(string)
+		if pkg == "module/a" {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"vulns": []map[string]interface{}{{"id": "OSV-2", "summary": "second"}, {"id": "OSV-1", "summary": "first"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"vulns": []map[string]interface{}{}})
+	}))
+	defer server.Close()
+
+	repo := t.TempDir()
+	goMod := "module demo\n\ngo 1.24\n\nrequire (\n\tmodule/b v1.0.0\n\tmodule/a v1.0.0\n)\n"
+	if err := os.WriteFile(filepath.Join(repo, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+
+	summary, warnings := ComputeDependencyVulnerabilities(repo, VulnerabilityOptions{
+		Enabled: true,
+		Timeout: 2 * time.Second,
+		APIURL:  server.URL,
+	})
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if summary.CheckedPackages != 2 {
+		t.Fatalf("expected 2 checked packages, got %d", summary.CheckedPackages)
+	}
+	if len(summary.Findings) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(summary.Findings))
+	}
+	if summary.Findings[0].ID != "OSV-1" || summary.Findings[1].ID != "OSV-2" {
+		t.Fatalf("expected deterministic findings ordering, got %v", summary.Findings)
+	}
+}

--- a/internal/model/vulnerability.go
+++ b/internal/model/vulnerability.go
@@ -1,0 +1,17 @@
+package model
+
+// VulnerabilitySummary contains deterministic vulnerability-check results.
+type VulnerabilitySummary struct {
+	Enabled         bool                   `json:"enabled"`
+	CheckedPackages int                    `json:"checkedPackages"`
+	Findings        []VulnerabilityFinding `json:"findings"`
+}
+
+// VulnerabilityFinding represents a dependency vulnerability advisory.
+type VulnerabilityFinding struct {
+	Package string `json:"package"`
+	Version string `json:"version"`
+	ID      string `json:"id"`
+	Summary string `json:"summary"`
+	Details string `json:"details,omitempty"`
+}

--- a/main.go
+++ b/main.go
@@ -78,17 +78,18 @@ func handleAnalyzeCommand(args []string) error {
 		return nil
 	}
 
-	runAnalyze(req.path, req.format, req.verbose, req.colorEnabled, true, req.profiling)
+	runAnalyze(req.path, req.format, req.verbose, req.colorEnabled, true, req.profiling, req.vulnerability)
 	return nil
 }
 
 type analyzeCommandRequest struct {
-	path         string
-	format       string
-	verbose      bool
-	colorEnabled bool
-	watch        bool
-	profiling    profilingRequest
+	path          string
+	format        string
+	verbose       bool
+	colorEnabled  bool
+	watch         bool
+	profiling     profilingRequest
+	vulnerability vulnerabilityCheckRequest
 }
 
 func composeAnalyzeRequest(args []string) (*analyzeCommandRequest, error) {
@@ -115,6 +116,11 @@ func composeAnalyzeRequest(args []string) (*analyzeCommandRequest, error) {
 		colorEnabled: !parsed.noColor,
 		watch:        parsed.watch,
 		profiling:    profiling,
+		vulnerability: vulnerabilityCheckRequest{
+			Enabled:         parsed.vulnCheck,
+			TimeoutSeconds:  parsed.vulnTimeout,
+			MaxDependencies: parsed.vulnMaxDeps,
+		},
 	}, nil
 }
 
@@ -126,6 +132,9 @@ type analyzeFlagInput struct {
 	noColor      bool
 	cpuProfile   string
 	memProfile   string
+	vulnCheck    bool
+	vulnTimeout  int
+	vulnMaxDeps  int
 	positional   []string
 }
 
@@ -141,6 +150,9 @@ func parseAnalyzeFlags(args []string) (*analyzeFlagInput, error) {
 	noColor := analyzeCmd.Bool("no-color", false, "Disable colored output")
 	cpuProfile := analyzeCmd.String("cpu-profile", "", "Write CPU profile to a file under analyze path")
 	memProfile := analyzeCmd.String("mem-profile", "", "Write heap profile to a file under analyze path")
+	vulnCheck := analyzeCmd.Bool("vuln-check", false, "Enable dependency vulnerability check (default: off)")
+	vulnTimeout := analyzeCmd.Int("vuln-timeout", 8, "Dependency vulnerability check timeout in seconds")
+	vulnMaxDeps := analyzeCmd.Int("vuln-max-deps", 30, "Max dependencies to query during vulnerability check")
 
 	if err := analyzeCmd.Parse(args); err != nil {
 		return nil, NewCLIError(
@@ -164,6 +176,9 @@ func parseAnalyzeFlags(args []string) (*analyzeFlagInput, error) {
 		noColor:      *noColor,
 		cpuProfile:   *cpuProfile,
 		memProfile:   *memProfile,
+		vulnCheck:    *vulnCheck,
+		vulnTimeout:  *vulnTimeout,
+		vulnMaxDeps:  *vulnMaxDeps,
 		positional:   analyzeCmd.Args(),
 	}, nil
 }
@@ -318,6 +333,9 @@ Arguments:
     -no-color  Disable colored output (default: enabled)
     -cpu-profile  Write CPU profile under analyze path (opt-in)
     -mem-profile  Write heap profile under analyze path (opt-in)
+    -vuln-check   Enable dependency vulnerability check (default: off)
+    -vuln-timeout Timeout seconds for vulnerability checks (default: 8)
+    -vuln-max-deps Max dependencies queried by vulnerability check (default: 30)
 
   extract [options]
     -path      Directory path to extract imports from (default: current directory)
@@ -347,7 +365,7 @@ Examples:
 	repodoctor version`)
 }
 
-func runAnalyze(path, format string, verbose bool, colorEnabled bool, exitOnViolation bool, profiling profilingRequest) int {
+func runAnalyze(path, format string, verbose bool, colorEnabled bool, exitOnViolation bool, profiling profilingRequest, vulnerability vulnerabilityCheckRequest) int {
 	service := NewAnalysisService()
 	exitCode := service.Run(AnalyzeRequest{
 		Path:            path,
@@ -356,6 +374,7 @@ func runAnalyze(path, format string, verbose bool, colorEnabled bool, exitOnViol
 		ColorEnabled:    colorEnabled,
 		ExitOnViolation: exitOnViolation,
 		Profiling:       profiling,
+		Vulnerability:   vulnerability,
 	})
 
 	if exitOnViolation && exitCode != 0 {
@@ -515,6 +534,7 @@ func generateReport(scorer *StructuralScorer, absPath, format string, verbose bo
 		writeAPIViolationsWithColor(&sb, report, reporter.formatter)
 		writeGitChurnSummaryWithColor(&sb, report, reporter.formatter)
 		writeHotspotSummaryWithColor(&sb, report, reporter.formatter)
+		writeVulnerabilitySummaryWithColor(&sb, report, reporter.formatter)
 		writeComplexityBandsWithColor(&sb, report, reporter.formatter)
 		writeTechnicalDebtSummaryWithColor(&sb, report, reporter.formatter)
 		writeScoreBreakdownWithColor(&sb, report, reporter.formatter)
@@ -523,10 +543,11 @@ func generateReport(scorer *StructuralScorer, absPath, format string, verbose bo
 	return report
 }
 
-func generateRuleEngineReport(absPath, format string, verbose bool, colorEnabled bool, cfg *Config, summary *runtimeRuleSummary) *StructuralReport {
+func generateRuleEngineReport(absPath, format string, verbose bool, colorEnabled bool, cfg *Config, summary *runtimeRuleSummary, vulnerability model.VulnerabilitySummary, vulnerabilityWarnings []string) *StructuralReport {
 	report := buildReportFromRuleViolations(absPath, version, cfg, summary.result.Violations)
 	churnSummary, churnWarnings := analysis.ComputeGitChurnSummary(absPath)
 	report.GitChurn = churnSummary
+	report.Vulnerability = vulnerability
 	report.Complexity = collectCyclomaticComplexitySummary(absPath)
 	report.Hotspots = collectHotspotSummary(absPath, report.GitChurn)
 	report.Debt = estimateTechnicalDebt(report)
@@ -535,6 +556,9 @@ func generateRuleEngineReport(absPath, format string, verbose bool, colorEnabled
 		fmt.Printf(ColorInfo("Rules in registry: ")+"%d\n", summary.rulesInScope)
 		fmt.Printf(ColorInfo("Rules executed: ")+"%d\n", summary.result.RulesExecuted)
 		for _, warning := range churnWarnings {
+			fmt.Printf("%s", ColorWarn(fmt.Sprintf("Warning: %s\n", warning)))
+		}
+		for _, warning := range vulnerabilityWarnings {
 			fmt.Printf("%s", ColorWarn(fmt.Sprintf("Warning: %s\n", warning)))
 		}
 	}
@@ -554,6 +578,7 @@ func generateRuleEngineReport(absPath, format string, verbose bool, colorEnabled
 		writeAPIViolationsWithColor(&sb, report, reporter.formatter)
 		writeGitChurnSummaryWithColor(&sb, report, reporter.formatter)
 		writeHotspotSummaryWithColor(&sb, report, reporter.formatter)
+		writeVulnerabilitySummaryWithColor(&sb, report, reporter.formatter)
 		writeComplexityBandsWithColor(&sb, report, reporter.formatter)
 		writeTechnicalDebtSummaryWithColor(&sb, report, reporter.formatter)
 		writeScoreBreakdownWithColor(&sb, report, reporter.formatter)

--- a/main_output_modes_test.go
+++ b/main_output_modes_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"RepoDoctor/internal/engine"
+	"RepoDoctor/internal/model"
 	"strings"
 	"testing"
 )
@@ -47,7 +48,7 @@ func TestGenerateRuleEngineReport_JSONV1Path(t *testing.T) {
 	}
 
 	output := captureStdout(t, func() {
-		_ = generateRuleEngineReport(".", "json-v1", false, false, nil, summary)
+		_ = generateRuleEngineReport(".", "json-v1", false, false, nil, summary, model.VulnerabilitySummary{}, nil)
 	})
 
 	if !strings.Contains(output, "\"version\"") {

--- a/reporter.go
+++ b/reporter.go
@@ -48,6 +48,7 @@ type StructuralReport struct {
 	Hotspots      []HotspotEntry
 	Debt          TechnicalDebtEstimate
 	GitChurn      model.GitChurnSummary
+	Vulnerability model.VulnerabilitySummary
 	HasViolations bool
 }
 
@@ -109,6 +110,7 @@ func (r *Reporter) GenerateReport(scorer *StructuralScorer, path, version string
 		Hotspots:      []HotspotEntry{},
 		Debt:          TechnicalDebtEstimate{},
 		GitChurn:      model.GitChurnSummary{Files: []model.GitChurnFile{}},
+		Vulnerability: model.VulnerabilitySummary{Enabled: false, Findings: []model.VulnerabilityFinding{}},
 		HasViolations: len(violations.Circular) > 0 || len(violations.Layer) > 0 || len(violations.Size) > 0 || len(violations.GodObject) > 0,
 	}
 }
@@ -139,6 +141,7 @@ func (r *Reporter) formatText(report *StructuralReport) string {
 	writeAPIViolations(&sb, report)
 	writeGitChurnSummary(&sb, report)
 	writeHotspotSummary(&sb, report)
+	writeVulnerabilitySummary(&sb, report)
 	writeComplexityBands(&sb, report)
 	writeTechnicalDebtSummary(&sb, report)
 	writeScoreBreakdown(&sb, report)
@@ -210,6 +213,11 @@ func (r *Reporter) formatJSON(report *StructuralReport) string {
 			"recentWindowCommits": report.GitChurn.RecentWindowCommits,
 			"distinctAuthors":     report.GitChurn.DistinctAuthors,
 			"files":               sortedGitChurnFiles(report.GitChurn.Files),
+		},
+		"dependencyVulnerabilities": map[string]interface{}{
+			"enabled":         report.Vulnerability.Enabled,
+			"checkedPackages": report.Vulnerability.CheckedPackages,
+			"findings":        sortedVulnerabilityFindings(report.Vulnerability.Findings),
 		},
 		"hotspots":            sortedHotspotEntries(report.Hotspots),
 		"circularViolations":  sortedCircularViolations(report.Circular),

--- a/reporter_json_test.go
+++ b/reporter_json_test.go
@@ -42,6 +42,9 @@ func TestReporter_JSONV2_ContainsSchemaAndSummary(t *testing.T) {
 	if !strings.Contains(jsonOut, "\"hotspots\"") {
 		t.Fatalf("expected hotspots section in output: %s", jsonOut)
 	}
+	if !strings.Contains(jsonOut, "\"dependencyVulnerabilities\"") {
+		t.Fatalf("expected dependencyVulnerabilities section in output: %s", jsonOut)
+	}
 	if !strings.Contains(jsonOut, "\"apiStability\"") {
 		t.Fatalf("expected apiStability section in output: %s", jsonOut)
 	}

--- a/reporter_methods.go
+++ b/reporter_methods.go
@@ -205,6 +205,32 @@ func writeHotspotSummary(sb *strings.Builder, report *StructuralReport) {
 	sb.WriteString("\n")
 }
 
+func writeVulnerabilitySummary(sb *strings.Builder, report *StructuralReport) {
+	if !report.Vulnerability.Enabled {
+		return
+	}
+
+	sb.WriteString("┌───────────────────────────────────────────────────────────┐\n")
+	sb.WriteString("│  DEPENDENCY VULNERABILITY CHECK                           │\n")
+	sb.WriteString("└───────────────────────────────────────────────────────────┘\n")
+	sb.WriteString(fmt.Sprintf("Checked packages: %d\n", report.Vulnerability.CheckedPackages))
+	sb.WriteString(fmt.Sprintf("Findings: %d\n", len(report.Vulnerability.Findings)))
+
+	findings := sortedVulnerabilityFindings(report.Vulnerability.Findings)
+	limit := 5
+	if len(findings) < limit {
+		limit = len(findings)
+	}
+	for i := 0; i < limit; i++ {
+		finding := findings[i]
+		sb.WriteString(fmt.Sprintf("[%d] %s@%s %s\n", i+1, finding.Package, finding.Version, finding.ID))
+		if finding.Summary != "" {
+			sb.WriteString(fmt.Sprintf("    %s\n", finding.Summary))
+		}
+	}
+	sb.WriteString("\n")
+}
+
 func writeComplexityBands(sb *strings.Builder, report *StructuralReport) {
 	sb.WriteString("┌───────────────────────────────────────────────────────────┐\n")
 	sb.WriteString("│  CYCLOMATIC COMPLEXITY BANDS                              │\n")

--- a/watcher.go
+++ b/watcher.go
@@ -155,7 +155,7 @@ func (w *Watcher) runAnalysis(changedFile string) {
 	fmt.Println(strings.Repeat("=", 60))
 
 	// Run analysis
-	if code := runAnalyze(w.path, "text", false, true, false, profilingRequest{}); code != 0 {
+	if code := runAnalyze(w.path, "text", false, true, false, profilingRequest{}, vulnerabilityCheckRequest{}); code != 0 {
 		fmt.Printf("Analysis finished with exit code %d (watch continues).\n", code)
 	}
 }
@@ -220,7 +220,7 @@ func WatchAndAnalyze(path string) error {
 	// Run initial analysis
 	fmt.Println("Running initial analysis...")
 	fmt.Println()
-	if code := runAnalyze(path, "text", false, true, false, profilingRequest{}); code != 0 {
+	if code := runAnalyze(path, "text", false, true, false, profilingRequest{}, vulnerabilityCheckRequest{}); code != 0 {
 		fmt.Printf("Initial analysis finished with exit code %d (watch continues).\n", code)
 	}
 


### PR DESCRIPTION
## Summary
- add default-off dependency vulnerability checking (`--vuln-check`) with explicit timeout and bounded dependency query count
- implement fail-soft OSV querying in `internal/analysis` with deterministic ordering and no analyzer hard-fail on advisory errors/timeouts
- expose vulnerability results in text/color and JSON v2 reports under `dependencyVulnerabilities`

## Architecture impact
- keeps vulnerability logic in analysis/orchestration layer
- keeps model layer pure via dedicated vulnerability DTOs
- avoids process-spawn in analyzer path and keeps behavior deterministic

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path . (100/100)

Closes #320