### PR TITLE
RD-18001: add safe auto-fix engine with dry-run default

### DIFF
--- a/autofix_command.go
+++ b/autofix_command.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func handleFixCommand(args []string) error {
+	request, err := parseFixFlags(args)
+	if err != nil {
+		return err
+	}
+
+	result, runErr := runAutoFix(request)
+	if runErr != nil {
+		return runErr
+	}
+
+	printAutoFixResult(result)
+	return nil
+}
+
+func parseFixFlags(args []string) (AutoFixRequest, error) {
+	fixCmd := flag.NewFlagSet("fix", flag.ContinueOnError)
+	fixCmd.SetOutput(os.Stderr)
+
+	path := fixCmd.String("path", ".", "Path to apply safe fixes")
+	apply := fixCmd.Bool("apply", false, "Apply safe changes to files (default: dry-run)")
+	packs := fixCmd.String("packs", "size,imports,error-wrap", "Safe fix packs: size,imports,error-wrap")
+
+	if err := fixCmd.Parse(args); err != nil {
+		return AutoFixRequest{}, NewCLIError(
+			ErrorCLIUsage,
+			fmt.Sprintf("Invalid fix arguments: %v", err),
+			"Usage: repodoctor fix -path . [--apply] [--packs size,imports,error-wrap]",
+			err,
+		)
+	}
+
+	request := AutoFixRequest{RepositoryPath: *path, Apply: *apply}
+	request.Packs = parseFixPacks(*packs)
+	if len(request.Packs) == 0 {
+		return AutoFixRequest{}, NewCLIError(
+			ErrorInvalidArgument,
+			"No valid safe packs provided",
+			"Use --packs size,imports,error-wrap",
+			nil,
+		)
+	}
+
+	return request, nil
+}
+
+func parseFixPacks(raw string) []AutoFixPack {
+	parts := strings.Split(strings.ToLower(strings.TrimSpace(raw)), ",")
+	result := make([]AutoFixPack, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		result = append(result, AutoFixPack(trimmed))
+	}
+	return resolveAutoFixPacks(result)
+}

