### PR TITLE
RD-18004: add v1.8 stabilization gate

### DIFF
--- a/.github/workflows/repodoctor.yml
+++ b/.github/workflows/repodoctor.yml
@@ -32,13 +32,13 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
-      - name: Run v1.7 stabilization gate (consolidated)
+      - name: Run v1.8 stabilization gate (consolidated)
         shell: pwsh
         env:
           TZ: UTC
           LC_ALL: C
           GOMAXPROCS: 1
-        run: ./scripts/v170_release_stabilization_gate.ps1
+        run: ./scripts/v180_release_stabilization_gate.ps1
 
       - name: Run RepoDoctor analysis
         run: go run . analyze -path . -format text

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Current CI pipeline includes:
 
 - Linux + Windows matrix
 - PR fast gate (`.github/workflows/repodoctor-fast.yml`)
-- consolidated stabilization gate (`scripts/v170_release_stabilization_gate.ps1`) including:
+- consolidated stabilization gate (`scripts/v180_release_stabilization_gate.ps1`) including:
   - `go test ./...`
   - `go vet ./...`
   - deterministic confidence suites

--- a/docs/report.md
+++ b/docs/report.md
@@ -121,6 +121,7 @@ Release path:
 
 - **Open:** Release distribution workflow'unda manuel tetikleme (`workflow_dispatch`) ile release akışı bypass riski; tag/ref doğrulaması ve protection kontrolü sıkılaştırılmalı.
 - **Mitigated (v1.7):** CI akışında stabilization script zinciri tek bir konsolide kapıya (`scripts/v170_release_stabilization_gate.ps1`) indirildi; mükerrer test/vet döngüleri azaltıldı.
+- **Mitigated (v1.8):** Auto-fix güvenlik sınırları gate kapsamına alındı (`scripts/v180_release_stabilization_gate.ps1`); dry-run default + high-risk pack disable doğrulamaları zorunlu.
 - **Plan (CI maliyet notu):**
   - PR tarafında hızlı kapı (`repodoctor-fast.yml`) düşük maliyetli geri bildirim için birincil kalacak.
   - Tam matris kapısı (`repodoctor.yml`) konsolide stabilization gate ile korunacak.

--- a/scripts/v180_release_stabilization_gate.ps1
+++ b/scripts/v180_release_stabilization_gate.ps1
@@ -1,0 +1,26 @@
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Command
+    )
+
+    Write-Host "==> $Name"
+    Invoke-Expression $Command
+    if (-not $? -or $LASTEXITCODE -ne 0) {
+        throw "step failed: $Name (exit code $LASTEXITCODE)"
+    }
+}
+
+$determinismRegex = "TestRunInternalRulePipeline_MultiLanguageMixedFixtureDeterministic|TestJSTSParity_DeterministicAcrossRepeatedRuns"
+$v18Regex = "TestParseFixFlags_.*|TestRunAutoFix_.*|TestExecuteCommand_FixCommandDryRun|TestParseGenerateDocsArgs_ValidAndInvalid|TestDocsGenerator_.*"
+
+Invoke-Step -Name "build" -Command "go build ."
+Invoke-Step -Name "core test suite" -Command "go test ./..."
+Invoke-Step -Name "static analysis" -Command "go vet ./..."
+Invoke-Step -Name "v1.8 auto-fix + docs confidence pack" -Command "go test ./... -run '$v18Regex'"
+Invoke-Step -Name "determinism confidence suite" -Command "go test ./... -run '$determinismRegex'"
+Invoke-Step -Name "self-analysis 100/100 gate" -Command "go run . analyze -path ."
+
+Write-Host "v1.8 release stabilization gate passed."


### PR DESCRIPTION
## Summary
- add `scripts/v180_release_stabilization_gate.ps1` for v1.8 release readiness
- wire workflow to v1.8 consolidated stabilization gate
- include auto-fix safety validations (safe subset tests, dry-run default tests) and update release risk watchlist notes

## Acceptance mapping
- mandatory quality gates green
- auto-fix safe subset + dry-run default explicitly validated in gate pack
- release bypass guardrail checklist note updated in report tracker

## Validation
- go test ./...
- go vet ./...
- go run . analyze -path . (100/100)

Closes #326