### PR TITLE
RD-17006: add v1.7 consolidated stabilization gate

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -32,93 +32,13 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
-      - name: Build RepoDoctor
-        run: go build .
-
-      - name: Run unit and integration tests
-        run: go test ./...
-
-      - name: Run static checks
-        run: go vet ./...
-
-      - name: Run v0.18 close-out gate pack
-        shell: pwsh
-        run: ./scripts/v018_closeout_gate.ps1
-
-      - name: Run v0.19 benchmark budget gate
+      - name: Run v1.7 stabilization gate (consolidated)
         shell: pwsh
         env:
           TZ: UTC
           LC_ALL: C
           GOMAXPROCS: 1
-        run: ./scripts/v019_benchmark_gate.ps1
-
-      - name: Run v0.19 release stabilization gate
-        shell: pwsh
-        env:
-          TZ: UTC
-          LC_ALL: C
-          GOMAXPROCS: 1
-        run: ./scripts/v019_release_stabilization_gate.ps1
-
-      - name: Run v1.0 release stabilization gate
-        shell: pwsh
-        env:
-          TZ: UTC
-          LC_ALL: C
-          GOMAXPROCS: 1
-        run: ./scripts/v100_release_stabilization_gate.ps1
-
-      - name: Run v1.1 release stabilization gate
-        shell: pwsh
-        env:
-          TZ: UTC
-          LC_ALL: C
-          GOMAXPROCS: 1
-        run: ./scripts/v110_release_stabilization_gate.ps1
-
-      - name: Run v1.2 release stabilization gate
-        shell: pwsh
-        env:
-          TZ: UTC
-          LC_ALL: C
-          GOMAXPROCS: 1
-        run: ./scripts/v120_release_stabilization_gate.ps1
-
-      - name: Run v1.3 release stabilization gate
-        shell: pwsh
-        env:
-          TZ: UTC
-          LC_ALL: C
-          GOMAXPROCS: 1
-        run: ./scripts/v130_release_stabilization_gate.ps1
-
-      - name: Run memory budget guard tests
-        run: go test ./internal/analysis -run "TestOrchestrator_Analyze_AppliesMemoryFileBudget|TestOrchestrator_Analyze_InvalidMemoryBudgetFailSoft"
-
-      - name: Run v1.4 stabilization benchmark gate
-        shell: pwsh
-        env:
-          TZ: UTC
-          LC_ALL: C
-          GOMAXPROCS: 1
-        run: ./scripts/v140_release_stabilization_gate.ps1
-
-      - name: Run v1.5 stabilization gate
-        shell: pwsh
-        env:
-          TZ: UTC
-          LC_ALL: C
-          GOMAXPROCS: 1
-        run: ./scripts/v150_release_stabilization_gate.ps1
-
-      - name: Run v1.6 stabilization gate
-        shell: pwsh
-        env:
-          TZ: UTC
-          LC_ALL: C
-          GOMAXPROCS: 1
-        run: ./scripts/v160_release_stabilization_gate.ps1
+        run: ./scripts/v170_release_stabilization_gate.ps1
 
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text

--- a/README.md
+++ b/README.md
@@ -270,20 +270,11 @@ Current CI pipeline includes:
 
 - Linux + Windows matrix
 - PR fast gate (`.github/workflows/repodoctor-fast.yml`)
