### PR TITLE
RD-18003: add v1.8 IDE plugin expansion plan

### DIFF
--- a/docs/report.md
+++ b/docs/report.md
@@ -14,6 +14,7 @@ Bu dosya sürüm bazlı ilerleme/rapor özetini tek yerde takip etmek için tutu
 | v1.3 | M6: v1.3 Observability | Completed | RD-13001..RD-13005 merged into `dev`; structured logging, safe profiling hooks, error taxonomy hardening, deterministic metrics export, and v1.3 gate pack activated. |
 | v1.4 | M7: v1.4 Performance Hardening | Completed | RD-14001..RD-14004 merged into `dev`; parallel parsing tuning, memory budget fail-soft controls, filesystem-safe cache warmup, and benchmark/race gate automation activated. |
 | v1.5 | M8: v1.5 Developer Experience | Completed | RD-15001..RD-15005 merged into `dev`; released to `main` via `dev -> main` PR #305. |
+| v1.8 | M11: v1.8 Safe Auto-fix & Expansion | In Progress | IDE expansion plan drafted (`docs/v1.8-ide-plugin-expansion-plan.md`) with CLI-first guardrails and effort estimate. |
 
 ---
 

--- a/docs/v1.8-ide-plugin-expansion-plan.md
+++ b/docs/v1.8-ide-plugin-expansion-plan.md
@@ -1,0 +1,86 @@
+# v1.8 IDE Plugin Expansion Plan (CLI-first)
+
+## Objective
+
+Extend RepoDoctor editor integrations beyond VS Code with a **CLI-first** strategy for:
+
+- IntelliJ Platform
+- Vim/Neovim
+- Emacs
+
+All integrations must consume RepoDoctor CLI outputs (`json` / `json-v1`) and must not re-implement rule logic inside editor plugins.
+
+## Guardrails
+
+1. **Single source of truth:** analysis engine remains in RepoDoctor CLI.
+2. **No architectural drift:** plugins provide UX shell only (run command, parse output, render diagnostics).
+3. **Fail-soft UX:** plugin errors must not block editing workflows.
+4. **Deterministic diagnostics:** plugin ordering mirrors CLI ordering.
+
+## Scope by IDE
+
+### 1) IntelliJ Platform (Kotlin)
+
+- Minimal plugin action: run `repodoctor analyze -path <project> -format json`.
+- Parse `schemaVersion=v2` response and map to IDE inspections.
+- Provide quick links to remediation hints and file/line navigation.
+
+### 2) Vim/Neovim
+
+- Command wrapper (`:RepoDoctorAnalyze`) calling CLI with JSON output.
+- Quickfix/location list population from violations.
+- Optional async background trigger (save-based).
+
+### 3) Emacs
+
+- Minor mode command to run CLI and parse JSON output.
+- Integrate with `compilation-mode`/`flymake` style diagnostics.
+- Keep command invocation customizable per workspace.
+
+## Delivery Phases
+
+### Phase A — Contract & Shared Adapter Notes (1 week)
+
+- Freeze minimal JSON fields required by all plugins.
+- Publish parser examples and mapping table.
+- Add compatibility test fixtures for plugin maintainers.
+
+### Phase B — IntelliJ MVP (2 weeks)
+
+- Project action + diagnostics panel + file navigation.
+- Manual smoke tests on medium Go repositories.
+
+### Phase C — Vim/Neovim + Emacs MVPs (2 weeks)
+
+- Basic command wrappers + diagnostics list integrations.
+- Lightweight docs and setup snippets.
+
+### Phase D — Hardening & Docs (1 week)
+
+- Error handling hardening and timeout guidance.
+- Cross-IDE troubleshooting section.
+
+## Effort Estimate
+
+- Engineering: **6 person-weeks** total
+  - IntelliJ: 2.5 pw
+  - Vim/Neovim: 1.5 pw
+  - Emacs: 1.5 pw
+  - Shared docs/contracts: 0.5 pw
+- QA/validation: **1 person-week**
+- Total: **~7 person-weeks**
+
+## Risks and Mitigations
+
+- **Risk:** schema drift between CLI and plugins.
+  - **Mitigation:** keep plugin contract pinned to `schemaVersion` and publish fixture-based compatibility checks.
+- **Risk:** plugin runtime overhead in large repos.
+  - **Mitigation:** default to on-demand run; async mode opt-in.
+- **Risk:** duplicated rule behavior in plugins.
+  - **Mitigation:** enforce CLI-first contribution rule in plugin docs.
+
+## Success Criteria
+
+- IntelliJ/Vim/Emacs each can run RepoDoctor and show file+line diagnostics.
+- No plugin re-implements rule logic.
+- CLI upgrades remain backward-compatible via documented schema gates.


### PR DESCRIPTION
## Summary
- add v1.8 IDE expansion plan document for IntelliJ/Vim/Emacs with CLI-first integration constraints
- include phased delivery roadmap and explicit effort estimate
- update report tracker to reference the new plan and current milestone state

## Acceptance mapping
- roadmap + effort estimate are explicit
- CLI-first principle is preserved and enforced by guardrails

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path . (100/100)

Closes #325