### PR TITLE
RD-18002: enforce low-risk auto-fix rule packs

### DIFF
--- a/autofix_command.go
+++ b/autofix_command.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 )
 
 func handleFixCommand(args []string) error {
@@ -40,28 +39,15 @@ func parseFixFlags(args []string) (AutoFixRequest, error) {
 	}
 
 	request := AutoFixRequest{RepositoryPath: *path, Apply: *apply}
-	request.Packs = parseFixPacks(*packs)
+	request.Packs, request.DisabledPacks, request.UnknownPacks = parseAutoFixPacks(*packs)
 	if len(request.Packs) == 0 {
 		return AutoFixRequest{}, NewCLIError(
 			ErrorInvalidArgument,
 			"No valid safe packs provided",
-			"Use --packs size,imports,error-wrap",
+			"Use --packs size,imports,error-wrap (high-risk packs remain suggestion-only)",
 			nil,
 		)
 	}
 
 	return request, nil
-}
-
-func parseFixPacks(raw string) []AutoFixPack {
-	parts := strings.Split(strings.ToLower(strings.TrimSpace(raw)), ",")
-	result := make([]AutoFixPack, 0, len(parts))
-	for _, part := range parts {
-		trimmed := strings.TrimSpace(part)
-		if trimmed == "" {
-			continue
-		}
-		result = append(result, AutoFixPack(trimmed))
-	}
-	return resolveAutoFixPacks(result)
 }

--- a/autofix_engine.go
+++ b/autofix_engine.go
@@ -23,6 +23,8 @@ type AutoFixRequest struct {
 	RepositoryPath string
 	Apply          bool
 	Packs          []AutoFixPack
+	DisabledPacks  []string
+	UnknownPacks   []string
 }
 
 type AutoFixResult struct {
@@ -60,6 +62,12 @@ func runAutoFix(request AutoFixRequest) (*AutoFixResult, error) {
 	}
 
 	result := &AutoFixResult{DryRun: !request.Apply, Preview: []string{}, ChangedFiles: []string{}, SkippedReasons: []string{}}
+	for _, item := range request.DisabledPacks {
+		result.SkippedReasons = append(result.SkippedReasons, "high-risk pack disabled in auto mode: "+item)
+	}
+	for _, item := range request.UnknownPacks {
+		result.SkippedReasons = append(result.SkippedReasons, "unknown pack skipped: "+item)
+	}
 	result.FilesScanned = len(files)
 
 	edits := make([]fileEdit, 0)
@@ -112,6 +120,47 @@ func resolveAutoFixPacks(input []AutoFixPack) []AutoFixPack {
 		resolved = append(resolved, normalized)
 	}
 	return resolved
+}
+
+func parseAutoFixPacks(raw string) (safe []AutoFixPack, disabled []string, unknown []string) {
+	parts := strings.Split(strings.ToLower(strings.TrimSpace(raw)), ",")
+
+	safeSet := map[AutoFixPack]bool{}
+	safe = make([]AutoFixPack, 0, len(parts))
+	disabled = make([]string, 0)
+	unknown = make([]string, 0)
+
+	safeCatalog := map[string]AutoFixPack{
+		"size":       AutoFixPackSize,
+		"imports":    AutoFixPackImports,
+		"error-wrap": AutoFixPackErrorWrap,
+	}
+	highRiskCatalog := map[string]bool{
+		"extract-method": true,
+		"layer-refactor": true,
+		"api-rewrite":    true,
+	}
+
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		if pack, ok := safeCatalog[trimmed]; ok {
+			if !safeSet[pack] {
+				safeSet[pack] = true
+				safe = append(safe, pack)
+			}
+			continue
+		}
+		if highRiskCatalog[trimmed] {
+			disabled = append(disabled, trimmed)
+			continue
+		}
+		unknown = append(unknown, trimmed)
+	}
+
+	return safe, disabled, unknown
 }
 
 func collectSafeGoFiles(root string) ([]string, error) {
@@ -258,6 +307,9 @@ func printAutoFixResult(result *AutoFixResult) {
 	fmt.Printf("Total edits: %d\n", result.TotalEdits)
 	for _, line := range result.Preview {
 		fmt.Println(line)
+	}
+	for _, reason := range result.SkippedReasons {
+		fmt.Printf("Skipped: %s\n", reason)
 	}
 	if result.DryRun {
 		fmt.Println("Dry-run is default. Re-run with --apply to write safe fixes.")

--- a/autofix_engine_test.go
+++ b/autofix_engine_test.go
@@ -20,6 +20,26 @@ func TestParseFixFlags_DryRunDefaultAndPacks(t *testing.T) {
 	}
 }
 
+func TestParseFixFlags_HighRiskPacksRemainDisabled(t *testing.T) {
+	request, err := parseFixFlags([]string{"-path", ".", "-packs", "size,extract-method"})
+	if err != nil {
+		t.Fatalf("parseFixFlags failed: %v", err)
+	}
+	if len(request.Packs) != 1 || request.Packs[0] != AutoFixPackSize {
+		t.Fatalf("expected only low-risk size pack enabled, got %v", request.Packs)
+	}
+	if len(request.DisabledPacks) != 1 || request.DisabledPacks[0] != "extract-method" {
+		t.Fatalf("expected high-risk pack to be disabled, got %v", request.DisabledPacks)
+	}
+}
+
+func TestParseFixFlags_OnlyHighRiskPackRejected(t *testing.T) {
+	_, err := parseFixFlags([]string{"-path", ".", "-packs", "extract-method"})
+	if err == nil {
+		t.Fatal("expected only high-risk pack selection to fail")
+	}
+}
+
 func TestRunAutoFix_DryRunDoesNotModifyFiles(t *testing.T) {
 	repo := t.TempDir()
 	file := filepath.Join(repo, "sample.go")


### PR DESCRIPTION
## Summary
- refine auto-fix pack selection to explicitly separate low-risk and high-risk packs
- keep low-risk packs (`size,imports,error-wrap`) controllable, deterministic, and auto-applicable
- keep high-risk refactor packs suggestion-only by disabling them in automatic mode and surfacing skip reasons

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path . (100/100)

Closes #324