-- `go test ./...`
-- `go vet ./...`
-- deterministic confidence suites
-- self-analysis score gate
-- milestone gate packs:
-  - `scripts/v018_closeout_gate.ps1`
-  - `scripts/v019_release_stabilization_gate.ps1`
-  - `scripts/v100_release_stabilization_gate.ps1`
-  - `scripts/v110_release_stabilization_gate.ps1`
-  - `scripts/v120_release_stabilization_gate.ps1`
-  - `scripts/v130_release_stabilization_gate.ps1`
-  - `scripts/v140_release_stabilization_gate.ps1`
-  - `scripts/v150_release_stabilization_gate.ps1`
-  - `scripts/v160_release_stabilization_gate.ps1`
+- consolidated stabilization gate (`scripts/v170_release_stabilization_gate.ps1`) including:
+  - `go test ./...`
+  - `go vet ./...`
+  - deterministic confidence suites
+  - self-analysis score gate (`go run . analyze -path .`)
 
 You can also scaffold CI templates quickly:
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -119,7 +119,11 @@ Release path:
 ## Process/Gate Risk Watchlist
 
 - **Open:** Release distribution workflow'unda manuel tetikleme (`workflow_dispatch`) ile release akışı bypass riski; tag/ref doğrulaması ve protection kontrolü sıkılaştırılmalı.
-- **Open:** CI akışında stabilization script zinciri nedeniyle mükerrer test/vet çalışmaları toplam süre ve runner maliyetini artırıyor; hızlı kapı vs tam kapı ayrımı netleştirilmeli.
+- **Mitigated (v1.7):** CI akışında stabilization script zinciri tek bir konsolide kapıya (`scripts/v170_release_stabilization_gate.ps1`) indirildi; mükerrer test/vet döngüleri azaltıldı.
+- **Plan (CI maliyet notu):**
+  - PR tarafında hızlı kapı (`repodoctor-fast.yml`) düşük maliyetli geri bildirim için birincil kalacak.
+  - Tam matris kapısı (`repodoctor.yml`) konsolide stabilization gate ile korunacak.
+  - Çalışma süresi/runner tüketimi 2 sprint boyunca izlenip eşik dışına taşarsa determinism alt testleri için ayrı gece-job ayrıştırması yapılacak.
 - **Open:** Branch governance doğrulaması (required status checks / required review / up-to-date) repo ayarı seviyesinde izlenmeli; yalnız doküman kuralı yeterli değil.
 
 Son güncelleme: 11 Nisan 2026 (roadmap v1.6+ ile hizalandı)

--- a/scripts/v170_release_stabilization_gate.ps1
+++ b/scripts/v170_release_stabilization_gate.ps1
@@ -1,0 +1,26 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    Write-Host "==> $Name"
+    Invoke-Expression $Command
+    if (-not $? -or $LASTEXITCODE -ne 0) {
+        throw "step failed: $Name (exit code $LASTEXITCODE)"
+    }
+}
+
+$determinismRegex = "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
+$v17PackRegex = "TestComputeAPIBreakingChanges_.*|TestComputeGitChurnSummary_.*|TestCollectHotspotSummary_DeterministicRiskOrdering|TestComputeDependencyVulnerabilities_.*|TestDocsGenerator_.*|TestParseGenerateDocsArgs_ValidAndInvalid"
+
+Invoke-Step -Name "build" -Command "go build ."
+Invoke-Step -Name "core test suite" -Command "go test ./..."
+Invoke-Step -Name "static analysis" -Command "go vet ./..."
+Invoke-Step -Name "v1.7 feature pack" -Command "go test ./... -run '$v17PackRegex'"
+Invoke-Step -Name "determinism confidence suite" -Command "go test ./... -run '$determinismRegex'"
+Invoke-Step -Name "self-analysis 100/100 gate" -Command "go run . analyze -path ."
+
+Write-Host "v1.7 release stabilization gate passed."


### PR DESCRIPTION
## Summary
- add `scripts/v170_release_stabilization_gate.ps1` as consolidated v1.7 gate (build/test/vet + v1.7 pack + determinism + self-analysis)
- simplify `.github/workflows/repodoctor.yml` by replacing chained milestone gate calls with a single v1.7 stabilization gate step to reduce duplicate test/vet cycles
- update `README.md` CI section and add a short CI cost/sustainability plan note in `docs/report.md`

## Acceptance mapping
- mandatory quality gates remain green
- duplicate test/vet loops minimized by consolidated gate wiring
- CI cost note plan added to `docs/report.md`

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path . (100/100)

Closes #322