--- a/autofix_engine.go
+++ b/autofix_engine.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/format"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type AutoFixPack string
+
+const (
+	AutoFixPackSize      AutoFixPack = "size"
+	AutoFixPackImports   AutoFixPack = "imports"
+	AutoFixPackErrorWrap AutoFixPack = "error-wrap"
+)
+
+type AutoFixRequest struct {
+	RepositoryPath string
+	Apply          bool
+	Packs          []AutoFixPack
+}
+
+type AutoFixResult struct {
+	DryRun         bool
+	FilesScanned   int
+	FilesChanged   int
+	TotalEdits     int
+	Preview        []string
+	ChangedFiles   []string
+	SkippedReasons []string
+}
+
+type fileEdit struct {
+	path     string
+	original []byte
+	updated  []byte
+	edits    int
+}
+
+func runAutoFix(request AutoFixRequest) (*AutoFixResult, error) {
+	absPath := validatePath(request.RepositoryPath)
+	packs := resolveAutoFixPacks(request.Packs)
+	if len(packs) == 0 {
+		return nil, NewCLIError(
+			ErrorInvalidArgument,
+			"No safe auto-fix packs selected",
+			"Use --packs size,imports,error-wrap",
+			nil,
+		)
+	}
+
+	files, err := collectSafeGoFiles(absPath)
+	if err != nil {
+		return nil, WrapError(err, ErrorRuntime, "auto-fix scan failed", GetSuggestion(err.Error()))
+	}
+
+	result := &AutoFixResult{DryRun: !request.Apply, Preview: []string{}, ChangedFiles: []string{}, SkippedReasons: []string{}}
+	result.FilesScanned = len(files)
+
+	edits := make([]fileEdit, 0)
+	for _, file := range files {
+		content, readErr := os.ReadFile(file)
+		if readErr != nil {
+			result.SkippedReasons = append(result.SkippedReasons, "read skipped: "+normalizeReportPathDeterministic(file))
+			continue
+		}
+
+		updated, count := applySafePacks(content, packs)
+		if count == 0 || bytes.Equal(content, updated) {
+			continue
+		}
+
+		edits = append(edits, fileEdit{path: file, original: content, updated: updated, edits: count})
+	}
+
+	sort.SliceStable(edits, func(i, j int) bool { return edits[i].path < edits[j].path })
+
+	for _, edit := range edits {
+		result.FilesChanged++
+		result.TotalEdits += edit.edits
+		rel := normalizeReportPathDeterministic(edit.path)
+		result.ChangedFiles = append(result.ChangedFiles, rel)
+		result.Preview = append(result.Preview, buildPatchPreview(rel, edit.original, edit.updated, 4)...)
+		if request.Apply {
+			if writeErr := os.WriteFile(edit.path, edit.updated, 0o644); writeErr != nil {
+				return nil, WrapError(writeErr, ErrorRuntime, "auto-fix apply failed", GetSuggestion(writeErr.Error()))
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func resolveAutoFixPacks(input []AutoFixPack) []AutoFixPack {
+	if len(input) == 0 {
+		return []AutoFixPack{AutoFixPackSize, AutoFixPackImports, AutoFixPackErrorWrap}
+	}
+	allowed := map[AutoFixPack]bool{AutoFixPackSize: true, AutoFixPackImports: true, AutoFixPackErrorWrap: true}
+	set := map[AutoFixPack]bool{}
+	resolved := make([]AutoFixPack, 0, len(input))
+	for _, pack := range input {
+		normalized := AutoFixPack(strings.ToLower(strings.TrimSpace(string(pack))))
+		if !allowed[normalized] || set[normalized] {
+			continue
+		}
+		set[normalized] = true
+		resolved = append(resolved, normalized)
+	}
+	return resolved
+}
+
+func collectSafeGoFiles(root string) ([]string, error) {
+	files := make([]string, 0)
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			name := strings.ToLower(d.Name())
+			if name == ".git" || name == "vendor" || name == "testdata" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		lower := strings.ToLower(path)
+		if !strings.HasSuffix(lower, ".go") || strings.HasSuffix(lower, "_test.go") {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func applySafePacks(content []byte, packs []AutoFixPack) ([]byte, int) {
+	updated := append([]byte(nil), content...)
+	edits := 0
+	for _, pack := range packs {
+		switch pack {
+		case AutoFixPackSize:
+			next, delta := applySizePack(updated)
+			updated, edits = next, edits+delta
+		case AutoFixPackImports:
+			next, delta := applyImportsPack(updated)
+			updated, edits = next, edits+delta
+		case AutoFixPackErrorWrap:
+			next, delta := applyErrorWrapPack(updated)
+			updated, edits = next, edits+delta
+		}
+	}
+	return updated, edits
+}
+
+func applySizePack(content []byte) ([]byte, int) {
+	text := strings.ReplaceAll(string(content), "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	edits := 0
+	for i, line := range lines {
+		trimmed := strings.TrimRight(line, " \t")
+		if trimmed != line {
+			lines[i] = trimmed
+			edits++
+		}
+	}
+
+	collapsed := make([]string, 0, len(lines))
+	blanks := 0
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			blanks++
+			if blanks > 2 {
+				edits++
+				continue
+			}
+		} else {
+			blanks = 0
+		}
+		collapsed = append(collapsed, line)
+	}
+
+	return []byte(strings.Join(collapsed, "\n")), edits
+}
+
+func applyImportsPack(content []byte) ([]byte, int) {
+	formatted, err := format.Source(content)
+	if err != nil {
+		return content, 0
+	}
+	if bytes.Equal(formatted, content) {
+		return content, 0
+	}
+	return formatted, 1
+}
+
+var errorWrapRegex = regexp.MustCompile(`fmt\.Errorf\("([^"]*?)%v([^"]*?)",\s*err\)`) // safe subset only
+
+func applyErrorWrapPack(content []byte) ([]byte, int) {
+	text := string(content)
+	matches := errorWrapRegex.FindAllStringSubmatchIndex(text, -1)
+	if len(matches) == 0 {
+		return content, 0
+	}
+	replaced := errorWrapRegex.ReplaceAllString(text, `fmt.Errorf("$1%w$2", err)`)
+	return []byte(replaced), len(matches)
+}
+
+func buildPatchPreview(path string, before, after []byte, maxLines int) []string {
+	left := strings.Split(strings.ReplaceAll(string(before), "\r\n", "\n"), "\n")
+	right := strings.Split(strings.ReplaceAll(string(after), "\r\n", "\n"), "\n")
+	limit := len(left)
+	if len(right) > limit {
+		limit = len(right)
+	}
+	lines := []string{fmt.Sprintf("--- %s", path), fmt.Sprintf("+++ %s", path)}
+	for i, used := 0, 0; i < limit && used < maxLines; i++ {
+		var l, r string
+		if i < len(left) {
+			l = left[i]
+		}
+		if i < len(right) {
+			r = right[i]
+		}
+		if l == r {
+			continue
+		}
+		if l != "" {
+			lines = append(lines, fmt.Sprintf("- %d:%s", i+1, l))
+			used++
+		}
+		if r != "" && used < maxLines {
+			lines = append(lines, fmt.Sprintf("+ %d:%s", i+1, r))
+			used++
+		}
+	}
+	return lines
+}
+
+func printAutoFixResult(result *AutoFixResult) {
+	if result == nil {
+		return
+	}
+	mode := "APPLY"
+	if result.DryRun {
+		mode = "DRY-RUN"
+	}
+	fmt.Printf("Auto-fix mode: %s\n", mode)
+	fmt.Printf("Files scanned: %d\n", result.FilesScanned)
+	fmt.Printf("Files changed: %d\n", result.FilesChanged)
+	fmt.Printf("Total edits: %d\n", result.TotalEdits)
+	for _, line := range result.Preview {
+		fmt.Println(line)
+	}
+	if result.DryRun {
+		fmt.Println("Dry-run is default. Re-run with --apply to write safe fixes.")
+	}
+}

--- a/autofix_engine_test.go
+++ b/autofix_engine_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseFixFlags_DryRunDefaultAndPacks(t *testing.T) {
+	request, err := parseFixFlags([]string{"-path", "."})
+	if err != nil {
+		t.Fatalf("parseFixFlags failed: %v", err)
+	}
+	if request.Apply {
+		t.Fatal("expected dry-run default (apply=false)")
+	}
+	if len(request.Packs) != 3 {
+		t.Fatalf("expected three safe default packs, got %d", len(request.Packs))
+	}
+}
+
+func TestRunAutoFix_DryRunDoesNotModifyFiles(t *testing.T) {
+	repo := t.TempDir()
+	file := filepath.Join(repo, "sample.go")
+	original := "package demo\n\nimport \"fmt\"\n\nfunc wrap(err error) error {\n\treturn fmt.Errorf(\"oops: %v\", err)\n}\n"
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	result, err := runAutoFix(AutoFixRequest{RepositoryPath: repo, Apply: false, Packs: []AutoFixPack{AutoFixPackErrorWrap}})
+	if err != nil {
+		t.Fatalf("runAutoFix failed: %v", err)
+	}
+	if result.FilesChanged == 0 || len(result.Preview) == 0 {
+		t.Fatalf("expected dry-run changes and preview, got %+v", result)
+	}
+
+	after, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if string(after) != original {
+		t.Fatal("expected dry-run not to modify file")
+	}
+}
+
+func TestRunAutoFix_ApplyWritesSafeSubsetChanges(t *testing.T) {
+	repo := t.TempDir()
+	file := filepath.Join(repo, "sample.go")
+	original := "package demo\n\nimport \"fmt\"\n\nfunc wrap(err error) error {\n\treturn fmt.Errorf(\"oops: %v\", err)\n}\n"
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	result, err := runAutoFix(AutoFixRequest{RepositoryPath: repo, Apply: true, Packs: []AutoFixPack{AutoFixPackErrorWrap}})
+	if err != nil {
+		t.Fatalf("runAutoFix failed: %v", err)
+	}
+	if result.DryRun {
+		t.Fatal("expected apply mode")
+	}
+
+	after, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if !strings.Contains(string(after), "%w") {
+		t.Fatalf("expected wrapped error conversion in file, got %q", string(after))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -49,6 +49,9 @@ func executeCommand(cmd string, args []string) error {
 	case "install-hook":
 		return handleInstallHookCommand(args)
 
+	case "fix":
+		return handleFixCommand(args)
+
 	case "version":
 		return handleVersionCommand()
 
@@ -286,7 +289,7 @@ func handleHelpCommand() error {
 }
 
 func getCommandSuggestion(cmd string) string {
-	commands := []string{"analyze", "extract", "report", "history", "interactive", "generate", "install-hook", "version", "help"}
+	commands := []string{"analyze", "extract", "report", "history", "interactive", "generate", "install-hook", "fix", "version", "help"}
 	closest := ""
 	for _, candidate := range commands {
 		if strings.HasPrefix(candidate, strings.ToLower(cmd[:min(1, len(cmd))])) || strings.Contains(candidate, strings.ToLower(cmd)) {
@@ -321,6 +324,7 @@ Commands:
   interactive  Start interactive mode for guided analysis
 	generate     Generate rule templates and other files
 	install-hook Install git hook templates
+	fix          Apply safe auto-fix packs (dry-run default)
 	version      Show version information
 	help         Show this help message
 
@@ -353,6 +357,11 @@ Arguments:
 	  --type     Hook type (supported: pre-commit)
 	  -path      Repository path (default: current directory)
 
+	fix [options]
+	  -path      Repository path to fix (default: current directory)
+	  --apply    Apply safe changes to files (default: dry-run)
+	  --packs    Comma-separated safe packs: size,imports,error-wrap
+
 Examples:
   repodoctor analyze .
   repodoctor analyze -path ./myproject -format json
@@ -362,6 +371,7 @@ Examples:
 	repodoctor report -path ./report.json
 	repodoctor history -path .
 	repodoctor install-hook --type pre-commit
+	repodoctor fix -path . --packs size,error-wrap
 	repodoctor version`)
 }
 

--- a/main_command_dispatch_test.go
+++ b/main_command_dispatch_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -85,5 +87,17 @@ func TestHasExplicitPathFlag_DetectionVariants(t *testing.T) {
 				t.Fatalf("hasExplicitPathFlag(%v)=%v, want %v", tc.args, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestExecuteCommand_FixCommandDryRun(t *testing.T) {
+	tmp := t.TempDir()
+	content := "package demo\n\nimport \"fmt\"\n\nfunc wrap(err error) error {\n\treturn fmt.Errorf(\"oops: %v\", err)\n}\n"
+	if err := os.WriteFile(filepath.Join(tmp, "sample.go"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	if err := executeCommand("fix", []string{"-path", tmp}); err != nil {
+		t.Fatalf("fix command dry-run failed: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add `repodoctor fix` command with safe-subset auto-fix engine and explicit pack selection
- keep `--dry-run` as default behavior and provide deterministic patch preview output
- enforce safe scope by only allowing low-risk packs (`size,imports,error-wrap`) and refusing unknown packs

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path . (100/100)

Closes #323